### PR TITLE
Fix actions cleared by stale gameStateUpdate race

### DIFF
--- a/apps/web/src/pages/Game.tsx
+++ b/apps/web/src/pages/Game.tsx
@@ -20,13 +20,9 @@ export function Game({ initialGameState, onLeave }: GameProps) {
     // gameStarted is handled by App.tsx (passed as initialGameState prop)
     // Only listen for subsequent updates here
     socket.on("gameStateUpdate", (state) => {
-      setGameState((prev) => {
-        // Clear actions if turn changed
-        if (prev && prev.currentTurn !== state.currentTurn) {
-          setActions(null);
-        }
-        return state;
-      });
+      setGameState(state);
+      // Don't clear actions here — actionRequired is the authoritative source.
+      // Clearing on turn change races with actionRequired and causes buttons to vanish.
     });
     socket.on("actionRequired", (availableActions) => {
       setActions(availableActions);


### PR DESCRIPTION
Discard button never appears. Root cause: gameStateUpdate arrives just before actionRequired. The setActions(null) in gameStateUpdate callback (turn changed) races with setActions(actions) from actionRequired. React batches them and null wins.

Fix: do not clear actions on turn change. Only clear actions when the player sends an action (handleAction). The actionRequired event is the authoritative source.

Closes #97