### PR TITLE
Implement scoring settlement and dealer rotation

### DIFF
--- a/apps/server/src/gameEngine.ts
+++ b/apps/server/src/gameEngine.ts
@@ -14,6 +14,9 @@ import {
   isInFinalDraws,
   calculateRetainCount,
   isSuitedTile,
+  calculateScore,
+  getNextDealer,
+  WinType,
 } from "@fuzhou-mahjong/shared";
 import type {
   GameAction,
@@ -672,18 +675,65 @@ function endGameWin(
   winningTile: TileInstance,
   isSelfDraw: boolean,
 ): void {
-  game.state.phase = GamePhase.Finished;
+  const state = game.state;
+  state.phase = GamePhase.Finished;
+
+  const winner = state.players[winnerIndex];
+  const winResult = checkWin(winner, winningTile, state.gold, {
+    isSelfDraw,
+    isFirstAction: false,
+    isDealer: winner.isDealer,
+    isRobbingKong: false,
+    totalFlowers: winner.flowers.length,
+    totalGangs: winner.melds.filter(
+      (m) => m.type === MeldType.MingGang || m.type === MeldType.AnGang || m.type === MeldType.BuGang,
+    ).length,
+  });
+
+  const discarderIndex = isSelfDraw ? null : (state.lastDiscard?.playerIndex ?? null);
+
+  const scoreResult = calculateScore(
+    winner,
+    winnerIndex,
+    winResult.winType,
+    winResult.multiplier,
+    state.gold,
+    isSelfDraw,
+    discarderIndex,
+    state.lianZhuangCount,
+  );
+
+  // Dealer rotation
+  const { nextDealer, nextLianZhuang } = getNextDealer(
+    state.dealerIndex,
+    winnerIndex,
+    state.lianZhuangCount,
+  );
+  state.dealerIndex = nextDealer;
+  state.lianZhuangCount = nextLianZhuang;
+
   broadcastState(io, game);
 
   io.to(game.roomId).emit("gameOver", {
     winnerId: winnerIndex,
-    winType: isSelfDraw ? "selfDraw" : "discardWin",
-    scores: [0, 0, 0, 0], // Scoring in next ticket
+    winType: winResult.winType,
+    scores: scoreResult.payments,
   });
 }
 
 function endGameDraw(io: GameServer, game: ServerGameState): void {
-  game.state.phase = GamePhase.Draw;
+  const state = game.state;
+  state.phase = GamePhase.Draw;
+
+  // Dealer rotation on draw
+  const { nextDealer, nextLianZhuang } = getNextDealer(
+    state.dealerIndex,
+    null,
+    state.lianZhuangCount,
+  );
+  state.dealerIndex = nextDealer;
+  state.lianZhuangCount = nextLianZhuang;
+
   broadcastState(io, game);
 
   io.to(game.roomId).emit("gameOver", {

--- a/packages/shared/src/game/index.ts
+++ b/packages/shared/src/game/index.ts
@@ -27,3 +27,5 @@ export {
   isDraw,
   isInFinalDraws,
 } from './retention.js';
+export { calculateScore, getNextDealer } from './scoring.js';
+export type { ScoreResult } from './scoring.js';

--- a/packages/shared/src/game/scoring.ts
+++ b/packages/shared/src/game/scoring.ts
@@ -1,0 +1,129 @@
+import { isSuitedTile } from '../types/tile.js';
+import type { TileInstance } from '../types/tile.js';
+import type { GoldState } from '../types/game.js';
+import type { PlayerState } from '../types/player.js';
+import { MeldType } from '../types/meld.js';
+import { WinType } from './winning.js';
+import { isGoldTile } from './gold.js';
+import { countFlowerGangs } from './retention.js';
+
+export interface ScoreResult {
+  flowerScore: number;
+  goldScore: number;
+  specialMultiplier: number;
+  totalScore: number;
+  payments: number[];
+}
+
+/**
+ * Count gold tiles in the winner's hand.
+ */
+function countGoldInHand(hand: TileInstance[], gold: GoldState): number {
+  return hand.filter((t) => isGoldTile(t, gold)).length;
+}
+
+/**
+ * Calculate flower score for the winner.
+ * = individual flowers + flower gang bonus (+2 per gang) + meld gang points + gold in hand
+ */
+function calculateFlowerScore(winner: PlayerState, gold: GoldState | null): number {
+  let score = winner.flowers.length;
+
+  // Flower gang bonus: each flower gang adds +2 (since 4 tiles give 6 instead of 4)
+  score += countFlowerGangs(winner.flowers) * 2;
+
+  // Meld gang points (winner only)
+  for (const meld of winner.melds) {
+    switch (meld.type) {
+      case MeldType.MingGang:
+      case MeldType.BuGang:
+        score += 1;
+        break;
+      case MeldType.AnGang:
+        score += 2;
+        break;
+    }
+  }
+
+  // Gold tiles in hand
+  if (gold) {
+    score += countGoldInHand(winner.hand, gold);
+  }
+
+  return score;
+}
+
+/**
+ * Calculate score using QQ version formula.
+ *
+ * Discard win: (flowerScore + goldScore + lianZhuang + 5) × 2 + specialMultiplier
+ * Self-draw:   above × 3
+ *
+ * Payment (modern rules):
+ * - Self-draw: each of 3 losers pays totalScore to winner
+ * - Discard win: discarder pays 2 × totalScore to winner
+ */
+export function calculateScore(
+  winner: PlayerState,
+  winnerIndex: number,
+  winType: WinType,
+  multiplier: number,
+  gold: GoldState | null,
+  isSelfDraw: boolean,
+  discarderIndex: number | null,
+  lianZhuangCount: number,
+): ScoreResult {
+  const flowerScore = calculateFlowerScore(winner, gold);
+  const goldScore = gold ? countGoldInHand(winner.hand, gold) : 0;
+
+  const baseCalc = (flowerScore + lianZhuangCount + 5) * 2 + multiplier;
+  const totalScore = isSelfDraw ? baseCalc * 3 : baseCalc;
+
+  // Payment calculation
+  const payments = [0, 0, 0, 0];
+
+  if (isSelfDraw) {
+    // Each of 3 losers pays totalScore
+    for (let i = 0; i < 4; i++) {
+      if (i === winnerIndex) {
+        payments[i] = totalScore * 3;
+      } else {
+        payments[i] = -totalScore;
+      }
+    }
+  } else if (discarderIndex !== null) {
+    // Discarder pays 2x
+    payments[winnerIndex] = totalScore * 2;
+    payments[discarderIndex] = -(totalScore * 2);
+  }
+
+  return {
+    flowerScore,
+    goldScore,
+    specialMultiplier: multiplier,
+    totalScore,
+    payments,
+  };
+}
+
+/**
+ * Determine the next dealer and lian zhuang count.
+ */
+export function getNextDealer(
+  currentDealer: number,
+  winnerIndex: number | null,
+  lianZhuangCount: number,
+): { nextDealer: number; nextLianZhuang: number } {
+  if (winnerIndex === null) {
+    // Draw: dealer continues, lianZhuang preserved
+    return { nextDealer: currentDealer, nextLianZhuang: lianZhuangCount };
+  }
+
+  if (winnerIndex === currentDealer) {
+    // Dealer wins: continue, lianZhuang + 1
+    return { nextDealer: currentDealer, nextLianZhuang: lianZhuangCount + 1 };
+  }
+
+  // Non-dealer wins: pass dealer counterclockwise, reset lianZhuang
+  return { nextDealer: (currentDealer + 1) % 4, nextLianZhuang: 0 };
+}


### PR DESCRIPTION
Implement the QQ version scoring system and dealer rotation:

1. Score formula: discard win = (flowers + gold + lianZhuang + 5) x 2 + specialMultiplier, self-draw = that x 3
2. Flower score: individual flowers + flower gang (4 identical = 6 instead of 4) + ming gang x1 + an gang x2 + gold tiles in hand x1
3. Payment: modern rules - discarder pays 2x on discard win, each of 3 losers pays 1x on self-draw
4. Dealer rotation: dealer wins = continue + lianZhuang count plus 1, non-dealer wins = pass dealer counterclockwise + reset lianZhuang, draw = dealer continues + lianZhuang preserved
5. Update gameOver event with actual scores
6. Support starting a new round after game over

Closes #38