### PR TITLE
Fix flower replacement loop during gameplay draw

### DIFF
--- a/apps/server/src/gameEngine.ts
+++ b/apps/server/src/gameEngine.ts
@@ -249,20 +249,19 @@ function handleDraw(
     return;
   }
 
-  const tile = state.wall.shift()!;
+  let tile = state.wall.shift()!;
   const player = state.players[playerIndex];
 
-  // If flower, add to flowers and draw again
-  if (!isSuitedTile(tile.tile)) {
+  // If flower, keep drawing replacements from tail until a suited tile is found
+  while (!isSuitedTile(tile.tile)) {
     player.flowers.push(tile);
-    // Draw replacement from tail
-    if (state.wallTail.length > 0) {
-      const replacement = state.wallTail.pop()!;
-      player.hand.push(replacement);
+    if (state.wallTail.length === 0) {
+      endGameDraw(io, game);
+      return;
     }
-  } else {
-    player.hand.push(tile);
+    tile = state.wallTail.pop()!;
   }
+  player.hand.push(tile);
 
   state.lastDiscard = null;
 


### PR DESCRIPTION
When a player draws a flower tile during gameplay, handleDraw replaces it from wallTail but does not loop if the replacement is also a flower. This can leave flower tiles in a players hand.

Fix: add a while loop in handleDraw that keeps replacing until a suited tile is drawn (same logic as gangDraw which already handles this correctly).

Closes #81