### PR TITLE
Implement turn management and action handling

### DIFF
--- a/apps/server/src/gameEngine.ts
+++ b/apps/server/src/gameEngine.ts
@@ -1,0 +1,700 @@
+import type { Server } from "socket.io";
+import {
+  ActionType,
+  GamePhase,
+  MeldType,
+  isGoldTile,
+  findChiCombinations,
+  canPeng,
+  canMingGang,
+  findAnGang,
+  findBuGang,
+  checkWin,
+  isDraw,
+  isInFinalDraws,
+  calculateRetainCount,
+  isSuitedTile,
+} from "@fuzhou-mahjong/shared";
+import type {
+  GameAction,
+  TileInstance,
+  ClientEvents,
+  ServerEvents,
+  Meld,
+  WinContext,
+} from "@fuzhou-mahjong/shared";
+import { ServerGameState, getGame } from "./gameState.js";
+import { findRoomBySocket } from "./room.js";
+
+type GameServer = Server<ClientEvents, ServerEvents>;
+
+const ACTION_TIMEOUT_MS = 30_000;
+
+// ─── Action Window ───────────────────────────────────────────────
+
+interface PendingAction {
+  playerIndex: number;
+  action: GameAction;
+  priority: number; // higher = higher priority
+}
+
+function actionPriority(action: GameAction): number {
+  switch (action.type) {
+    case ActionType.Hu: return 100;
+    case ActionType.Peng: return 50;
+    case ActionType.MingGang: return 50;
+    case ActionType.Chi: return 10;
+    case ActionType.Pass: return 0;
+    default: return 0;
+  }
+}
+
+class ActionWindow {
+  private responses = new Map<number, GameAction>();
+  private pendingPlayers: Set<number>;
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private onResolve: (winner: PendingAction | null) => void;
+  private discarderIndex: number;
+
+  constructor(
+    pendingPlayers: number[],
+    discarderIndex: number,
+    onResolve: (winner: PendingAction | null) => void,
+  ) {
+    this.pendingPlayers = new Set(pendingPlayers);
+    this.discarderIndex = discarderIndex;
+    this.onResolve = onResolve;
+
+    this.timer = setTimeout(() => {
+      // Auto-pass for all remaining
+      for (const pi of this.pendingPlayers) {
+        this.responses.set(pi, { type: ActionType.Pass, playerIndex: pi });
+      }
+      this.pendingPlayers.clear();
+      this.tryResolve();
+    }, ACTION_TIMEOUT_MS);
+  }
+
+  addResponse(playerIndex: number, action: GameAction): boolean {
+    if (!this.pendingPlayers.has(playerIndex)) return false;
+    this.responses.set(playerIndex, action);
+    this.pendingPlayers.delete(playerIndex);
+    this.tryResolve();
+    return true;
+  }
+
+  private tryResolve(): void {
+    if (this.pendingPlayers.size > 0) return;
+    if (this.timer) { clearTimeout(this.timer); this.timer = null; }
+
+    // Find highest priority action
+    let best: PendingAction | null = null;
+    for (const [playerIndex, action] of this.responses) {
+      const priority = actionPriority(action);
+      if (priority === 0) continue; // pass
+      if (!best || priority > best.priority ||
+          (priority === best.priority && this.isCloserToDiscarder(playerIndex, best.playerIndex))) {
+        best = { playerIndex, action, priority };
+      }
+    }
+
+    this.onResolve(best);
+  }
+
+  private isCloserToDiscarder(a: number, b: number): boolean {
+    const distA = ((a - this.discarderIndex + 4) % 4);
+    const distB = ((b - this.discarderIndex + 4) % 4);
+    return distA < distB;
+  }
+
+  cancel(): void {
+    if (this.timer) { clearTimeout(this.timer); this.timer = null; }
+  }
+}
+
+// ─── Game Engine ─────────────────────────────────────────────────
+
+const activeWindows = new Map<string, ActionWindow>();
+
+export function handlePlayerAction(
+  io: GameServer,
+  socketId: string,
+  action: GameAction,
+): void {
+  const room = findRoomBySocket(socketId);
+  if (!room) return;
+
+  const game = getGame(room.id);
+  if (!game || game.state.phase !== GamePhase.Playing) return;
+
+  const playerIndex = game.getPlayerIndex(socketId);
+  if (playerIndex === -1) return;
+
+  // Check if there's an active action window
+  const window = activeWindows.get(room.id);
+  if (window) {
+    window.addResponse(playerIndex, action);
+    return;
+  }
+
+  // Direct actions (during player's own turn)
+  const state = game.state;
+  if (state.currentTurn !== playerIndex) return;
+
+  switch (action.type) {
+    case ActionType.Discard:
+      handleDiscard(io, game, playerIndex, action.tile);
+      break;
+    case ActionType.AnGang:
+      handleAnGang(io, game, playerIndex, action.tile);
+      break;
+    case ActionType.BuGang:
+      handleBuGang(io, game, playerIndex, action.tile);
+      break;
+    case ActionType.Hu:
+      handleSelfDrawHu(io, game, playerIndex);
+      break;
+    case ActionType.Draw:
+      handleDraw(io, game, playerIndex);
+      break;
+    default:
+      break;
+  }
+}
+
+function handleDiscard(
+  io: GameServer,
+  game: ServerGameState,
+  playerIndex: number,
+  tile: TileInstance,
+): void {
+  const state = game.state;
+  const player = state.players[playerIndex];
+
+  // Remove tile from hand
+  const tileIdx = player.hand.findIndex((t) => t.id === tile.id);
+  if (tileIdx === -1) return;
+  player.hand.splice(tileIdx, 1);
+  player.discards.push(tile);
+  state.lastDiscard = { tile, playerIndex };
+
+  // Gold discard penalty
+  if (state.gold && isGoldTile(tile, state.gold)) {
+    player.hasDiscardedGold = true;
+  }
+
+  // Check if anyone can act on this discard
+  const pendingPlayers: number[] = [];
+
+  for (let i = 0; i < 4; i++) {
+    if (i === playerIndex) continue;
+
+    const actions = getResponseActions(game, i, tile, playerIndex);
+    if (actions.canHu || actions.canPeng || actions.canMingGang || actions.chiOptions.length > 0) {
+      pendingPlayers.push(i);
+      io.to(game.getSocketId(i)).emit("actionRequired", actions);
+    }
+  }
+
+  if (pendingPlayers.length === 0) {
+    // No one can act, next player draws
+    advanceToNextPlayer(io, game, playerIndex);
+  } else {
+    // Open action window
+    const window = new ActionWindow(pendingPlayers, playerIndex, (winner) => {
+      activeWindows.delete(game.roomId);
+      resolveActionWindow(io, game, winner, playerIndex, tile);
+    });
+    activeWindows.set(game.roomId, window);
+  }
+
+  broadcastState(io, game);
+}
+
+function handleDraw(
+  io: GameServer,
+  game: ServerGameState,
+  playerIndex: number,
+): void {
+  const state = game.state;
+
+  // Check draw condition
+  state.retainCount = calculateRetainCount(state.players);
+  if (isDraw(state.wall.length, state.wallTail.length, state.retainCount)) {
+    endGameDraw(io, game);
+    return;
+  }
+
+  // Draw from wall
+  if (state.wall.length === 0) {
+    endGameDraw(io, game);
+    return;
+  }
+
+  const tile = state.wall.shift()!;
+  const player = state.players[playerIndex];
+
+  // If flower, add to flowers and draw again
+  if (!isSuitedTile(tile.tile)) {
+    player.flowers.push(tile);
+    // Draw replacement from tail
+    if (state.wallTail.length > 0) {
+      const replacement = state.wallTail.pop()!;
+      player.hand.push(replacement);
+    }
+  } else {
+    player.hand.push(tile);
+  }
+
+  state.lastDiscard = null;
+
+  broadcastState(io, game);
+
+  // Check for available actions after draw
+  const inFinalDraws = isInFinalDraws(state.wall.length, state.wallTail.length, state.retainCount);
+
+  const actions = getPostDrawActions(game, playerIndex, inFinalDraws);
+  io.to(game.getSocketId(playerIndex)).emit("actionRequired", actions);
+}
+
+function handleAnGang(
+  io: GameServer,
+  game: ServerGameState,
+  playerIndex: number,
+  tile: TileInstance,
+): void {
+  const state = game.state;
+  const player = state.players[playerIndex];
+
+  // Find all 4 matching tiles
+  const matching = player.hand.filter(
+    (t) => isSuitedTile(t.tile) && isSuitedTile(tile.tile) &&
+           t.tile.suit === tile.tile.suit && t.tile.value === tile.tile.value,
+  );
+  if (matching.length < 4) return;
+
+  // Remove from hand
+  for (const m of matching) {
+    const idx = player.hand.findIndex((t) => t.id === m.id);
+    if (idx >= 0) player.hand.splice(idx, 1);
+  }
+
+  // Create meld
+  const meld: Meld = { type: MeldType.AnGang, tiles: matching };
+  player.melds.push(meld);
+
+  // Update retain count
+  state.retainCount = calculateRetainCount(state.players);
+
+  // Draw replacement from tail
+  gangDraw(io, game, playerIndex);
+}
+
+function handleBuGang(
+  io: GameServer,
+  game: ServerGameState,
+  playerIndex: number,
+  tile: TileInstance,
+): void {
+  const state = game.state;
+  const player = state.players[playerIndex];
+
+  // Find the peng meld to upgrade
+  const meldIdx = player.melds.findIndex(
+    (m) => m.type === MeldType.Peng && m.tiles[0] &&
+           isSuitedTile(m.tiles[0].tile) && isSuitedTile(tile.tile) &&
+           m.tiles[0].tile.suit === tile.tile.suit && m.tiles[0].tile.value === tile.tile.value,
+  );
+  if (meldIdx === -1) return;
+
+  // Check for robbing kong (抢杠胡)
+  // Other players can hu on this tile
+  const canRob: number[] = [];
+  for (let i = 0; i < 4; i++) {
+    if (i === playerIndex) continue;
+    const winResult = checkWin(state.players[i], tile, state.gold, {
+      isSelfDraw: false,
+      isFirstAction: false,
+      isDealer: state.players[i].isDealer,
+      isRobbingKong: true,
+      totalFlowers: state.players[i].flowers.length,
+      totalGangs: state.players[i].melds.filter(
+        (m) => m.type === MeldType.MingGang || m.type === MeldType.AnGang || m.type === MeldType.BuGang,
+      ).length,
+    });
+    if (winResult.isWin) canRob.push(i);
+  }
+
+  if (canRob.length > 0) {
+    // Ask robbers if they want to hu
+    for (const i of canRob) {
+      const actions: import("@fuzhou-mahjong/shared").AvailableActions = {
+        canDraw: false, canDiscard: false, chiOptions: [], canPeng: false,
+        canMingGang: false, anGangOptions: [], buGangOptions: [], canHu: true, canPass: true,
+      };
+      io.to(game.getSocketId(i)).emit("actionRequired", actions);
+    }
+
+    const window = new ActionWindow(canRob, playerIndex, (winner) => {
+      activeWindows.delete(game.roomId);
+      if (winner && winner.action.type === ActionType.Hu) {
+        endGameWin(io, game, winner.playerIndex, tile, false);
+      } else {
+        // No one robbed, proceed with bu gang
+        executeBuGang(io, game, playerIndex, tile, meldIdx);
+      }
+    });
+    activeWindows.set(game.roomId, window);
+  } else {
+    executeBuGang(io, game, playerIndex, tile, meldIdx);
+  }
+}
+
+function executeBuGang(
+  io: GameServer,
+  game: ServerGameState,
+  playerIndex: number,
+  tile: TileInstance,
+  meldIdx: number,
+): void {
+  const player = game.state.players[playerIndex];
+
+  // Remove tile from hand
+  const handIdx = player.hand.findIndex((t) => t.id === tile.id);
+  if (handIdx >= 0) player.hand.splice(handIdx, 1);
+
+  // Upgrade peng to bu gang
+  player.melds[meldIdx].type = MeldType.BuGang;
+  player.melds[meldIdx].tiles.push(tile);
+
+  game.state.retainCount = calculateRetainCount(game.state.players);
+
+  gangDraw(io, game, playerIndex);
+}
+
+function handleSelfDrawHu(
+  io: GameServer,
+  game: ServerGameState,
+  playerIndex: number,
+): void {
+  const player = game.state.players[playerIndex];
+  if (player.hand.length === 0) return;
+
+  // The last tile in hand is the winning tile (just drawn)
+  const winningTile = player.hand[player.hand.length - 1];
+
+  const winResult = checkWin(player, winningTile, game.state.gold, {
+    isSelfDraw: true,
+    isFirstAction: false,
+    isDealer: player.isDealer,
+    isRobbingKong: false,
+    totalFlowers: player.flowers.length,
+    totalGangs: player.melds.filter(
+      (m) => m.type === MeldType.MingGang || m.type === MeldType.AnGang || m.type === MeldType.BuGang,
+    ).length,
+  });
+
+  if (winResult.isWin) {
+    endGameWin(io, game, playerIndex, winningTile, true);
+  }
+}
+
+function gangDraw(
+  io: GameServer,
+  game: ServerGameState,
+  playerIndex: number,
+): void {
+  const state = game.state;
+  if (state.wallTail.length === 0) {
+    endGameDraw(io, game);
+    return;
+  }
+
+  const tile = state.wallTail.pop()!;
+  const player = state.players[playerIndex];
+
+  if (!isSuitedTile(tile.tile)) {
+    player.flowers.push(tile);
+    // Draw another replacement
+    gangDraw(io, game, playerIndex);
+    return;
+  }
+
+  player.hand.push(tile);
+  broadcastState(io, game);
+
+  // After gang draw, player gets actions (discard, check hu/gang)
+  const actions = getPostDrawActions(game, playerIndex, false);
+  io.to(game.getSocketId(playerIndex)).emit("actionRequired", actions);
+}
+
+// ─── Action Resolution ──────────────────────────────────────────
+
+function resolveActionWindow(
+  io: GameServer,
+  game: ServerGameState,
+  winner: PendingAction | null,
+  discarderIndex: number,
+  discardTile: TileInstance,
+): void {
+  if (!winner) {
+    // All passed, next player draws
+    advanceToNextPlayer(io, game, discarderIndex);
+    return;
+  }
+
+  const state = game.state;
+
+  switch (winner.action.type) {
+    case ActionType.Hu:
+      endGameWin(io, game, winner.playerIndex, discardTile, false);
+      break;
+
+    case ActionType.Peng: {
+      const player = state.players[winner.playerIndex];
+      // Remove 2 matching tiles from hand
+      const matching = player.hand.filter(
+        (t) => isSuitedTile(t.tile) && isSuitedTile(discardTile.tile) &&
+               t.tile.suit === discardTile.tile.suit && t.tile.value === discardTile.tile.value,
+      );
+      for (let i = 0; i < 2 && i < matching.length; i++) {
+        const idx = player.hand.findIndex((t) => t.id === matching[i].id);
+        if (idx >= 0) player.hand.splice(idx, 1);
+      }
+      // Remove from discarder's discards
+      const discardIdx = state.players[discarderIndex].discards.findIndex((t) => t.id === discardTile.id);
+      if (discardIdx >= 0) state.players[discarderIndex].discards.splice(discardIdx, 1);
+      // Create meld
+      player.melds.push({
+        type: MeldType.Peng,
+        tiles: [matching[0], matching[1], discardTile],
+        sourceTile: discardTile,
+        sourcePlayer: discarderIndex,
+      });
+      state.currentTurn = winner.playerIndex;
+      state.lastDiscard = null;
+      broadcastState(io, game);
+      // Player must discard
+      io.to(game.getSocketId(winner.playerIndex)).emit("actionRequired",
+        getPostClaimActions(game, winner.playerIndex));
+      break;
+    }
+
+    case ActionType.MingGang: {
+      const player = state.players[winner.playerIndex];
+      const matching = player.hand.filter(
+        (t) => isSuitedTile(t.tile) && isSuitedTile(discardTile.tile) &&
+               t.tile.suit === discardTile.tile.suit && t.tile.value === discardTile.tile.value,
+      );
+      for (let i = 0; i < 3 && i < matching.length; i++) {
+        const idx = player.hand.findIndex((t) => t.id === matching[i].id);
+        if (idx >= 0) player.hand.splice(idx, 1);
+      }
+      const discardIdx = state.players[discarderIndex].discards.findIndex((t) => t.id === discardTile.id);
+      if (discardIdx >= 0) state.players[discarderIndex].discards.splice(discardIdx, 1);
+      player.melds.push({
+        type: MeldType.MingGang,
+        tiles: [...matching.slice(0, 3), discardTile],
+        sourceTile: discardTile,
+        sourcePlayer: discarderIndex,
+      });
+      state.currentTurn = winner.playerIndex;
+      state.retainCount = calculateRetainCount(state.players);
+      gangDraw(io, game, winner.playerIndex);
+      break;
+    }
+
+    case ActionType.Chi: {
+      const chiAction = winner.action as import("@fuzhou-mahjong/shared").ChiAction;
+      const player = state.players[winner.playerIndex];
+      // Remove the 2 chi tiles from hand
+      for (const ct of chiAction.tiles) {
+        const idx = player.hand.findIndex((t) => t.id === ct.id);
+        if (idx >= 0) player.hand.splice(idx, 1);
+      }
+      const discardIdx = state.players[discarderIndex].discards.findIndex((t) => t.id === discardTile.id);
+      if (discardIdx >= 0) state.players[discarderIndex].discards.splice(discardIdx, 1);
+      player.melds.push({
+        type: MeldType.Chi,
+        tiles: [...chiAction.tiles, discardTile],
+        sourceTile: discardTile,
+        sourcePlayer: discarderIndex,
+      });
+      state.currentTurn = winner.playerIndex;
+      state.lastDiscard = null;
+      broadcastState(io, game);
+      io.to(game.getSocketId(winner.playerIndex)).emit("actionRequired",
+        getPostClaimActions(game, winner.playerIndex));
+      break;
+    }
+
+    default:
+      advanceToNextPlayer(io, game, discarderIndex);
+      break;
+  }
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────
+
+function advanceToNextPlayer(
+  io: GameServer,
+  game: ServerGameState,
+  currentPlayerIndex: number,
+): void {
+  const nextPlayer = (currentPlayerIndex + 1) % 4;
+  game.state.currentTurn = nextPlayer;
+  handleDraw(io, game, nextPlayer);
+}
+
+function getResponseActions(
+  game: ServerGameState,
+  playerIndex: number,
+  discardTile: TileInstance,
+  discarderIndex: number,
+): import("@fuzhou-mahjong/shared").AvailableActions {
+  const state = game.state;
+  const player = state.players[playerIndex];
+  const gold = state.gold;
+
+  // Check hu (discard win)
+  let canHuFlag = false;
+  if (!player.hasDiscardedGold) {
+    const winResult = checkWin(player, discardTile, gold, {
+      isSelfDraw: false,
+      isFirstAction: false,
+      isDealer: player.isDealer,
+      isRobbingKong: false,
+      totalFlowers: player.flowers.length,
+      totalGangs: player.melds.filter(
+        (m) => m.type === MeldType.MingGang || m.type === MeldType.AnGang || m.type === MeldType.BuGang,
+      ).length,
+    });
+    canHuFlag = winResult.isWin;
+  }
+
+  // Chi: only the next counterclockwise player can chi
+  const isNextPlayer = ((discarderIndex + 1) % 4) === playerIndex;
+  const chiOpts = isNextPlayer ? findChiCombinations(player.hand, discardTile, gold) : [];
+
+  const canPengFlag = canPeng(player.hand, discardTile, gold);
+  const canMingGangFlag = canMingGang(player.hand, discardTile, gold);
+
+  return {
+    canDraw: false,
+    canDiscard: false,
+    chiOptions: chiOpts,
+    canPeng: canPengFlag,
+    canMingGang: canMingGangFlag,
+    anGangOptions: [],
+    buGangOptions: [],
+    canHu: canHuFlag,
+    canPass: true,
+  };
+}
+
+function getPostDrawActions(
+  game: ServerGameState,
+  playerIndex: number,
+  inFinalDraws: boolean,
+): import("@fuzhou-mahjong/shared").AvailableActions {
+  const state = game.state;
+  const player = state.players[playerIndex];
+  const gold = state.gold;
+
+  // Check self-draw hu
+  const lastTile = player.hand[player.hand.length - 1];
+  let canHuFlag = false;
+  if (lastTile) {
+    const winResult = checkWin(player, lastTile, gold, {
+      isSelfDraw: true,
+      isFirstAction: false,
+      isDealer: player.isDealer,
+      isRobbingKong: false,
+      totalFlowers: player.flowers.length,
+      totalGangs: player.melds.filter(
+        (m) => m.type === MeldType.MingGang || m.type === MeldType.AnGang || m.type === MeldType.BuGang,
+      ).length,
+    });
+    canHuFlag = winResult.isWin;
+  }
+
+  if (inFinalDraws) {
+    return {
+      canDraw: false,
+      canDiscard: false,
+      chiOptions: [],
+      canPeng: false,
+      canMingGang: false,
+      anGangOptions: [],
+      buGangOptions: [],
+      canHu: canHuFlag,
+      canPass: true,
+    };
+  }
+
+  const anGangOpts = findAnGang(player.hand, gold);
+  const buGangOpts = findBuGang(player.hand, player.melds, gold);
+
+  return {
+    canDraw: false,
+    canDiscard: true,
+    chiOptions: [],
+    canPeng: false,
+    canMingGang: false,
+    anGangOptions: anGangOpts,
+    buGangOptions: buGangOpts,
+    canHu: canHuFlag,
+    canPass: false,
+  };
+}
+
+function getPostClaimActions(
+  game: ServerGameState,
+  playerIndex: number,
+): import("@fuzhou-mahjong/shared").AvailableActions {
+  return {
+    canDraw: false,
+    canDiscard: true,
+    chiOptions: [],
+    canPeng: false,
+    canMingGang: false,
+    anGangOptions: [],
+    buGangOptions: [],
+    canHu: false,
+    canPass: false,
+  };
+}
+
+function endGameWin(
+  io: GameServer,
+  game: ServerGameState,
+  winnerIndex: number,
+  winningTile: TileInstance,
+  isSelfDraw: boolean,
+): void {
+  game.state.phase = GamePhase.Finished;
+  broadcastState(io, game);
+
+  io.to(game.roomId).emit("gameOver", {
+    winnerId: winnerIndex,
+    winType: isSelfDraw ? "selfDraw" : "discardWin",
+    scores: [0, 0, 0, 0], // Scoring in next ticket
+  });
+}
+
+function endGameDraw(io: GameServer, game: ServerGameState): void {
+  game.state.phase = GamePhase.Draw;
+  broadcastState(io, game);
+
+  io.to(game.roomId).emit("gameOver", {
+    winnerId: null,
+    winType: "draw",
+    scores: [0, 0, 0, 0],
+  });
+}
+
+function broadcastState(io: GameServer, game: ServerGameState): void {
+  for (let i = 0; i < 4; i++) {
+    io.to(game.getSocketId(i)).emit("gameStateUpdate", game.getClientGameState(i));
+  }
+}

--- a/apps/server/src/handlers/gameHandlers.ts
+++ b/apps/server/src/handlers/gameHandlers.ts
@@ -1,0 +1,12 @@
+import type { Server, Socket } from "socket.io";
+import type { ClientEvents, ServerEvents, GameAction } from "@fuzhou-mahjong/shared";
+import { handlePlayerAction } from "../gameEngine.js";
+
+type GameSocket = Socket<ClientEvents, ServerEvents>;
+type GameServer = Server<ClientEvents, ServerEvents>;
+
+export function registerGameHandlers(io: GameServer, socket: GameSocket): void {
+  socket.on("playerAction", (action: GameAction) => {
+    handlePlayerAction(io, socket.id, action);
+  });
+}

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -3,6 +3,7 @@ import { createServer } from "node:http";
 import { Server } from "socket.io";
 import type { HealthResponse, ClientEvents, ServerEvents } from "@fuzhou-mahjong/shared";
 import { registerRoomHandlers } from "./handlers/roomHandlers.js";
+import { registerGameHandlers } from "./handlers/gameHandlers.js";
 
 const app = express();
 const httpServer = createServer(app);
@@ -24,6 +25,7 @@ app.get("/api/health", (_req, res) => {
 io.on("connection", (socket) => {
   console.log(`Client connected: ${socket.id}`);
   registerRoomHandlers(io, socket);
+  registerGameHandlers(io, socket);
 });
 
 httpServer.listen(PORT, () => {


### PR DESCRIPTION
Implement the full play phase game loop on the server:

1. playerAction handler: validate and execute discard, chi, peng, gang, hu, pass
2. Action window: after a discard, wait for all players to respond (hu/peng/gang/chi/pass)
3. Priority resolution: hu > peng/gang > chi, then execute highest priority action
4. Turn rotation: counterclockwise after discard (if no one claims)
5. Draw phase: current player draws from wall head, check for an gang/bu gang/hu
6. Gold discard penalty: player who discards gold can only self-draw win
7. Gang replacement: after any gang, draw from wall tail
8. Robbing kong: when bu gang attempted, others can hu on that tile
9. Final draws phase: last 4 tiles, no discard, self-draw only
10. Draw detection: when wall exhausted per retain count
11. Broadcast updated ClientGameState after each action
12. Timeout: auto-pass after 30 seconds of inaction

Closes #36