### PR TITLE
Fix CD deploy script docker PATH issue

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,7 +68,8 @@ jobs:
           key: ${{ secrets.DEPLOY_SSH_KEY }}
           command_timeout: 10m
           script: |
-            cd /Users/minyic/fuzhou-mahjong
+            export PATH=/usr/local/bin:/opt/homebrew/bin:$PATH
+            cd /Users/${{ secrets.DEPLOY_USER }}/fuzhou-mahjong
             docker compose down
             docker compose build --no-cache
             docker compose up -d


### PR DESCRIPTION
The deploy workflow fails because SSH into Mac Mini uses zsh non-interactive shell which does not have docker in PATH.

Error: `zsh:2: command not found: docker`

Fix: Add `export PATH=/usr/local/bin:/opt/homebrew/bin:$PATH` at the start of the SSH script in .github/workflows/deploy.yml, before the docker compose commands.

Closes #13