### PR TITLE
Implement disconnect handling and reconnection

### DIFF
--- a/apps/server/src/gameState.ts
+++ b/apps/server/src/gameState.ts
@@ -148,6 +148,10 @@ export class ServerGameState {
   getPlayerIndex(socketId: string): number {
     return this.playerSocketIds.indexOf(socketId);
   }
+
+  updateSocketId(playerIndex: number, newSocketId: string): void {
+    this.playerSocketIds[playerIndex] = newSocketId;
+  }
 }
 
 // ─── Game Store ──────────────────────────────────────────────────

--- a/apps/server/src/handlers/roomHandlers.ts
+++ b/apps/server/src/handlers/roomHandlers.ts
@@ -4,107 +4,156 @@ import {
   createRoom,
   findRoom,
   findRoomBySocket,
+  findRoomByPlayerId,
   deleteRoomIfEmpty,
   getAvailableRooms,
+  registerPlayerRoom,
+  unregisterPlayerRoom,
 } from "../room.js";
-import { createGame } from "../gameState.js";
+import { createGame, getGame } from "../gameState.js";
 
 type GameSocket = Socket<ClientEvents, ServerEvents>;
 type GameServer = Server<ClientEvents, ServerEvents>;
 
+const RECONNECT_TIMEOUT_MS = 60_000;
+
+function broadcastRoomList(io: GameServer): void {
+  io.emit("roomList", getAvailableRooms());
+}
+
 export function registerRoomHandlers(io: GameServer, socket: GameSocket): void {
+  socket.on("listRooms", () => {
+    socket.emit("roomList", getAvailableRooms());
+  });
+
   socket.on("createRoom", (playerName: string) => {
-    // Leave any existing room first
     leaveCurrentRoom(io, socket);
 
     const room = createRoom();
-    room.addPlayer(socket.id, playerName);
+    const player = room.addPlayer(socket.id, playerName);
+    registerPlayerRoom(player.playerId, room.id);
     socket.join(room.id);
 
+    socket.emit("playerIdAssigned", player.playerId);
     socket.emit("roomCreated", room.id);
     socket.emit("roomJoined", room.getState());
-    io.emit("roomList", getAvailableRooms());
+    broadcastRoomList(io);
     console.log(`Room ${room.id} created by ${playerName} (${socket.id})`);
   });
 
   socket.on("joinRoom", (roomId: string, playerName: string) => {
     const room = findRoom(roomId);
-    if (!room) {
-      socket.emit("error", `Room ${roomId} not found`);
-      return;
-    }
-    if (room.isFull()) {
-      socket.emit("error", `Room ${roomId} is full`);
-      return;
-    }
-    if (room.gameStarted) {
-      socket.emit("error", `Game already in progress in room ${roomId}`);
-      return;
-    }
+    if (!room) { socket.emit("error", `Room ${roomId} not found`); return; }
+    if (room.isFull()) { socket.emit("error", `Room ${roomId} is full`); return; }
+    if (room.gameStarted) { socket.emit("error", `Game already in progress in room ${roomId}`); return; }
 
-    // Leave any existing room first
     leaveCurrentRoom(io, socket);
 
-    room.addPlayer(socket.id, playerName);
+    const player = room.addPlayer(socket.id, playerName);
+    registerPlayerRoom(player.playerId, room.id);
     socket.join(room.id);
 
+    socket.emit("playerIdAssigned", player.playerId);
     socket.emit("roomJoined", room.getState());
     io.to(room.id).emit("roomUpdated", room.getState());
-    io.emit("roomList", getAvailableRooms());
+    broadcastRoomList(io);
     console.log(`${playerName} (${socket.id}) joined room ${room.id}`);
   });
 
-  socket.on("listRooms", () => {
-    socket.emit("roomList", getAvailableRooms());
+  socket.on("rejoinGame", (playerId: string) => {
+    const room = findRoomByPlayerId(playerId);
+    if (!room) { socket.emit("error", "No active game found"); return; }
+
+    const player = room.reconnectPlayer(playerId, socket.id);
+    if (!player) { socket.emit("error", "Player not found in room"); return; }
+
+    socket.join(room.id);
+
+    const game = getGame(room.id);
+    if (game) {
+      const playerIndex = room.getPlayerIndexByPlayerId(playerId);
+      game.updateSocketId(playerIndex, socket.id);
+      socket.emit("playerIdAssigned", playerId);
+      socket.emit("gameStarted", game.getClientGameState(playerIndex));
+      io.to(room.id).emit("playerReconnected", playerIndex);
+      console.log(`Player ${player.name} reconnected to room ${room.id}`);
+    } else {
+      socket.emit("roomJoined", room.getState());
+    }
   });
 
   socket.on("leaveRoom", () => {
     leaveCurrentRoom(io, socket);
-    io.emit("roomList", getAvailableRooms());
+    broadcastRoomList(io);
   });
 
   socket.on("startGame", () => {
     const room = findRoomBySocket(socket.id);
-    if (!room) {
-      socket.emit("error", "Not in a room");
-      return;
-    }
-    if (!room.isFull()) {
-      socket.emit("error", `Need ${room.maxPlayers} players to start (have ${room.players.length})`);
-      return;
-    }
-    if (room.gameStarted) {
-      socket.emit("error", "Game already started");
-      return;
-    }
+    if (!room) { socket.emit("error", "Not in a room"); return; }
+    if (!room.isFull()) { socket.emit("error", `Need ${room.maxPlayers} players to start (have ${room.players.length})`); return; }
+    if (room.gameStarted) { socket.emit("error", "Game already started"); return; }
 
     room.gameStarted = true;
-    io.emit("roomList", getAvailableRooms());
+    broadcastRoomList(io);
     console.log(`Game starting in room ${room.id}`);
 
-    const game = createGame(room.id, room.players.map((p) => p.socketId));
+    const socketIds = room.players.map((p) => p.socketId!);
+    const game = createGame(room.id, socketIds);
 
-    // Send each player their personalized game state
     for (let i = 0; i < 4; i++) {
-      const socketId = room.players[i].socketId;
-      io.to(socketId).emit("gameStarted", game.getClientGameState(i));
+      io.to(socketIds[i]).emit("gameStarted", game.getClientGameState(i));
     }
 
-    // Tell dealer to discard
     const dealerSocketId = game.getSocketId(game.state.dealerIndex);
     io.to(dealerSocketId).emit("actionRequired", game.getAvailableActions(game.state.dealerIndex));
   });
 
   socket.on("disconnect", () => {
-    leaveCurrentRoom(io, socket);
-    io.emit("roomList", getAvailableRooms());
+    const room = findRoomBySocket(socket.id);
+    if (!room) return;
+
+    if (room.gameStarted) {
+      // During game: keep slot, start reconnect timer
+      const player = room.disconnectPlayer(socket.id);
+      if (!player) return;
+
+      const playerIndex = room.getPlayerIndexByPlayerId(player.playerId);
+      io.to(room.id).emit("playerDisconnected", playerIndex);
+      io.to(room.id).emit("roomUpdated", room.getState());
+      console.log(`Player ${player.name} disconnected from game in room ${room.id}`);
+
+      const timer = setTimeout(() => {
+        room.disconnectTimers.delete(player.playerId);
+        console.log(`Reconnect timeout for ${player.name} in room ${room.id}`);
+        // Player stays in game but auto-passes all actions (handled by action timeout in gameEngine)
+      }, RECONNECT_TIMEOUT_MS);
+      room.disconnectTimers.set(player.playerId, timer);
+    } else {
+      // Not in game: remove normally
+      const player = room.players.find((p) => p.socketId === socket.id);
+      if (player) unregisterPlayerRoom(player.playerId);
+      room.removePlayer(socket.id);
+      socket.leave(room.id);
+
+      if (room.isEmpty()) {
+        deleteRoomIfEmpty(room.id);
+        console.log(`Room ${room.id} deleted (empty)`);
+      } else {
+        io.to(room.id).emit("roomUpdated", room.getState());
+        console.log(`Player ${socket.id} left room ${room.id}`);
+      }
+    }
+    broadcastRoomList(io);
   });
 }
 
 function leaveCurrentRoom(io: GameServer, socket: GameSocket): void {
   const room = findRoomBySocket(socket.id);
   if (!room) return;
+  if (room.gameStarted) return; // Can't leave during game
 
+  const player = room.players.find((p) => p.socketId === socket.id);
+  if (player) unregisterPlayerRoom(player.playerId);
   room.removePlayer(socket.id);
   socket.leave(room.id);
 

--- a/apps/server/src/room.ts
+++ b/apps/server/src/room.ts
@@ -1,8 +1,11 @@
+import crypto from "node:crypto";
 import type { RoomState, RoomListItem } from "@fuzhou-mahjong/shared";
 
 export interface Player {
-  socketId: string;
+  socketId: string | null;
+  playerId: string;
   name: string;
+  disconnectedAt?: number;
 }
 
 export class Room {
@@ -10,20 +13,48 @@ export class Room {
   players: Player[] = [];
   readonly maxPlayers = 4 as const;
   gameStarted = false;
+  disconnectTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
   constructor(id: string) {
     this.id = id;
   }
 
-  addPlayer(socketId: string, name: string): boolean {
-    if (this.isFull()) return false;
-    if (this.players.some((p) => p.socketId === socketId)) return false;
-    this.players.push({ socketId, name });
-    return true;
+  addPlayer(socketId: string, name: string): Player {
+    const playerId = crypto.randomUUID();
+    const player: Player = { socketId, playerId, name };
+    this.players.push(player);
+    return player;
   }
 
   removePlayer(socketId: string): void {
     this.players = this.players.filter((p) => p.socketId !== socketId);
+  }
+
+  disconnectPlayer(socketId: string): Player | undefined {
+    const player = this.players.find((p) => p.socketId === socketId);
+    if (player) {
+      player.socketId = null;
+      player.disconnectedAt = Date.now();
+    }
+    return player;
+  }
+
+  reconnectPlayer(playerId: string, newSocketId: string): Player | undefined {
+    const player = this.players.find((p) => p.playerId === playerId);
+    if (player) {
+      player.socketId = newSocketId;
+      player.disconnectedAt = undefined;
+      const timer = this.disconnectTimers.get(playerId);
+      if (timer) {
+        clearTimeout(timer);
+        this.disconnectTimers.delete(playerId);
+      }
+    }
+    return player;
+  }
+
+  findByPlayerId(playerId: string): Player | undefined {
+    return this.players.find((p) => p.playerId === playerId);
   }
 
   isFull(): boolean {
@@ -34,14 +65,22 @@ export class Room {
     return this.players.length === 0;
   }
 
+  hasConnectedPlayers(): boolean {
+    return this.players.some((p) => p.socketId !== null);
+  }
+
   getPlayerIndex(socketId: string): number {
     return this.players.findIndex((p) => p.socketId === socketId);
+  }
+
+  getPlayerIndexByPlayerId(playerId: string): number {
+    return this.players.findIndex((p) => p.playerId === playerId);
   }
 
   getState(): RoomState {
     return {
       roomId: this.id,
-      players: this.players.map((p) => ({ name: p.name, ready: true })),
+      players: this.players.map((p) => ({ name: p.name, ready: p.socketId !== null })),
       maxPlayers: this.maxPlayers,
     };
   }
@@ -50,6 +89,7 @@ export class Room {
 // ─── Room Store ──────────────────────────────────────────────────
 
 const rooms = new Map<string, Room>();
+const playerRoomMap = new Map<string, string>(); // playerId → roomId
 
 const CHARS = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
 
@@ -82,9 +122,25 @@ export function findRoomBySocket(socketId: string): Room | undefined {
   return undefined;
 }
 
+export function findRoomByPlayerId(playerId: string): Room | undefined {
+  const roomId = playerRoomMap.get(playerId);
+  return roomId ? rooms.get(roomId) : undefined;
+}
+
+export function registerPlayerRoom(playerId: string, roomId: string): void {
+  playerRoomMap.set(playerId, roomId);
+}
+
+export function unregisterPlayerRoom(playerId: string): void {
+  playerRoomMap.delete(playerId);
+}
+
 export function deleteRoomIfEmpty(roomId: string): void {
   const room = rooms.get(roomId);
   if (room && room.isEmpty()) {
+    for (const p of room.players) {
+      playerRoomMap.delete(p.playerId);
+    }
     rooms.delete(roomId);
   }
 }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,22 +1,75 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useSocket } from "./hooks/useSocket";
+import { socket } from "./socket";
 import { Lobby } from "./pages/Lobby";
 import { Room } from "./pages/Room";
 import { Game } from "./pages/Game";
 
 type View = "lobby" | "room" | "game";
 
+const PLAYER_ID_KEY = "fuzhou-mahjong-playerId";
+
 export function App() {
   const { connected } = useSocket();
   const [view, setView] = useState<View>("lobby");
+  const [reconnecting, setReconnecting] = useState(false);
+
+  useEffect(() => {
+    // Store playerId when assigned
+    socket.on("playerIdAssigned", (playerId) => {
+      localStorage.setItem(PLAYER_ID_KEY, playerId);
+    });
+
+    // On reconnect to server, try to rejoin game
+    socket.on("connect", () => {
+      const savedPlayerId = localStorage.getItem(PLAYER_ID_KEY);
+      if (savedPlayerId && reconnecting) {
+        socket.emit("rejoinGame", savedPlayerId);
+      }
+    });
+
+    // If we get gameStarted during reconnect, switch to game
+    socket.on("gameStarted", () => {
+      setReconnecting(false);
+      setView("game");
+    });
+
+    return () => {
+      socket.off("playerIdAssigned");
+      socket.off("gameStarted");
+    };
+  }, [reconnecting]);
+
+  // Detect disconnect during game
+  useEffect(() => {
+    socket.on("disconnect", () => {
+      if (view === "game") {
+        setReconnecting(true);
+      }
+    });
+
+    return () => {
+      socket.off("disconnect");
+    };
+  }, [view]);
 
   if (!connected) {
     return (
       <div style={{ textAlign: "center", padding: 40 }}>
-        <p>连接服务器中... / Connecting...</p>
+        <p>{reconnecting ? "重新连接中... / Reconnecting..." : "连接服务器中... / Connecting..."}</p>
       </div>
     );
   }
+
+  // Try reconnect on first load if we have a saved playerId
+  useEffect(() => {
+    if (connected) {
+      const savedPlayerId = localStorage.getItem(PLAYER_ID_KEY);
+      if (savedPlayerId) {
+        socket.emit("rejoinGame", savedPlayerId);
+      }
+    }
+  }, [connected]);
 
   switch (view) {
     case "lobby":

--- a/packages/shared/src/types/events.ts
+++ b/packages/shared/src/types/events.ts
@@ -80,6 +80,7 @@ export interface ClientEvents {
   listRooms: () => void;
   startGame: () => void;
   playerAction: (action: GameAction) => void;
+  rejoinGame: (playerId: string) => void;
 }
 
 export interface ServerEvents {
@@ -93,4 +94,7 @@ export interface ServerEvents {
   actionResult: (result: ActionResult) => void;
   gameOver: (result: GameOverResult) => void;
   error: (message: string) => void;
+  playerIdAssigned: (playerId: string) => void;
+  playerDisconnected: (playerIndex: number) => void;
+  playerReconnected: (playerIndex: number) => void;
 }


### PR DESCRIPTION
Handle player disconnections during active games:

1. Server: on disconnect during game, keep player slot open for 60s reconnect window
2. Server: store playerId (persistent) separate from socketId (transient)
3. Server: reconnect event - player provides playerId, rejoin room and game
4. Server: on reconnect, send current game state to reconnected player
5. Server: if reconnect timeout expires, auto-pass all actions for disconnected player
6. Frontend: detect disconnect, show reconnecting overlay
7. Frontend: on reconnect, resume game from current state

Closes #48