### PR TITLE
Implement tile wall shuffling and dealing

### DIFF
--- a/packages/shared/src/game/flowers.ts
+++ b/packages/shared/src/game/flowers.ts
@@ -1,0 +1,68 @@
+import { isFlowerTile } from '../types/tile.js';
+import type { TileInstance } from '../types/tile.js';
+import type { PlayerState } from '../types/player.js';
+
+export interface FlowerReplacementResult {
+  hands: TileInstance[][];
+  wallTail: TileInstance[];
+  players: PlayerState[];
+}
+
+export function replaceFlowers(
+  hands: TileInstance[][],
+  wallTail: TileInstance[],
+  players: PlayerState[],
+  dealerIndex: number,
+): FlowerReplacementResult {
+  const updatedHands = hands.map(h => [...h]);
+  const updatedWallTail = [...wallTail];
+  const updatedPlayers = players.map(p => ({ ...p, flowers: [...p.flowers] }));
+
+  // Player processing order: dealer first, then counterclockwise
+  const order = [0, 1, 2, 3].map(i => (dealerIndex + i) % 4);
+
+  let hasNewFlowers = true;
+
+  while (hasNewFlowers) {
+    hasNewFlowers = false;
+
+    for (const playerIdx of order) {
+      // Find all flower tiles in this player's hand
+      const flowerIndices: number[] = [];
+      for (let i = 0; i < updatedHands[playerIdx].length; i++) {
+        if (isFlowerTile(updatedHands[playerIdx][i].tile)) {
+          flowerIndices.push(i);
+        }
+      }
+
+      if (flowerIndices.length === 0) continue;
+
+      // Remove flowers from hand (reverse order to preserve indices)
+      const flowers: TileInstance[] = [];
+      for (let i = flowerIndices.length - 1; i >= 0; i--) {
+        flowers.unshift(updatedHands[playerIdx].splice(flowerIndices[i], 1)[0]);
+      }
+
+      // Add to player's flower area
+      updatedPlayers[playerIdx].flowers.push(...flowers);
+
+      // Draw replacements from wall tail
+      for (let i = 0; i < flowers.length; i++) {
+        if (updatedWallTail.length === 0) break;
+        const replacement = updatedWallTail.pop()!;
+        updatedHands[playerIdx].push(replacement);
+
+        // If replacement is also a flower, it will be caught in the next round
+        if (isFlowerTile(replacement.tile)) {
+          hasNewFlowers = true;
+        }
+      }
+    }
+  }
+
+  return {
+    hands: updatedHands,
+    wallTail: updatedWallTail,
+    players: updatedPlayers,
+  };
+}

--- a/packages/shared/src/game/index.ts
+++ b/packages/shared/src/game/index.ts
@@ -1,0 +1,5 @@
+export { createAllTiles, shuffleTiles } from './tiles.js';
+export { createWall, dealTiles } from './wall.js';
+export type { WallSetup, DealResult } from './wall.js';
+export { replaceFlowers } from './flowers.js';
+export type { FlowerReplacementResult } from './flowers.js';

