### PR TITLE
Add screen flash and hand highlight for claim actions

### DIFF
--- a/apps/web/src/animations.css
+++ b/apps/web/src/animations.css
@@ -122,3 +122,48 @@
 .last-discard {
   animation: discardHighlight 1.2s ease-in-out infinite;
 }
+
+/* Screen flash overlay for claim opportunities */
+@keyframes screenFlash {
+  0% { opacity: 0.6; }
+  100% { opacity: 0; }
+}
+
+.screen-flash {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: radial-gradient(ellipse at center, rgba(255,165,0,0.3) 0%, transparent 70%);
+  pointer-events: none;
+  z-index: 50;
+  animation: screenFlash 1.2s ease-out forwards;
+}
+
+/* Screen border flash */
+@keyframes borderFlash {
+  0% { box-shadow: inset 0 0 60px rgba(255,165,0,0.6); }
+  100% { box-shadow: inset 0 0 0 transparent; }
+}
+
+.border-flash {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  pointer-events: none;
+  z-index: 49;
+  animation: borderFlash 1.5s ease-out forwards;
+}
+
+/* Highlight tiles that can be used in claim */
+@keyframes tileHighlight {
+  0%, 100% { box-shadow: 0 0 6px rgba(0,255,136,0.4); }
+  50% { box-shadow: 0 0 14px rgba(0,255,136,0.9); }
+}
+
+.tile-claimable {
+  animation: tileHighlight 0.8s ease-in-out infinite;
+}

--- a/apps/web/src/components/ActionBar.tsx
+++ b/apps/web/src/components/ActionBar.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import { ActionType } from "@fuzhou-mahjong/shared";
 import type { AvailableActions, ClientGameState, GameAction, TileInstance } from "@fuzhou-mahjong/shared";
 import { TileView } from "./Tile";
