### PR TITLE
Polish UI bot indicators and game over screen

### DIFF
--- a/apps/server/src/gameState.ts
+++ b/apps/server/src/gameState.ts
@@ -103,6 +103,7 @@ export class ServerGameState {
       const p = state.players[idx];
       otherPlayers.push({
         name: this.playerNames[idx] ?? "",
+        isBot: this.botIndices.has(idx),
         flowers: p.flowers,
         melds: p.melds,
         handCount: p.hand.length,

--- a/apps/web/src/components/GameTable.tsx
+++ b/apps/web/src/components/GameTable.tsx
@@ -10,7 +10,13 @@ interface GameTableProps {
 
 export function GameTable({ state, onTileSelect, selectedTileId }: GameTableProps) {
   const { myHand, myFlowers, myMelds, myDiscards, myName, otherPlayers, currentTurn, myIndex, gold, dealerIndex, lianZhuangCount, wallRemaining } = state;
-  const labels = [myName || "我", otherPlayers[0]?.name || "右", otherPlayers[1]?.name || "上", otherPlayers[2]?.name || "左"];
+  const botLabel = (name: string, isBot?: boolean) => isBot ? `${name} 🤖` : name;
+  const labels = [
+    myName || "我",
+    botLabel(otherPlayers[0]?.name || "右", otherPlayers[0]?.isBot),
+    botLabel(otherPlayers[1]?.name || "上", otherPlayers[1]?.isBot),
+    botLabel(otherPlayers[2]?.name || "左", otherPlayers[2]?.isBot),
+  ];
 
   return (
     <div style={{

--- a/apps/web/src/pages/Game.tsx
+++ b/apps/web/src/pages/Game.tsx
@@ -51,14 +51,38 @@ export function Game() {
       setSelectedTileId(null);
     };
 
+    const winTypeNames: Record<string, string> = {
+      normal: "普通胡", tianHu: "天胡 30x", grabGold: "抢金 30x",
+      pingHu0: "平胡(无花) 30x", pingHu1: "平胡(一花) 15x",
+      threeGoldDown: "三金倒 40x", goldSparrow: "金雀 60x", goldDragon: "金龙 120x",
+      duiDuiHu: "对对胡", qingYiSe: "清一色", draw: "流局",
+    };
+
+    const getPlayerName = (idx: number) => {
+      if (!gameState) return `玩家${idx}`;
+      if (idx === gameState.myIndex) return gameState.myName || "我";
+      const other = gameState.otherPlayers.find((_, i) => (gameState.myIndex + i + 1) % 4 === idx);
+      return other?.name || `玩家${idx}`;
+    };
+
     return (
       <div style={{ textAlign: "center", padding: 40 }}>
-        <h2>{gameOver.winnerId !== null ? `玩家 ${gameOver.winnerId} 胡了!` : "流局 / Draw"}</h2>
-        <p>胡法: {gameOver.winType}</p>
-        <p>分数: {gameOver.scores.join(", ")}</p>
+        <h2 style={{ fontSize: 28, marginBottom: 16 }}>
+          {gameOver.winnerId !== null ? `🎉 ${getPlayerName(gameOver.winnerId)} 胡了!` : "流局 / Draw"}
+        </h2>
+        <p style={{ fontSize: 18, color: "#ffd700", marginBottom: 12 }}>
+          {winTypeNames[gameOver.winType] || gameOver.winType}
+        </p>
+        <div style={{ marginBottom: 20 }}>
+          {gameOver.scores.map((score, i) => (
+            <p key={i} style={{ color: score > 0 ? "#4caf50" : score < 0 ? "#f44336" : "#aaa" }}>
+              {getPlayerName(i)}: {score > 0 ? "+" : ""}{score}
+            </p>
+          ))}
+        </div>
         <button
           onClick={handleNextRound}
-          style={{ marginTop: 20, padding: "12px 32px", fontSize: 18, background: "#0f3460", color: "#eee", border: "none", borderRadius: 6, cursor: "pointer" }}
+          style={{ padding: "12px 32px", fontSize: 18, background: "#0f3460", color: "#eee", border: "none", borderRadius: 6, cursor: "pointer" }}
         >
           下一局 / Next Round
         </button>

--- a/apps/web/src/pages/Lobby.tsx
+++ b/apps/web/src/pages/Lobby.tsx
@@ -66,6 +66,9 @@ export function Lobby({ onJoined }: LobbyProps) {
         >
           创建房间 / Create Room
         </button>
+        <p style={{ color: "#888", fontSize: 13, marginTop: 8, textAlign: "center" }}>
+          一个人也能玩！创建房间后可添加机器人凑满 4 人
+        </p>
       </div>
 
       <hr />

--- a/apps/web/src/pages/Room.tsx
+++ b/apps/web/src/pages/Room.tsx
@@ -62,7 +62,7 @@ export function Room({ initialRoomState, onGameStarted }: RoomProps) {
         ))}
         {Array.from({ length: 4 - room.players.length }).map((_, i) => (
           <li key={`empty-${i}`} style={{ padding: 8, borderBottom: "1px solid #eee", color: "#ccc" }}>
-            等待加入...
+            空位 — 等待玩家或添加机器人
           </li>
         ))}
       </ul>

--- a/packages/shared/src/types/events.ts
+++ b/packages/shared/src/types/events.ts
@@ -15,6 +15,7 @@ export interface RoomState {
 
 export interface OtherPlayerView {
   name: string;
+  isBot?: boolean;
   flowers: TileInstance[];
   melds: Meld[];
   handCount: number;


### PR DESCRIPTION
UI polish items:

1. Add isBot flag to OtherPlayerView in events.ts and pass from gameState.ts
2. Show bot emoji in PlayerArea label during game (not just in room)
3. Improve game over screen: show winner name, Chinese win type names, formatted scores
4. Room empty slots: change text from just waiting to hint about adding bots
5. Lobby: add hint text that bots are available for solo play

Closes #71