--- a/packages/shared/src/game/tiles.ts
+++ b/packages/shared/src/game/tiles.ts
@@ -1,0 +1,62 @@
+import {
+  Suit,
+  WindType,
+  DragonType,
+  SeasonType,
+  PlantType,
+} from '../types/tile.js';
+import type { SuitedTile, Tile, TileInstance } from '../types/tile.js';
+
+type SuitedValue = SuitedTile['value'];
+
+export function createAllTiles(): TileInstance[] {
+  const tiles: TileInstance[] = [];
+  let id = 0;
+
+  // 108 suited tiles: 3 suits × 9 values × 4 copies
+  for (const suit of [Suit.Wan, Suit.Bing, Suit.Tiao]) {
+    for (let value = 1; value <= 9; value++) {
+      for (let copy = 0; copy < 4; copy++) {
+        tiles.push({
+          id: id++,
+          tile: { kind: 'suited', suit, value: value as SuitedValue },
+        });
+      }
+    }
+  }
+
+  // 16 wind tiles: 4 types × 4 copies
+  for (const windType of [WindType.East, WindType.South, WindType.West, WindType.North]) {
+    for (let copy = 0; copy < 4; copy++) {
+      tiles.push({ id: id++, tile: { kind: 'wind', windType } });
+    }
+  }
+
+  // 12 dragon tiles: 3 types × 4 copies
+  for (const dragonType of [DragonType.Red, DragonType.Green, DragonType.White]) {
+    for (let copy = 0; copy < 4; copy++) {
+      tiles.push({ id: id++, tile: { kind: 'dragon', dragonType } });
+    }
+  }
+
+  // 4 season tiles: 1 each
+  for (const seasonType of [SeasonType.Spring, SeasonType.Summer, SeasonType.Autumn, SeasonType.Winter]) {
+    tiles.push({ id: id++, tile: { kind: 'season', seasonType } });
+  }
+
+  // 4 plant tiles: 1 each
+  for (const plantType of [PlantType.Plum, PlantType.Orchid, PlantType.Bamboo, PlantType.Chrysanthemum]) {
+    tiles.push({ id: id++, tile: { kind: 'plant', plantType } });
+  }
+
+  return tiles;
+}
+
+export function shuffleTiles(tiles: TileInstance[]): TileInstance[] {
+  const result = [...tiles];
+  for (let i = result.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [result[i], result[j]] = [result[j], result[i]];
+  }
+  return result;
+}

--- a/packages/shared/src/game/wall.ts
+++ b/packages/shared/src/game/wall.ts
@@ -1,0 +1,48 @@
+import type { TileInstance } from '../types/tile.js';
+import { createAllTiles, shuffleTiles } from './tiles.js';
+
+const WALL_TAIL_SIZE = 40;
+
+export interface WallSetup {
+  wall: TileInstance[];
+  wallTail: TileInstance[];
+}
+
+export function createWall(): WallSetup {
+  const allTiles = shuffleTiles(createAllTiles());
+  const splitPoint = allTiles.length - WALL_TAIL_SIZE;
+  return {
+    wall: allTiles.slice(0, splitPoint),
+    wallTail: allTiles.slice(splitPoint),
+  };
+}
+
+export interface DealResult {
+  hands: [TileInstance[], TileInstance[], TileInstance[], TileInstance[]];
+  remainingWall: TileInstance[];
+}
+
+export function dealTiles(wall: TileInstance[], dealerIndex: number): DealResult {
+  const hands: [TileInstance[], TileInstance[], TileInstance[], TileInstance[]] = [[], [], [], []];
+  let drawIndex = 0;
+
+  // Player order: dealer first, then counterclockwise
+  const order = [0, 1, 2, 3].map(i => (dealerIndex + i) % 4);
+
+  // 4 rounds, 4 tiles each per player
+  for (let round = 0; round < 4; round++) {
+    for (const playerIdx of order) {
+      for (let t = 0; t < 4; t++) {
+        hands[playerIdx].push(wall[drawIndex++]);
+      }
+    }
+  }
+
+  // Dealer draws 1 extra tile (跳牌)
+  hands[dealerIndex].push(wall[drawIndex++]);
+
+  return {
+    hands,
+    remainingWall: wall.slice(drawIndex),
+  };
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -6,3 +6,4 @@ export interface HealthResponse {
 }
 
 export * from './types/index.js';
+export * from './game/index.js';


### PR DESCRIPTION
In packages/shared, implement tile wall initialization, shuffling, and dealing:

1. Create all 144 tiles (108 suited + 36 flowers)
2. Shuffle using Fisher-Yates algorithm
3. Deal: dealer gets 17 tiles, other 3 players get 16 each
4. Flower replacement flow: detect flower tiles in hand, draw replacements from wall tail, loop until no flowers remain in any hand
5. Multiple rounds of flower replacement: if replacement tile is also a flower, wait for all players to finish current round, then start new round from dealer

Closes #20