### PR TITLE
Integrate bots into server and room UI

### DIFF
--- a/apps/server/src/gameEngine.ts
+++ b/apps/server/src/gameEngine.ts
@@ -17,6 +17,7 @@ import {
   calculateScore,
   getNextDealer,
   WinType,
+  decideBotAction,
 } from "@fuzhou-mahjong/shared";
 import type {
   GameAction,
@@ -196,7 +197,7 @@ function handleDiscard(
     const actions = getResponseActions(game, i, tile, playerIndex);
     if (actions.canHu || actions.canPeng || actions.canMingGang || actions.chiOptions.length > 0) {
       pendingPlayers.push(i);
-      io.to(game.getSocketId(i)).emit("actionRequired", actions);
+      emitOrBotAction(io, game, i, actions, tile);
     }
   }
 
@@ -258,7 +259,7 @@ function handleDraw(
   const inFinalDraws = isInFinalDraws(state.wall.length, state.wallTail.length, state.retainCount);
 
   const actions = getPostDrawActions(game, playerIndex, inFinalDraws);
-  io.to(game.getSocketId(playerIndex)).emit("actionRequired", actions);
+  emitOrBotAction(io, game, playerIndex, actions);
 }
 
 function handleAnGang(
@@ -336,7 +337,7 @@ function handleBuGang(
         canDraw: false, canDiscard: false, chiOptions: [], canPeng: false,
         canMingGang: false, anGangOptions: [], buGangOptions: [], canHu: true, canPass: true,
       };
-      io.to(game.getSocketId(i)).emit("actionRequired", actions);
+      emitOrBotAction(io, game, i, actions, tile);
     }
 
     const window = new ActionWindow(canRob, playerIndex, (winner) => {
@@ -429,7 +430,7 @@ function gangDraw(
 
   // After gang draw, player gets actions (discard, check hu/gang)
   const actions = getPostDrawActions(game, playerIndex, false);
-  io.to(game.getSocketId(playerIndex)).emit("actionRequired", actions);
+  emitOrBotAction(io, game, playerIndex, actions);
 }
 
 // ─── Action Resolution ──────────────────────────────────────────
@@ -479,7 +480,7 @@ function resolveActionWindow(
       state.lastDiscard = null;
       broadcastState(io, game);
       // Player must discard
-      io.to(game.getSocketId(winner.playerIndex)).emit("actionRequired",
+      emitOrBotAction(io, game, winner.playerIndex,
         getPostClaimActions(game, winner.playerIndex));
       break;
     }
@@ -527,7 +528,7 @@ function resolveActionWindow(
       state.currentTurn = winner.playerIndex;
       state.lastDiscard = null;
       broadcastState(io, game);
-      io.to(game.getSocketId(winner.playerIndex)).emit("actionRequired",
+      emitOrBotAction(io, game, winner.playerIndex,
         getPostClaimActions(game, winner.playerIndex));
       break;
     }
@@ -746,6 +747,29 @@ function endGameDraw(io: GameServer, game: ServerGameState): void {
 
 function broadcastState(io: GameServer, game: ServerGameState): void {
   for (let i = 0; i < 4; i++) {
-    io.to(game.getSocketId(i)).emit("gameStateUpdate", game.getClientGameState(i));
+    if (!game.isBot(i)) {
+      io.to(game.getSocketId(i)).emit("gameStateUpdate", game.getClientGameState(i));
+    }
+  }
+}
+
+/**
+ * Emit actionRequired to a player, or auto-respond if bot.
+ */
+function emitOrBotAction(
+  io: GameServer,
+  game: ServerGameState,
+  playerIndex: number,
+  actions: import("@fuzhou-mahjong/shared").AvailableActions,
+  lastDiscardTile?: TileInstance,
+): void {
+  if (game.isBot(playerIndex)) {
+    setTimeout(() => {
+      const player = game.state.players[playerIndex];
+      const botAction = decideBotAction(player.hand, player.melds, actions, playerIndex, game.state.gold, lastDiscardTile);
+      handlePlayerAction(io, game.getSocketId(playerIndex), botAction);
+    }, 300 + Math.random() * 500);
+  } else {
+    io.to(game.getSocketId(playerIndex)).emit("actionRequired", actions);
   }
 }

--- a/apps/server/src/gameState.ts
+++ b/apps/server/src/gameState.ts
@@ -19,11 +19,13 @@ export class ServerGameState {
   state!: GameState;
   roomId: string;
   playerSocketIds: string[];
+  botIndices: Set<number> = new Set();
   firstActionTaken = false;
 
-  constructor(roomId: string, playerSocketIds: string[], dealerIndex?: number, lianZhuangCount?: number) {
+  constructor(roomId: string, playerSocketIds: string[], botIndices?: number[], dealerIndex?: number, lianZhuangCount?: number) {
     this.roomId = roomId;
     this.playerSocketIds = playerSocketIds;
+    if (botIndices) this.botIndices = new Set(botIndices);
     this.initRound(dealerIndex ?? Math.floor(Math.random() * 4), lianZhuangCount ?? 0);
   }
 
@@ -148,6 +150,10 @@ export class ServerGameState {
   updateSocketId(playerIndex: number, newSocketId: string): void {
     this.playerSocketIds[playerIndex] = newSocketId;
   }
+
+  isBot(playerIndex: number): boolean {
+    return this.botIndices.has(playerIndex);
+  }
 }
 
 // ─── Game Store ──────────────────────────────────────────────────
@@ -157,8 +163,9 @@ const games = new Map<string, ServerGameState>();
 export function createGame(
   roomId: string,
   playerSocketIds: string[],
+  botIndices?: number[],
 ): ServerGameState {
-  const game = new ServerGameState(roomId, playerSocketIds);
+  const game = new ServerGameState(roomId, playerSocketIds, botIndices);
   games.set(roomId, game);
   return game;
 }

--- a/apps/server/src/handlers/roomHandlers.ts
+++ b/apps/server/src/handlers/roomHandlers.ts
@@ -11,7 +11,8 @@ import {
   unregisterPlayerRoom,
 } from "../room.js";
 import { createGame, getGame } from "../gameState.js";
-import { checkWin, MeldType, isGoldTile, GamePhase } from "@fuzhou-mahjong/shared";
+import { checkWin, MeldType, isGoldTile, GamePhase, decideBotAction } from "@fuzhou-mahjong/shared";
+import { handlePlayerAction } from "../gameEngine.js";
 
 type GameSocket = Socket<ClientEvents, ServerEvents>;
 type GameServer = Server<ClientEvents, ServerEvents>;
@@ -83,6 +84,20 @@ export function registerRoomHandlers(io: GameServer, socket: GameSocket): void {
     }
   });
 
+  socket.on("addBot", () => {
+    const room = findRoomBySocket(socket.id);
+    if (!room) { socket.emit("error", "Not in a room"); return; }
+    if (room.isFull()) { socket.emit("error", "Room is full"); return; }
+    if (room.gameStarted) { socket.emit("error", "Game already started"); return; }
+
+    const bot = room.addBot();
+    if (!bot) { socket.emit("error", "Failed to add bot"); return; }
+
+    io.to(room.id).emit("roomUpdated", room.getState());
+    broadcastRoomList(io);
+    console.log(`Bot ${bot.name} added to room ${room.id}`);
+  });
+
   socket.on("leaveRoom", () => {
     leaveCurrentRoom(io, socket);
     broadcastRoomList(io);
@@ -98,11 +113,14 @@ export function registerRoomHandlers(io: GameServer, socket: GameSocket): void {
     broadcastRoomList(io);
     console.log(`Game starting in room ${room.id}`);
 
-    const socketIds = room.players.map((p) => p.socketId!);
-    const game = createGame(room.id, socketIds);
+    const socketIds = room.players.map((p) => p.socketId ?? `bot-${p.playerId}`);
+    const botIndices = room.players.map((p, i) => p.isBot ? i : -1).filter((i) => i >= 0);
+    const game = createGame(room.id, socketIds, botIndices);
 
     for (let i = 0; i < 4; i++) {
-      io.to(socketIds[i]).emit("gameStarted", game.getClientGameState(i));
+      if (!game.isBot(i) && room.players[i].socketId) {
+        io.to(room.players[i].socketId!).emit("gameStarted", game.getClientGameState(i));
+      }
     }
 
     // Check tianhu: dealer wins immediately if hand is complete after gold reveal
@@ -131,8 +149,7 @@ export function registerRoomHandlers(io: GameServer, socket: GameSocket): void {
       }
     }
 
-    const dealerSocketId = game.getSocketId(game.state.dealerIndex);
-    io.to(dealerSocketId).emit("actionRequired", game.getInitialDealerActions());
+    triggerDealerAction(io, game, room);
   });
 
   socket.on("nextRound", () => {
@@ -154,8 +171,7 @@ export function registerRoomHandlers(io: GameServer, socket: GameSocket): void {
       io.to(socketIds[i]).emit("gameStarted", game.getClientGameState(i));
     }
 
-    const dealerSocketId = game.getSocketId(game.state.dealerIndex);
-    io.to(dealerSocketId).emit("actionRequired", game.getInitialDealerActions());
+    triggerDealerAction(io, game, room);
   });
 
   socket.on("disconnect", () => {
@@ -195,6 +211,20 @@ export function registerRoomHandlers(io: GameServer, socket: GameSocket): void {
     }
     broadcastRoomList(io);
   });
+}
+
+function triggerDealerAction(io: GameServer, game: import("../gameState.js").ServerGameState, room: import("../room.js").Room): void {
+  const dealerIdx = game.state.dealerIndex;
+  if (game.isBot(dealerIdx)) {
+    setTimeout(() => {
+      const actions = game.getInitialDealerActions();
+      const player = game.state.players[dealerIdx];
+      const botAction = decideBotAction(player.hand, player.melds, actions, dealerIdx, game.state.gold);
+      handlePlayerAction(io, game.getSocketId(dealerIdx), botAction);
+    }, 500);
+  } else if (room.players[dealerIdx].socketId) {
+    io.to(room.players[dealerIdx].socketId!).emit("actionRequired", game.getInitialDealerActions());
+  }
 }
 
 function leaveCurrentRoom(io: GameServer, socket: GameSocket): void {

--- a/apps/server/src/room.ts
+++ b/apps/server/src/room.ts
@@ -5,8 +5,11 @@ export interface Player {
   socketId: string | null;
   playerId: string;
   name: string;
+  isBot?: boolean;
   disconnectedAt?: number;
 }
+
+const BOT_NAMES = ["Bot 东", "Bot 南", "Bot 西", "Bot 北"];
 
 export class Room {
   readonly id: string;
@@ -22,6 +25,20 @@ export class Room {
   addPlayer(socketId: string, name: string): Player {
     const playerId = crypto.randomUUID();
     const player: Player = { socketId, playerId, name };
+    this.players.push(player);
+    return player;
+  }
+
+  addBot(): Player | null {
+    if (this.isFull()) return null;
+    const botIndex = this.players.filter((p) => p.isBot).length;
+    const name = BOT_NAMES[botIndex] ?? `Bot ${botIndex + 1}`;
+    const player: Player = {
+      socketId: null,
+      playerId: crypto.randomUUID(),
+      name,
+      isBot: true,
+    };
     this.players.push(player);
     return player;
   }
@@ -80,7 +97,7 @@ export class Room {
   getState(): RoomState {
     return {
       roomId: this.id,
-      players: this.players.map((p) => ({ name: p.name, ready: p.socketId !== null })),
+      players: this.players.map((p) => ({ name: p.name, ready: p.isBot || p.socketId !== null, isBot: p.isBot })),
       maxPlayers: this.maxPlayers,
     };
   }

--- a/apps/web/src/pages/Room.tsx
+++ b/apps/web/src/pages/Room.tsx
@@ -57,7 +57,7 @@ export function Room({ initialRoomState, onGameStarted }: RoomProps) {
       <ul style={{ listStyle: "none", padding: 0 }}>
         {room.players.map((p, i) => (
           <li key={i} style={{ padding: 8, borderBottom: "1px solid #eee" }}>
-            {p.name}
+            {p.name} {p.isBot && <span style={{ color: "#888", fontSize: 12 }}>🤖</span>}
           </li>
         ))}
         {Array.from({ length: 4 - room.players.length }).map((_, i) => (
@@ -67,7 +67,14 @@ export function Room({ initialRoomState, onGameStarted }: RoomProps) {
         ))}
       </ul>
 
-      <div style={{ marginTop: 20, display: "flex", gap: 10 }}>
+      <div style={{ marginTop: 20, display: "flex", gap: 10, flexWrap: "wrap" }}>
+        <button
+          onClick={() => socket.emit("addBot")}
+          disabled={room.players.length >= 4}
+          style={{ flex: 1, padding: 12, fontSize: 16 }}
+        >
+          添加机器人 / Add Bot
+        </button>
         <button
           onClick={handleStart}
           disabled={room.players.length < 4}

--- a/packages/shared/src/types/events.ts
+++ b/packages/shared/src/types/events.ts
@@ -7,7 +7,7 @@ import type { Meld } from './meld.js';
 
 export interface RoomState {
   roomId: string;
-  players: { name: string; ready: boolean }[];
+  players: { name: string; ready: boolean; isBot?: boolean }[];
   maxPlayers: 4;
 }
 
@@ -82,6 +82,7 @@ export interface ClientEvents {
   playerAction: (action: GameAction) => void;
   rejoinGame: (playerId: string) => void;
   nextRound: () => void;
+  addBot: () => void;
 }
 
 export interface ServerEvents {


### PR DESCRIPTION
Allow games with fewer than 4 humans by filling with bots:

Server:
1. Room: addBot() to add bot player with isBot flag and generated name
2. Room: allow startGame when humans + bots = 4
3. Add addBot socket event
4. GameEngine: on bot turn, call decideBotAction with small delay and execute
5. GameEngine: bots auto-respond to action windows
6. Bot players have no socketId, skip socket emissions for them

Frontend:
7. Room page: Add Bot button to fill empty seats
8. Show bot indicator next to bot player names
9. Allow starting game with any mix of humans and bots totaling 4

Closes #63