### PR TITLE
Add long-press tile detail tooltip for mobile

### DIFF
--- a/apps/web/src/components/PlayerArea.tsx
+++ b/apps/web/src/components/PlayerArea.tsx
@@ -1,6 +1,7 @@
 import type { TileInstance, Meld, GoldState } from "@fuzhou-mahjong/shared";
 import { MeldType } from "@fuzhou-mahjong/shared";
 import { TileView } from "./Tile";
+import { useLongPress } from "./TileTooltip";
 
 interface PlayerAreaProps {
   isMe: boolean;
@@ -26,7 +27,11 @@ export function PlayerArea({
   isCurrentTurn, isDealer, gold, selectedTileId, onTileClick, label,
   claimableTileIds, onTileDoubleClick, lastDrawnTileId, tenpaiTiles,
 }: PlayerAreaProps) {
+  const { onTouchStart, onTouchEnd, onMouseEnter, onMouseLeave, Tooltip } = useLongPress(gold);
+
   return (
+    <>
+    <Tooltip />
     <div
       className={isCurrentTurn ? "current-turn" : ""}
       style={{
@@ -73,6 +78,10 @@ export function PlayerArea({
                 selected={selectedTileId === t.id}
                 claimable={claimableTileIds?.has(t.id)}
                 className={lastDrawnTileId === t.id ? "tile-new" : undefined}
+                onTouchStart={(e) => onTouchStart(t, e)}
+                onTouchEnd={onTouchEnd}
+                onMouseEnter={(e) => onMouseEnter(t, e)}
+                onMouseLeave={onMouseLeave}
                 onClick={() => onTileClick?.(t)}
                 onDoubleClick={() => onTileDoubleClick?.(t)}
               />
@@ -137,5 +146,6 @@ export function PlayerArea({
         </div>
       )}
     </div>
+    </>
   );
 }

--- a/apps/web/src/components/Tile.tsx
+++ b/apps/web/src/components/Tile.tsx
@@ -11,6 +11,10 @@ interface TileProps {
   gold?: GoldState | null;
   small?: boolean;
   className?: string;
+  onTouchStart?: (e: React.TouchEvent) => void;
+  onTouchEnd?: () => void;
+  onMouseEnter?: (e: React.MouseEvent) => void;
+  onMouseLeave?: () => void;
 }
 
 const SUIT_CHARS: Record<string, string> = { wan: "万", bing: "饼", tiao: "条" };
@@ -39,7 +43,7 @@ function getTileText(tile: Tile): { text: string; color: string } {
   }
 }
 
-export function TileView({ tile, faceUp = true, selected, claimable, onClick, onDoubleClick, gold, small, className }: TileProps) {
+export function TileView({ tile, faceUp = true, selected, claimable, onClick, onDoubleClick, gold, small, className, onTouchStart, onTouchEnd, onMouseEnter, onMouseLeave }: TileProps) {
   const size = small ? { width: 28, height: 38, fontSize: 11 } : { width: 40, height: 56, fontSize: 15 };
   const isGold = gold && isSuitedTile(tile.tile) && isGoldTile(tile, gold);
 
@@ -63,6 +67,10 @@ export function TileView({ tile, faceUp = true, selected, claimable, onClick, on
       className={className || (claimable ? "tile-claimable" : undefined)}
       onClick={onClick}
       onDoubleClick={onDoubleClick}
+      onTouchStart={onTouchStart}
+      onTouchEnd={onTouchEnd}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
       style={{
         ...size,
         background: selected ? "#ffe4b5" : claimable ? "#e0ffe8" : "#f5f0e0",

--- a/apps/web/src/components/TileTooltip.tsx
+++ b/apps/web/src/components/TileTooltip.tsx
@@ -1,0 +1,87 @@
+import { useCallback, useRef, useState } from "react";
+import type { TileInstance, GoldState, Tile } from "@fuzhou-mahjong/shared";
+import { isSuitedTile, isGoldTile } from "@fuzhou-mahjong/shared";
+
+const SUIT_NAMES: Record<string, string> = { wan: "万", bing: "饼", tiao: "条" };
+const VALUE_NAMES = ["", "一", "二", "三", "四", "五", "六", "七", "八", "九"];
+const WIND_NAMES: Record<string, string> = { east: "东风", south: "南风", west: "西风", north: "北风" };
+const DRAGON_NAMES: Record<string, string> = { red: "红中", green: "发财", white: "白板" };
+const SEASON_NAMES: Record<string, string> = { spring: "春", summer: "夏", autumn: "秋", winter: "冬" };
+const PLANT_NAMES: Record<string, string> = { plum: "梅", orchid: "兰", bamboo: "竹", chrysanthemum: "菊" };
+
+export function getTileName(tile: Tile): string {
+  if (isSuitedTile(tile)) {
+    return `${VALUE_NAMES[tile.value]}${SUIT_NAMES[tile.suit]}`;
+  }
+  switch (tile.kind) {
+    case "wind": return WIND_NAMES[tile.windType] ?? "";
+    case "dragon": return DRAGON_NAMES[tile.dragonType] ?? "";
+    case "season": return SEASON_NAMES[tile.seasonType] ?? "";
+    case "plant": return PLANT_NAMES[tile.plantType] ?? "";
+  }
+}
+
+interface TooltipState {
+  visible: boolean;
+  tile: TileInstance | null;
+  x: number;
+  y: number;
+}
+
+export function useLongPress(gold: GoldState | null) {
+  const [tooltip, setTooltip] = useState<TooltipState>({ visible: false, tile: null, x: 0, y: 0 });
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const onTouchStart = useCallback((tile: TileInstance, e: React.TouchEvent) => {
+    const touch = e.touches[0];
+    timerRef.current = setTimeout(() => {
+      setTooltip({ visible: true, tile, x: touch.clientX, y: touch.clientY });
+    }, 500);
+  }, []);
+
+  const onTouchEnd = useCallback(() => {
+    if (timerRef.current) { clearTimeout(timerRef.current); timerRef.current = null; }
+    setTooltip((t) => t.visible ? { ...t, visible: false } : t);
+  }, []);
+
+  const onMouseEnter = useCallback((tile: TileInstance, e: React.MouseEvent) => {
+    // Desktop: show on hover after short delay
+    timerRef.current = setTimeout(() => {
+      setTooltip({ visible: true, tile, x: e.clientX, y: e.clientY });
+    }, 800);
+  }, []);
+
+  const onMouseLeave = useCallback(() => {
+    if (timerRef.current) { clearTimeout(timerRef.current); timerRef.current = null; }
+    setTooltip((t) => t.visible ? { ...t, visible: false } : t);
+  }, []);
+
+  const Tooltip = () => {
+    if (!tooltip.visible || !tooltip.tile) return null;
+    const tile = tooltip.tile;
+    const name = getTileName(tile.tile);
+    const isGold = gold && isSuitedTile(tile.tile) && isGoldTile(tile, gold);
+
+    return (
+      <div style={{
+        position: "fixed",
+        left: Math.min(tooltip.x - 40, window.innerWidth - 120),
+        top: Math.max(tooltip.y - 100, 10),
+        background: "#1a1a2e",
+        border: isGold ? "2px solid #ffd700" : "1px solid #555",
+        borderRadius: 8,
+        padding: 12,
+        zIndex: 200,
+        textAlign: "center",
+        boxShadow: "0 4px 20px rgba(0,0,0,0.5)",
+        pointerEvents: "none",
+      }}>
+        <div style={{ fontSize: 28, marginBottom: 4 }}>{name}</div>
+        {isGold && <div style={{ fontSize: 12, color: "#ffd700" }}>金牌 (百搭)</div>}
+        {!isSuitedTile(tile.tile) && <div style={{ fontSize: 12, color: "#888" }}>花牌</div>}
+      </div>
+    );
+  };
+
+  return { onTouchStart, onTouchEnd, onMouseEnter, onMouseLeave, Tooltip };
+}


### PR DESCRIPTION
On mobile, add long-press (500ms) gesture on any tile to show a tooltip with:
1. Tile name in Chinese (e.g. 三万, 七饼)
2. Larger preview of the tile
3. If gold tile, show gold indicator
4. For flower tiles, show flower type name
5. Dismiss on release or tap elsewhere
6. Works on both hand tiles and table tiles

Closes #109