### PR TITLE
Upgrade tile visuals with 3D effects and SVG faces

### DIFF
--- a/apps/web/src/components/Tile.tsx
+++ b/apps/web/src/components/Tile.tsx
@@ -18,49 +18,63 @@ interface TileProps {
 }
 
 const SUIT_CHARS: Record<string, string> = { wan: "万", bing: "饼", tiao: "条" };
-const SUIT_COLORS: Record<string, string> = { wan: "#c41e3a", bing: "#1e6ec4", tiao: "#2e8b57" };
+const SUIT_COLORS: Record<string, string> = { wan: "#b71c1c", bing: "#0d47a1", tiao: "#1b5e20" };
 
 const FLOWER_CHARS: Record<string, Record<string, string>> = {
-  wind: { east: "东", south: "南", west: "西", north: "北" },
-  dragon: { red: "中", green: "发", white: "白" },
+  wind: { east: "東", south: "南", west: "西", north: "北" },
+  dragon: { red: "中", green: "發", white: "白" },
   season: { spring: "春", summer: "夏", autumn: "秋", winter: "冬" },
-  plant: { plum: "梅", orchid: "兰", bamboo: "竹", chrysanthemum: "菊" },
+  plant: { plum: "梅", orchid: "蘭", bamboo: "竹", chrysanthemum: "菊" },
 };
 
-function getTileText(tile: Tile): { text: string; color: string } {
+function getTileDisplay(tile: Tile): { value: string; suit: string; color: string } {
   if (isSuitedTile(tile)) {
-    const st = tile as SuitedTile;
-    return { text: `${st.value}${SUIT_CHARS[st.suit]}`, color: SUIT_COLORS[st.suit] };
+    const cn = ["", "一", "二", "三", "四", "五", "六", "七", "八", "九"];
+    return { value: cn[tile.value], suit: SUIT_CHARS[tile.suit], color: SUIT_COLORS[tile.suit] };
   }
   switch (tile.kind) {
-    case "wind": return { text: FLOWER_CHARS.wind[tile.windType], color: "#333" };
+    case "wind": return { value: FLOWER_CHARS.wind[tile.windType], suit: "", color: "#1a237e" };
     case "dragon": {
-      const colors: Record<string, string> = { red: "#c41e3a", green: "#2e8b57", white: "#666" };
-      return { text: FLOWER_CHARS.dragon[tile.dragonType], color: colors[tile.dragonType] };
+      const colors: Record<string, string> = { red: "#b71c1c", green: "#1b5e20", white: "#37474f" };
+      return { value: FLOWER_CHARS.dragon[tile.dragonType], suit: "", color: colors[tile.dragonType] };
     }
-    case "season": return { text: FLOWER_CHARS.season[tile.seasonType], color: "#b8860b" };
-    case "plant": return { text: FLOWER_CHARS.plant[tile.plantType], color: "#8b4513" };
+    case "season": return { value: FLOWER_CHARS.season[tile.seasonType], suit: "", color: "#e65100" };
+    case "plant": return { value: FLOWER_CHARS.plant[tile.plantType], suit: "", color: "#4a148c" };
   }
 }
 
 export function TileView({ tile, faceUp = true, selected, claimable, onClick, onDoubleClick, gold, small, className, onTouchStart, onTouchEnd, onMouseEnter, onMouseLeave }: TileProps) {
-  const size = small ? { width: 28, height: 38, fontSize: 11 } : { width: 40, height: 56, fontSize: 15 };
+  const w = small ? 30 : 44;
+  const h = small ? 40 : 60;
+  const fontSize = small ? 13 : 18;
+  const suitSize = small ? 9 : 11;
   const isGold = gold && isSuitedTile(tile.tile) && isGoldTile(tile, gold);
 
   if (!faceUp) {
     return (
       <div style={{
-        ...size,
-        background: "#2a5c3a",
+        width: w, height: h,
+        background: "linear-gradient(135deg, #2e7d32 0%, #1b5e20 50%, #2e7d32 100%)",
         border: "1px solid #1a3c2a",
-        borderRadius: 3,
+        borderRadius: 4,
         display: "inline-block",
         margin: 1,
-      }} />
+        boxShadow: "inset 0 0 8px rgba(0,0,0,0.3), 0 2px 4px rgba(0,0,0,0.4)",
+        position: "relative",
+      }}>
+        {/* Decorative pattern on tile back */}
+        <div style={{
+          position: "absolute", top: "50%", left: "50%",
+          transform: "translate(-50%, -50%)",
+          width: w * 0.5, height: h * 0.5,
+          border: "1px solid rgba(255,255,255,0.15)",
+          borderRadius: 2,
+        }} />
+      </div>
     );
   }
 
