### PR TITLE
Improve action visibility and discard highlight UX

### DIFF
--- a/apps/web/src/animations.css
+++ b/apps/web/src/animations.css
@@ -92,3 +92,23 @@
 .current-turn {
   animation: turnGlow 1.5s ease-in-out infinite;
 }
+
+/* Claim action alert */
+@keyframes claimPulse {
+  0%, 100% { border-color: rgba(255, 165, 0, 0.4); background: rgba(255, 140, 0, 0.1); }
+  50% { border-color: rgba(255, 165, 0, 1); background: rgba(255, 140, 0, 0.25); }
+}
+
+.claim-alert {
+  animation: claimPulse 1s ease-in-out infinite;
+}
+
+/* Last discard highlight */
+@keyframes discardHighlight {
+  0%, 100% { box-shadow: 0 0 8px rgba(255, 165, 0, 0.4); }
+  50% { box-shadow: 0 0 16px rgba(255, 165, 0, 0.8); }
+}
+
+.last-discard {
+  animation: discardHighlight 1.2s ease-in-out infinite;
+}

--- a/apps/web/src/components/ActionBar.tsx
+++ b/apps/web/src/components/ActionBar.tsx
@@ -47,18 +47,27 @@ export function ActionBar({ actions, selectedTileId, gameState, onAction }: Acti
     ? gameState.myHand.find((t) => t.id === selectedTileId) ?? null
     : null;
 
+  const hasClaimAction = actions.canHu || actions.canPeng || actions.canMingGang || actions.chiOptions.length > 0;
+  const isClaimWindow = hasClaimAction && !actions.canDiscard;
+
   return (
     <div style={{
       display: "flex",
       flexWrap: "wrap",
       justifyContent: "center",
       alignItems: "center",
-      gap: 4,
-      padding: 12,
-      background: "rgba(0,0,0,0.5)",
+      gap: 8,
+      padding: isClaimWindow ? 16 : 12,
+      background: isClaimWindow ? "rgba(255,140,0,0.2)" : "rgba(0,0,0,0.5)",
+      border: isClaimWindow ? "2px solid #ffa500" : "none",
       borderRadius: 8,
       marginTop: 8,
     }}>
+      {isClaimWindow && (
+        <div style={{ width: "100%", textAlign: "center", color: "#ffa500", fontWeight: "bold", fontSize: 14, marginBottom: 4 }}>
+          可以操作！请选择 👇
+        </div>
+      )}
       {actions.canDraw && (
         <button
           style={{ ...BTN.base, ...BTN.draw }}

--- a/apps/web/src/components/GameInfo.tsx
+++ b/apps/web/src/components/GameInfo.tsx
@@ -1,4 +1,4 @@
-import type { GoldState } from "@fuzhou-mahjong/shared";
+import type { GoldState, TileInstance } from "@fuzhou-mahjong/shared";
 import { TileView } from "./Tile";
 
 interface GameInfoProps {
@@ -7,12 +7,15 @@ interface GameInfoProps {
   dealerIndex: number;
   lianZhuangCount: number;
   myIndex: number;
+  lastDiscard: { tile: TileInstance; playerIndex: number } | null;
+  playerNames: string[];
 }
 
-const POSITION_LABELS = ["下 (我)", "右", "上", "左"];
-
-export function GameInfo({ gold, wallRemaining, dealerIndex, lianZhuangCount, myIndex }: GameInfoProps) {
-  const dealerLabel = POSITION_LABELS[(dealerIndex - myIndex + 4) % 4];
+export function GameInfo({ gold, wallRemaining, dealerIndex, lianZhuangCount, myIndex, lastDiscard, playerNames }: GameInfoProps) {
+  const posLabel = (idx: number) => {
+    const rel = (idx - myIndex + 4) % 4;
+    return rel === 0 ? "我" : (playerNames[rel] || ["我", "右", "上", "左"][rel]);
+  };
 
   return (
     <div style={{
@@ -22,11 +25,27 @@ export function GameInfo({ gold, wallRemaining, dealerIndex, lianZhuangCount, my
       borderRadius: 8,
     }}>
       <div style={{ marginBottom: 8 }}>
-        <span style={{ color: "#aaa", fontSize: 12 }}>金牌 / Gold: </span>
+        <span style={{ color: "#aaa", fontSize: 12 }}>金牌: </span>
         {gold && <TileView tile={gold.indicatorTile} faceUp gold={null} small />}
       </div>
+
+      {lastDiscard && (
+        <div style={{
+          marginBottom: 8,
+          padding: 8,
+          background: "rgba(255,165,0,0.15)",
+          borderRadius: 6,
+          border: "1px solid rgba(255,165,0,0.4)",
+        }}>
+          <div style={{ fontSize: 11, color: "#ffa500", marginBottom: 4 }}>
+            {posLabel(lastDiscard.playerIndex)} 打出:
+          </div>
+          <TileView tile={lastDiscard.tile} faceUp gold={gold} />
+        </div>
+      )}
+
       <div style={{ fontSize: 12, color: "#aaa" }}>
-        剩余: {wallRemaining} | 庄: {dealerLabel} | 连庄: {lianZhuangCount}
+        剩余: {wallRemaining} | 庄: {posLabel(dealerIndex)} | 连庄: {lianZhuangCount}
       </div>
     </div>
   );

--- a/apps/web/src/components/GameTable.tsx
+++ b/apps/web/src/components/GameTable.tsx
@@ -70,6 +70,8 @@ export function GameTable({ state, onTileSelect, selectedTileId }: GameTableProp
           dealerIndex={dealerIndex}
           lianZhuangCount={lianZhuangCount}
           myIndex={myIndex}
+          lastDiscard={state.lastDiscard}
+          playerNames={[myName || "我", ...otherPlayers.map(p => p.name || "")]}
         />
       </div>
 


### PR DESCRIPTION
UX issues with action visibility:

1. Last discarded tile not highlighted on the table - player cant see what was just played
2. No prominent alert when chi/peng/gang/hu is available - easy to miss
3. Action bar needs stronger visual distinction when claim actions appear
4. GameInfo should show the last discarded tile prominently
5. Add auto-dismiss timer showing remaining time to respond

Closes #85