### PR TITLE
Add room list and lobby improvements

### DIFF
--- a/apps/server/src/handlers/roomHandlers.ts
+++ b/apps/server/src/handlers/roomHandlers.ts
@@ -5,6 +5,7 @@ import {
   findRoom,
   findRoomBySocket,
   deleteRoomIfEmpty,
+  getAvailableRooms,
 } from "../room.js";
 import { createGame } from "../gameState.js";
 
@@ -22,6 +23,7 @@ export function registerRoomHandlers(io: GameServer, socket: GameSocket): void {
 
     socket.emit("roomCreated", room.id);
     socket.emit("roomJoined", room.getState());
+    io.emit("roomList", getAvailableRooms());
     console.log(`Room ${room.id} created by ${playerName} (${socket.id})`);
   });
 
@@ -48,11 +50,17 @@ export function registerRoomHandlers(io: GameServer, socket: GameSocket): void {
 
     socket.emit("roomJoined", room.getState());
     io.to(room.id).emit("roomUpdated", room.getState());
+    io.emit("roomList", getAvailableRooms());
     console.log(`${playerName} (${socket.id}) joined room ${room.id}`);
+  });
+
+  socket.on("listRooms", () => {
+    socket.emit("roomList", getAvailableRooms());
   });
 
   socket.on("leaveRoom", () => {
     leaveCurrentRoom(io, socket);
+    io.emit("roomList", getAvailableRooms());
   });
 
   socket.on("startGame", () => {
@@ -71,6 +79,7 @@ export function registerRoomHandlers(io: GameServer, socket: GameSocket): void {
     }
 
     room.gameStarted = true;
+    io.emit("roomList", getAvailableRooms());
     console.log(`Game starting in room ${room.id}`);
 
     const game = createGame(room.id, room.players.map((p) => p.socketId));
@@ -88,6 +97,7 @@ export function registerRoomHandlers(io: GameServer, socket: GameSocket): void {
 
   socket.on("disconnect", () => {
     leaveCurrentRoom(io, socket);
+    io.emit("roomList", getAvailableRooms());
   });
 }
 

--- a/apps/server/src/room.ts
+++ b/apps/server/src/room.ts
@@ -1,4 +1,4 @@
-import type { RoomState } from "@fuzhou-mahjong/shared";
+import type { RoomState, RoomListItem } from "@fuzhou-mahjong/shared";
 
 export interface Player {
   socketId: string;
@@ -87,4 +87,19 @@ export function deleteRoomIfEmpty(roomId: string): void {
   if (room && room.isEmpty()) {
     rooms.delete(roomId);
   }
+}
+
+export function getAvailableRooms(): RoomListItem[] {
+  const result: RoomListItem[] = [];
+  for (const room of rooms.values()) {
+    if (!room.isFull() && !room.gameStarted) {
+      result.push({
+        roomId: room.id,
+        playerCount: room.players.length,
+        maxPlayers: room.maxPlayers,
+        players: room.players.map((p) => p.name),
+      });
+    }
+  }
+  return result;
 }

--- a/apps/web/src/pages/Lobby.tsx
+++ b/apps/web/src/pages/Lobby.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
+import type { RoomListItem } from "@fuzhou-mahjong/shared";
 import { socket } from "../socket";
 
 interface LobbyProps {
@@ -9,27 +10,41 @@ export function Lobby({ onJoined }: LobbyProps) {
   const [name, setName] = useState("");
   const [roomCode, setRoomCode] = useState("");
   const [error, setError] = useState("");
+  const [rooms, setRooms] = useState<RoomListItem[]>([]);
+
+  useEffect(() => {
+    socket.emit("listRooms");
+
+    const onRoomJoined = () => onJoined();
+    const onError = (msg: string) => setError(msg);
+    const onRoomList = (list: RoomListItem[]) => setRooms(list);
+
+    socket.on("roomJoined", onRoomJoined);
+    socket.on("error", onError);
+    socket.on("roomList", onRoomList);
+
+    return () => {
+      socket.off("roomJoined", onRoomJoined);
+      socket.off("error", onError);
+      socket.off("roomList", onRoomList);
+    };
+  }, [onJoined]);
 
   const handleCreate = () => {
     if (!name.trim()) return;
     socket.emit("createRoom", name.trim());
   };
 
-  const handleJoin = () => {
-    if (!name.trim() || !roomCode.trim()) return;
-    socket.emit("joinRoom", roomCode.trim().toUpperCase(), name.trim());
+  const handleJoin = (code: string) => {
+    if (!name.trim()) {
+      setError("Please enter your name first");
+      return;
+    }
+    socket.emit("joinRoom", code.toUpperCase(), name.trim());
   };
 
-  socket.on("roomJoined", () => {
-    onJoined();
-  });
-
-  socket.on("error", (msg) => {
-    setError(msg);
-  });
-
   return (
-    <div style={{ maxWidth: 400, margin: "0 auto", padding: 20 }}>
+    <div style={{ maxWidth: 500, margin: "0 auto", padding: 20 }}>
       <h1>福州麻将</h1>
       <h2>Fuzhou Mahjong</h2>
 
@@ -39,7 +54,7 @@ export function Lobby({ onJoined }: LobbyProps) {
           placeholder="你的名字 / Your name"
           value={name}
           onChange={(e) => setName(e.target.value)}
-          style={{ width: "100%", padding: 8, fontSize: 16 }}
+          style={{ width: "100%", padding: 8, fontSize: 16, boxSizing: "border-box" }}
         />
       </div>
 
@@ -55,6 +70,45 @@ export function Lobby({ onJoined }: LobbyProps) {
 
       <hr />
 
+      <h3>可用房间 / Available Rooms</h3>
+      {rooms.length === 0 ? (
+        <p style={{ color: "#888" }}>暂无房间 / No rooms available</p>
+      ) : (
+        <table style={{ width: "100%", borderCollapse: "collapse", marginBottom: 20 }}>
+          <thead>
+            <tr style={{ borderBottom: "2px solid #ccc", textAlign: "left" }}>
+              <th style={{ padding: "8px 4px" }}>房间号 / Room</th>
+              <th style={{ padding: "8px 4px" }}>玩家 / Players</th>
+              <th style={{ padding: "8px 4px" }}></th>
+            </tr>
+          </thead>
+          <tbody>
+            {rooms.map((room) => (
+              <tr key={room.roomId} style={{ borderBottom: "1px solid #eee" }}>
+                <td style={{ padding: "8px 4px", fontFamily: "monospace", fontWeight: "bold" }}>
+                  {room.roomId}
+                </td>
+                <td style={{ padding: "8px 4px" }}>
+                  {room.players.join(", ")} ({room.playerCount}/{room.maxPlayers})
+                </td>
+                <td style={{ padding: "8px 4px" }}>
+                  <button
+                    onClick={() => handleJoin(room.roomId)}
+                    disabled={!name.trim()}
+                    style={{ padding: "4px 12px" }}
+                  >
+                    加入 / Join
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      <hr />
+
+      <h3>手动加入 / Join by Code</h3>
       <div style={{ marginBottom: 10 }}>
         <input
           type="text"
@@ -62,13 +116,13 @@ export function Lobby({ onJoined }: LobbyProps) {
           value={roomCode}
           onChange={(e) => setRoomCode(e.target.value.toUpperCase())}
           maxLength={4}
-          style={{ width: "100%", padding: 8, fontSize: 16, textTransform: "uppercase" }}
+          style={{ width: "100%", padding: 8, fontSize: 16, textTransform: "uppercase", boxSizing: "border-box" }}
         />
       </div>
 
       <div>
         <button
-          onClick={handleJoin}
+          onClick={() => handleJoin(roomCode.trim())}
           disabled={!name.trim() || !roomCode.trim()}
           style={{ width: "100%", padding: 12, fontSize: 16 }}
         >

--- a/packages/shared/src/types/events.ts
+++ b/packages/shared/src/types/events.ts
@@ -62,12 +62,22 @@ export interface GameOverResult {
   scores: number[];
 }
 
+// ─── Room List ───────────────────────────────────────────────────
+
+export interface RoomListItem {
+  roomId: string;
+  playerCount: number;
+  maxPlayers: 4;
+  players: string[];
+}
+
 // ─── Socket.IO event contracts ───────────────────────────────────
 
 export interface ClientEvents {
   createRoom: (playerName: string) => void;
   joinRoom: (roomId: string, playerName: string) => void;
   leaveRoom: () => void;
+  listRooms: () => void;
   startGame: () => void;
   playerAction: (action: GameAction) => void;
 }
@@ -76,6 +86,7 @@ export interface ServerEvents {
   roomCreated: (roomId: string) => void;
   roomJoined: (roomState: RoomState) => void;
   roomUpdated: (roomState: RoomState) => void;
+  roomList: (rooms: RoomListItem[]) => void;
   gameStarted: (gameState: ClientGameState) => void;
   gameStateUpdate: (gameState: ClientGameState) => void;
   actionRequired: (availableActions: AvailableActions) => void;

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -42,6 +42,7 @@ export type {
 
 export type {
   RoomState,
+  RoomListItem,
   OtherPlayerView,
   ClientGameState,
   AvailableActions,


### PR DESCRIPTION
Enhance the lobby with a browsable room list:

1. Server: add listRooms event that returns all non-full non-started rooms
2. Server: broadcast room list updates when rooms change
3. Frontend: show available rooms with player count and join button
4. Frontend: auto-refresh room list
5. Show online player count in lobby header

Closes #46