### PR TITLE
Define tile types and core data structures

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -4,3 +4,5 @@ export interface HealthResponse {
   status: "ok";
   timestamp: string;
 }
+
+export * from './types/index.js';

--- a/packages/shared/src/types/action.ts
+++ b/packages/shared/src/types/action.ts
@@ -1,0 +1,77 @@
+import type { TileInstance } from './tile.js';
+
+export enum ActionType {
+  Draw = 'draw',
+  Discard = 'discard',
+  Chi = 'chi',
+  Peng = 'peng',
+  MingGang = 'mingGang',
+  AnGang = 'anGang',
+  BuGang = 'buGang',
+  Hu = 'hu',
+  Pass = 'pass',
+}
+
+export interface DrawAction {
+  type: ActionType.Draw;
+  playerIndex: number;
+}
+
+export interface DiscardAction {
+  type: ActionType.Discard;
+  playerIndex: number;
+  tile: TileInstance;
+}
+
+export interface ChiAction {
+  type: ActionType.Chi;
+  playerIndex: number;
+  tiles: [TileInstance, TileInstance];
+  targetTile: TileInstance;
+}
+
+export interface PengAction {
+  type: ActionType.Peng;
+  playerIndex: number;
+  targetTile: TileInstance;
+}
+
+export interface MingGangAction {
+  type: ActionType.MingGang;
+  playerIndex: number;
+  targetTile: TileInstance;
+}
+
+export interface AnGangAction {
+  type: ActionType.AnGang;
+  playerIndex: number;
+  tile: TileInstance;
+}
+
+export interface BuGangAction {
+  type: ActionType.BuGang;
+  playerIndex: number;
+  tile: TileInstance;
+}
+
+export interface HuAction {
+  type: ActionType.Hu;
+  playerIndex: number;
+  tile?: TileInstance;
+}
+
+export interface PassAction {
+  type: ActionType.Pass;
+  playerIndex: number;
+}
+
+export type GameAction =
+  | DrawAction
+  | DiscardAction
+  | ChiAction
+  | PengAction
+  | MingGangAction
+  | AnGangAction
+  | BuGangAction
+  | HuAction
+  | PassAction;

--- a/packages/shared/src/types/game.ts
+++ b/packages/shared/src/types/game.ts
@@ -1,0 +1,29 @@
+import type { TileInstance, SuitedTile } from './tile.js';
+import type { PlayerState } from './player.js';
+
+export enum GamePhase {
+  Dealing = 'dealing',
+  FlowerReplacement = 'flowerReplacement',
+  RevealingGold = 'revealingGold',
+  Playing = 'playing',
+  Finished = 'finished',
+  Draw = 'draw',
+}
+
+export interface GoldState {
+  indicatorTile: TileInstance;
+  wildTile: SuitedTile;
+}
+
+export interface GameState {
+  wall: TileInstance[];
+  wallTail: TileInstance[];
+  players: [PlayerState, PlayerState, PlayerState, PlayerState];
+  currentTurn: number;
+  dealerIndex: number;
+  lianZhuangCount: number;
+  phase: GamePhase;
+  gold: GoldState | null;
+  lastDiscard: { tile: TileInstance; playerIndex: number } | null;
+  retainCount: number;
+}

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -1,0 +1,41 @@
+export {
+  Suit,
+  WindType,
+  DragonType,
+  SeasonType,
+  PlantType,
+  isSuitedTile,
+  isFlowerTile,
+} from './tile.js';
+export type {
+  SuitedTile,
+  WindTile,
+  DragonTile,
+  SeasonTile,
+  PlantTile,
+  FlowerTile,
+  Tile,
+  TileInstance,
+} from './tile.js';
+
+export { MeldType } from './meld.js';
+export type { Meld } from './meld.js';
+
+export type { PlayerState } from './player.js';
+
+export { GamePhase } from './game.js';
+export type { GoldState, GameState } from './game.js';
+
+export { ActionType } from './action.js';
+export type {
+  DrawAction,
+  DiscardAction,
+  ChiAction,
+  PengAction,
+  MingGangAction,
+  AnGangAction,
+  BuGangAction,
+  HuAction,
+  PassAction,
+  GameAction,
+} from './action.js';

