### PR TITLE
Fix event ordering - broadcast state before action prompts

### DIFF
--- a/apps/server/src/gameEngine.ts
+++ b/apps/server/src/gameEngine.ts
@@ -201,6 +201,9 @@ function handleDiscard(
     player.hasDiscardedGold = true;
   }
 
+  // Broadcast state before action prompts so clients have updated lastDiscard
+  broadcastState(io, game);
+
   // Check if anyone can act on this discard
   const pendingPlayers: number[] = [];
 
@@ -225,8 +228,6 @@ function handleDiscard(
     });
     activeWindows.set(game.roomId, window);
   }
-
-  broadcastState(io, game);
 }
 
 function handleDraw(


### PR DESCRIPTION
In handleDiscard, broadcastState is called AFTER emitOrBotAction. This means actionRequired reaches the client before gameStateUpdate, so lastDiscard is stale when the claim prompt appears. Player sees wrong tile in center panel.

Fix: move broadcastState before the action window loop so clients have updated state when they receive actionRequired.

Closes #91