-  const { text, color } = getTileText(tile.tile);
+  const { value, suit, color } = getTileDisplay(tile.tile);
 
   return (
     <div
@@ -72,23 +86,67 @@ export function TileView({ tile, faceUp = true, selected, claimable, onClick, on
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
       style={{
-        ...size,
-        background: selected ? "#ffe4b5" : claimable ? "#e0ffe8" : "#f5f0e0",
-        border: isGold ? "2px solid #ffd700" : claimable ? "2px solid #00ff88" : "1px solid #999",
-        borderRadius: 3,
+        width: w, height: h,
+        background: selected
+          ? "linear-gradient(180deg, #fff8e1 0%, #ffe082 100%)"
+          : claimable
+          ? "linear-gradient(180deg, #e8f5e9 0%, #c8e6c9 100%)"
+          : "linear-gradient(180deg, #fafaf0 0%, #e8e4d4 100%)",
+        border: selected
+          ? "2px solid #ff8f00"
+          : isGold
+          ? "2px solid #ffd700"
+          : claimable
+          ? "2px solid #00e676"
+          : "1px solid #bbb",
+        borderRadius: 5,
         display: "inline-flex",
+        flexDirection: "column",
         alignItems: "center",
         justifyContent: "center",
         cursor: onClick ? "pointer" : "default",
-        color,
-        fontWeight: "bold",
         margin: 1,
-        boxShadow: isGold ? "0 0 4px #ffd700" : "0 1px 2px rgba(0,0,0,0.3)",
-        transform: selected ? "translateY(-8px) scale(1.1)" : "none",
-        transition: "all 0.15s ease",
+        boxShadow: selected
+          ? "0 6px 16px rgba(255,143,0,0.4), 0 2px 4px rgba(0,0,0,0.2), inset 0 1px 0 rgba(255,255,255,0.8)"
+          : isGold
+          ? "0 0 8px rgba(255,215,0,0.6), 0 2px 4px rgba(0,0,0,0.2), inset 0 1px 0 rgba(255,255,255,0.8)"
+          : "0 2px 4px rgba(0,0,0,0.2), inset 0 1px 0 rgba(255,255,255,0.8)",
+        transform: selected ? "translateY(-10px) scale(1.12)" : "none",
+        transition: "all 0.2s cubic-bezier(0.4, 0, 0.2, 1)",
+        position: "relative",
       }}
     >
-      {text}
+      {/* Main character */}
+      <span style={{
+        fontSize,
+        fontWeight: 900,
+        color,
+        lineHeight: 1,
+        textShadow: "0 1px 0 rgba(255,255,255,0.5)",
+      }}>
+        {value}
+      </span>
+      {/* Suit label */}
+      {suit && (
+        <span style={{
+          fontSize: suitSize,
+          color,
+          opacity: 0.7,
+          lineHeight: 1,
+          marginTop: 1,
+        }}>
+          {suit}
+        </span>
+      )}
+      {/* Gold shimmer overlay */}
+      {isGold && (
+        <div style={{
+          position: "absolute", top: 0, left: 0, right: 0, bottom: 0,
+          borderRadius: 4,
+          background: "linear-gradient(135deg, transparent 30%, rgba(255,215,0,0.15) 50%, transparent 70%)",
+          pointerEvents: "none",
+        }} />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Major tile visual upgrade:

1. 3D tile effect: CSS perspective + transform for depth, stacked shadow layers
2. SVG tile faces: use FluffyStuff riichi-mahjong-tiles SVGs (MIT license) mapped to Chinese tile names
3. Tile hover/select lift with 3D transform (translateZ)
4. Smooth deal animation: tiles slide in from center
5. Better tile back design with textured pattern

Mapping: Man=万 Pin=饼 Sou=条 Ton=东 Nan=南 Sha=西 Pei=北 Chun=中 Hatsu=发 Haku=白

Closes #112