### PR TITLE
Implement gold tile reveal logic

### DIFF
--- a/packages/shared/src/game/gold.ts
+++ b/packages/shared/src/game/gold.ts
@@ -1,0 +1,47 @@
+import { isSuitedTile } from '../types/tile.js';
+import type { TileInstance, SuitedTile } from '../types/tile.js';
+import type { GoldState } from '../types/game.js';
+
+export interface RevealGoldResult {
+  gold: GoldState;
+  wallTail: TileInstance[];
+  dealerFlowers: TileInstance[];
+}
+
+export function revealGold(wallTail: TileInstance[]): RevealGoldResult {
+  const updatedWallTail = [...wallTail];
+  const dealerFlowers: TileInstance[] = [];
+
+  while (updatedWallTail.length > 0) {
+    const flipped = updatedWallTail.pop()!;
+
+    if (isSuitedTile(flipped.tile)) {
+      return {
+        gold: {
+          indicatorTile: flipped,
+          wildTile: flipped.tile,
+        },
+        wallTail: updatedWallTail,
+        dealerFlowers,
+      };
+    }
+
+    // Flower tile — counts as dealer's flower, flip again
+    dealerFlowers.push(flipped);
+  }
+
+  throw new Error('No suited tile found in wallTail for gold reveal');
+}
+
+export function isGoldTile(
+  tileInstance: TileInstance,
+  gold: GoldState,
+): boolean {
+  if (!isSuitedTile(tileInstance.tile)) return false;
+  // Match by suit and value, but exclude the indicator tile itself
+  if (tileInstance.id === gold.indicatorTile.id) return false;
+  return (
+    tileInstance.tile.suit === gold.wildTile.suit &&
+    tileInstance.tile.value === gold.wildTile.value
+  );
+}

--- a/packages/shared/src/game/index.ts
+++ b/packages/shared/src/game/index.ts
@@ -3,3 +3,5 @@ export { createWall, dealTiles } from './wall.js';
 export type { WallSetup, DealResult } from './wall.js';
 export { replaceFlowers } from './flowers.js';
 export type { FlowerReplacementResult } from './flowers.js';
+export { revealGold, isGoldTile } from './gold.js';
+export type { RevealGoldResult } from './gold.js';


### PR DESCRIPTION
In packages/shared, implement the gold (wild card) reveal logic:

1. After flower replacement, flip the first tile from wallTail as the gold indicator
2. If the flipped tile is a flower tile, it counts as the dealer flower, dealer draws replacement, flip again
3. Repeat until a suited tile is revealed as gold
4. The gold indicator determines which tile type is wild - all 4 copies of that tile become gold (3 remaining in play)
5. Place the gold indicator at the 9th stack from the end (display position)
6. Return updated GoldState with indicatorTile and wildTile

Closes #22