### PR TITLE
Fix Socket IO path for production nginx proxy

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -11,7 +11,7 @@ const PORT = process.env.PORT || 7701;
 
 const io = new Server<ClientEvents, ServerEvents>(httpServer, {
   cors: { origin: "*" },
-  path: "/socket.io",
+  path: "/api/socket.io",
 });
 
 app.get("/api/health", (_req, res) => {

--- a/apps/web/src/socket.ts
+++ b/apps/web/src/socket.ts
@@ -6,7 +6,11 @@ const URL = import.meta.env.PROD
   ? window.location.origin
   : "http://localhost:7701";
 
+const SOCKET_PATH = import.meta.env.PROD
+  ? "/fuzhou-mahjong/api/socket.io"
+  : "/api/socket.io";
+
 export const socket: Socket<ServerEvents, ClientEvents> = io(URL, {
-  path: "/socket.io",
+  path: SOCKET_PATH,
   autoConnect: false,
 });


### PR DESCRIPTION
Socket.IO cannot connect in production because the path does not match nginx proxy config.

Fix: change socket path to /fuzhou-mahjong/api/socket.io in both frontend and server so nginx proxies it correctly to port 7701.

Closes #50