--- a/packages/shared/src/types/meld.ts
+++ b/packages/shared/src/types/meld.ts
@@ -1,0 +1,16 @@
+import type { TileInstance } from './tile.js';
+
+export enum MeldType {
+  Chi = 'chi',
+  Peng = 'peng',
+  MingGang = 'mingGang',
+  AnGang = 'anGang',
+  BuGang = 'buGang',
+}
+
+export interface Meld {
+  type: MeldType;
+  tiles: TileInstance[];
+  sourceTile?: TileInstance;
+  sourcePlayer?: number;
+}

--- a/packages/shared/src/types/player.ts
+++ b/packages/shared/src/types/player.ts
@@ -1,0 +1,12 @@
+import type { TileInstance, WindType } from './tile.js';
+import type { Meld } from './meld.js';
+
+export interface PlayerState {
+  hand: TileInstance[];
+  melds: Meld[];
+  flowers: TileInstance[];
+  discards: TileInstance[];
+  seatWind: WindType;
+  isDealer: boolean;
+  hasDiscardedGold: boolean;
+}

--- a/packages/shared/src/types/tile.ts
+++ b/packages/shared/src/types/tile.ts
@@ -1,0 +1,77 @@
+// Suited tiles: Wan (万), Bing (饼), Tiao (条)
+export enum Suit {
+  Wan = 'wan',
+  Bing = 'bing',
+  Tiao = 'tiao',
+}
+
+export interface SuitedTile {
+  kind: 'suited';
+  suit: Suit;
+  value: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
+}
+
+// Flower tiles: Wind, Dragon, Season, Plant
+export enum WindType {
+  East = 'east',
+  South = 'south',
+  West = 'west',
+  North = 'north',
+}
+
+export enum DragonType {
+  Red = 'red',
+  Green = 'green',
+  White = 'white',
+}
+
+export enum SeasonType {
+  Spring = 'spring',
+  Summer = 'summer',
+  Autumn = 'autumn',
+  Winter = 'winter',
+}
+
+export enum PlantType {
+  Plum = 'plum',
+  Orchid = 'orchid',
+  Bamboo = 'bamboo',
+  Chrysanthemum = 'chrysanthemum',
+}
+
+export interface WindTile {
+  kind: 'wind';
+  windType: WindType;
+}
+
+export interface DragonTile {
+  kind: 'dragon';
+  dragonType: DragonType;
+}
+
+export interface SeasonTile {
+  kind: 'season';
+  seasonType: SeasonType;
+}
+
+export interface PlantTile {
+  kind: 'plant';
+  plantType: PlantType;
+}
+
+export type FlowerTile = WindTile | DragonTile | SeasonTile | PlantTile;
+
+export type Tile = SuitedTile | FlowerTile;
+
+export interface TileInstance {
+  id: number; // 0-143
+  tile: Tile;
+}
+
+export function isSuitedTile(tile: Tile): tile is SuitedTile {
+  return tile.kind === 'suited';
+}
+
+export function isFlowerTile(tile: Tile): tile is FlowerTile {
+  return tile.kind !== 'suited';
+}


### PR DESCRIPTION
In packages/shared, define all TypeScript types for the game:

1. Tile types: Suit (wan/bing/tiao), value (1-9), 4 copies each = 108 suited tiles
2. Flower tile types: Wind (东南西北 x4), Dragon (中发白 x4), Season (春夏秋冬 x1), Plant (梅兰竹菊 x1) = 36 flower tiles
3. Gold (wild card) indicator type
4. Player state: hand tiles, exposed melds (chi/peng/gang), flower area, discard pool
5. Game state: tile wall, 4 players, current turn, dealer, gold indicator, lian zhuang count, game phase enum
6. Meld types: Chi (sequence), Peng (triplet), Ming Gang, An Gang, Bu Gang
7. Action types: Draw, Discard, Chi, Peng, Gang, Hu, Pass

Closes #18