@@ -23,6 +23,7 @@ const BTN = {
 
 export function ActionBar({ actions, selectedTileId, gameState, onAction }: ActionBarProps) {
   const [showChiPicker, setShowChiPicker] = useState(false);
+  const barRef = useRef<HTMLDivElement>(null);
   const myIndex = gameState.myIndex;
 
   if (!actions) {
@@ -50,8 +51,14 @@ export function ActionBar({ actions, selectedTileId, gameState, onAction }: Acti
   const hasClaimAction = actions.canHu || actions.canPeng || actions.canMingGang || actions.chiOptions.length > 0;
   const isClaimWindow = hasClaimAction && !actions.canDiscard;
 
+  useEffect(() => {
+    if (isClaimWindow && barRef.current) {
+      barRef.current.scrollIntoView({ behavior: "smooth", block: "nearest" });
+    }
+  }, [isClaimWindow]);
+
   return (
-    <div style={{
+    <div ref={barRef} style={{
       display: "flex",
       flexWrap: "wrap",
       justifyContent: "center",

--- a/apps/web/src/components/GameTable.tsx
+++ b/apps/web/src/components/GameTable.tsx
@@ -6,9 +6,10 @@ interface GameTableProps {
   state: ClientGameState;
   onTileSelect: (tile: TileInstance | null) => void;
   selectedTileId: number | null;
+  claimableTileIds?: Set<number>;
 }
 
-export function GameTable({ state, onTileSelect, selectedTileId }: GameTableProps) {
+export function GameTable({ state, onTileSelect, selectedTileId, claimableTileIds }: GameTableProps) {
   const { myHand, myFlowers, myMelds, myDiscards, myName, otherPlayers, currentTurn, myIndex, gold, dealerIndex, lianZhuangCount, wallRemaining } = state;
   const botLabel = (name: string, isBot?: boolean) => isBot ? `${name} 🤖` : name;
   const labels = [
@@ -104,6 +105,7 @@ export function GameTable({ state, onTileSelect, selectedTileId }: GameTableProp
           selectedTileId={selectedTileId}
           onTileClick={(t) => onTileSelect(selectedTileId === t.id ? null : t)}
           label={labels[0]}
+          claimableTileIds={claimableTileIds}
         />
       </div>
     </div>

--- a/apps/web/src/components/PlayerArea.tsx
+++ b/apps/web/src/components/PlayerArea.tsx
@@ -15,11 +15,13 @@ interface PlayerAreaProps {
   selectedTileId?: number | null;
   onTileClick?: (tile: TileInstance) => void;
   label: string;
+  claimableTileIds?: Set<number>;
 }
 
 export function PlayerArea({
   isMe, hand, handCount, melds, flowers, discards,
   isCurrentTurn, isDealer, gold, selectedTileId, onTileClick, label,
+  claimableTileIds,
 }: PlayerAreaProps) {
   return (
     <div
@@ -45,6 +47,7 @@ export function PlayerArea({
               faceUp
               gold={gold}
               selected={selectedTileId === t.id}
+              claimable={claimableTileIds?.has(t.id)}
               onClick={() => onTileClick?.(t)}
             />
           ))

--- a/apps/web/src/components/Tile.tsx
+++ b/apps/web/src/components/Tile.tsx
@@ -5,6 +5,7 @@ interface TileProps {
   tile: TileInstance;
   faceUp?: boolean;
   selected?: boolean;
+  claimable?: boolean;
   onClick?: () => void;
   gold?: GoldState | null;
   small?: boolean;
@@ -36,7 +37,7 @@ function getTileText(tile: Tile): { text: string; color: string } {
   }
 }
 
-export function TileView({ tile, faceUp = true, selected, onClick, gold, small }: TileProps) {
+export function TileView({ tile, faceUp = true, selected, claimable, onClick, gold, small }: TileProps) {
   const size = small ? { width: 28, height: 38, fontSize: 11 } : { width: 40, height: 56, fontSize: 15 };
   const isGold = gold && isSuitedTile(tile.tile) && isGoldTile(tile, gold);
 
@@ -57,11 +58,12 @@ export function TileView({ tile, faceUp = true, selected, onClick, gold, small }
 
   return (
     <div
+      className={claimable ? "tile-claimable" : undefined}
       onClick={onClick}
       style={{
         ...size,
-        background: selected ? "#ffe4b5" : "#f5f0e0",
-        border: isGold ? "2px solid #ffd700" : "1px solid #999",
+        background: selected ? "#ffe4b5" : claimable ? "#e0ffe8" : "#f5f0e0",
+        border: isGold ? "2px solid #ffd700" : claimable ? "2px solid #00ff88" : "1px solid #999",
         borderRadius: 3,
         display: "inline-flex",
         alignItems: "center",

--- a/apps/web/src/pages/Game.tsx
+++ b/apps/web/src/pages/Game.tsx
@@ -14,6 +14,7 @@ export function Game({ initialGameState, onLeave }: GameProps) {
   const [selectedTileId, setSelectedTileId] = useState<number | null>(null);
   const [gameOver, setGameOver] = useState<GameOverResult | null>(null);
   const [actions, setActions] = useState<AvailableActions | null>(null);
+  const [showFlash, setShowFlash] = useState(false);
 
   useEffect(() => {
     // gameStarted is handled by App.tsx (passed as initialGameState prop)
@@ -29,6 +30,12 @@ export function Game({ initialGameState, onLeave }: GameProps) {
     });
     socket.on("actionRequired", (availableActions) => {
       setActions(availableActions);
+      // Flash screen when claim actions available (chi/peng/gang/hu)
+      const hasClaim = availableActions.canHu || availableActions.canPeng || availableActions.canMingGang || (availableActions.chiOptions?.length > 0);
+      if (hasClaim && !availableActions.canDiscard) {
+        setShowFlash(true);
+        setTimeout(() => setShowFlash(false), 1500);
+      }
     });
     socket.on("gameOver", (result) => setGameOver(result));
 
@@ -38,6 +45,25 @@ export function Game({ initialGameState, onLeave }: GameProps) {
       socket.off("gameOver");
     };
   }, []);
+
+  const getClaimableTileIds = (a: AvailableActions | null): Set<number> => {
+    const ids = new Set<number>();
+    if (!a) return ids;
+    // Chi tiles
+    for (const combo of a.chiOptions ?? []) {
+      for (const t of combo) ids.add(t.id);
+    }
+    // Peng: tiles matching lastDiscard
+    if (a.canPeng && gameState?.lastDiscard && gameState.myHand) {
+      const d = gameState.lastDiscard.tile.tile;
+      if (d.kind === "suited") {
+        for (const t of gameState.myHand) {
+          if (t.tile.kind === "suited" && t.tile.suit === d.suit && t.tile.value === d.value) ids.add(t.id);
+        }
+      }
+    }
+    return ids;
+  };
 
   const handleAction = (action: GameAction) => {
     socket.emit("playerAction", action);
@@ -134,10 +160,17 @@ export function Game({ initialGameState, onLeave }: GameProps) {
 
   return (
     <div>
+      {showFlash && (
+        <>
+          <div className="screen-flash" />
+          <div className="border-flash" />
+        </>
+      )}
       <GameTable
         state={gameState}
         onTileSelect={(tile) => setSelectedTileId(tile?.id ?? null)}
         selectedTileId={selectedTileId}
+        claimableTileIds={getClaimableTileIds(actions)}
       />
       <ActionBar
         actions={actions}


### PR DESCRIPTION
Current claim prompts are too subtle. Players miss chi/peng/gang/hu opportunities.

Add:
1. Full-width orange flash overlay when claim actions available (fades after 1s)
2. Highlight hand tiles that can form chi/peng with the discarded tile
3. Make the claim ActionBar auto-scroll into view on mobile
4. Add a brief screen border flash animation

Closes #89