### PR TITLE
Fix room stuck on loading after create or join

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { useSocket } from "./hooks/useSocket";
 import { socket } from "./socket";
+import type { RoomState } from "@fuzhou-mahjong/shared";
 import { Lobby } from "./pages/Lobby";
 import { Room } from "./pages/Room";
 import { Game } from "./pages/Game";
@@ -13,6 +14,7 @@ export function App() {
   const { connected } = useSocket();
   const [view, setView] = useState<View>("lobby");
   const [reconnecting, setReconnecting] = useState(false);
+  const [initialRoomState, setInitialRoomState] = useState<RoomState | null>(null);
 
   // Store playerId when assigned
   useEffect(() => {
@@ -84,9 +86,9 @@ export function App() {
 
   switch (view) {
     case "lobby":
-      return <Lobby onJoined={() => setView("room")} />;
+      return <Lobby onJoined={(roomState) => { setInitialRoomState(roomState); setView("room"); }} />;
     case "room":
-      return <Room onGameStarted={() => setView("game")} />;
+      return <Room initialRoomState={initialRoomState} onGameStarted={() => setView("game")} />;
     case "game":
       return <Game />;
   }

--- a/apps/web/src/pages/Lobby.tsx
+++ b/apps/web/src/pages/Lobby.tsx
@@ -1,9 +1,9 @@
 import { useState, useEffect } from "react";
-import type { RoomListItem } from "@fuzhou-mahjong/shared";
+import type { RoomListItem, RoomState } from "@fuzhou-mahjong/shared";
 import { socket } from "../socket";
 
 interface LobbyProps {
-  onJoined: () => void;
+  onJoined: (roomState: RoomState) => void;
 }
 
 export function Lobby({ onJoined }: LobbyProps) {
@@ -15,7 +15,7 @@ export function Lobby({ onJoined }: LobbyProps) {
   useEffect(() => {
     socket.emit("listRooms");
 
-    const onRoomJoined = () => onJoined();
+    const onRoomJoined = (state: RoomState) => onJoined(state);
     const onError = (msg: string) => setError(msg);
     const onRoomList = (list: RoomListItem[]) => setRooms(list);
 

--- a/apps/web/src/pages/Room.tsx
+++ b/apps/web/src/pages/Room.tsx
@@ -3,21 +3,26 @@ import { socket } from "../socket";
 import type { RoomState } from "@fuzhou-mahjong/shared";
 
 interface RoomProps {
+  initialRoomState: RoomState | null;
   onGameStarted: () => void;
 }
 
-export function Room({ onGameStarted }: RoomProps) {
-  const [room, setRoom] = useState<RoomState | null>(null);
+export function Room({ initialRoomState, onGameStarted }: RoomProps) {
+  const [room, setRoom] = useState<RoomState | null>(initialRoomState);
 
   useEffect(() => {
-    socket.on("roomJoined", (state) => setRoom(state));
-    socket.on("roomUpdated", (state) => setRoom(state));
-    socket.on("gameStarted", () => onGameStarted());
+    const onRoomJoined = (state: RoomState) => setRoom(state);
+    const onRoomUpdated = (state: RoomState) => setRoom(state);
+    const onGameStart = () => onGameStarted();
+
+    socket.on("roomJoined", onRoomJoined);
+    socket.on("roomUpdated", onRoomUpdated);
+    socket.on("gameStarted", onGameStart);
 
     return () => {
-      socket.off("roomJoined");
-      socket.off("roomUpdated");
-      socket.off("gameStarted");
+      socket.off("roomJoined", onRoomJoined);
+      socket.off("roomUpdated", onRoomUpdated);
+      socket.off("gameStarted", onGameStart);
     };
   }, [onGameStarted]);
 


### PR DESCRIPTION
When creating or joining a room, the Room page shows Loading forever. Root cause: Lobby consumes the roomJoined event and triggers view switch, but Room component mounts too late to receive the same event.

Fix: Pass the RoomState from Lobby to App to Room, so Room has initial state on mount without needing to catch the roomJoined event.

Closes #59