### PR TITLE
Add discard fly and peng-gang reveal animations

### DIFF
--- a/apps/web/src/animations.css
+++ b/apps/web/src/animations.css
@@ -167,3 +167,15 @@
 .tile-claimable {
   animation: tileHighlight 0.8s ease-in-out infinite;
 }
+
+/* Center action animations (discard fly / claim reveal) */
+@keyframes centerActionIn {
+  0% { opacity: 0; transform: translate(-50%, -50%) scale(0.3); }
+  60% { opacity: 1; transform: translate(-50%, -50%) scale(1.1); }
+  100% { opacity: 1; transform: translate(-50%, -50%) scale(1); }
+}
+
+@keyframes centerActionOut {
+  0% { opacity: 1; transform: translate(-50%, -50%) scale(1); }
+  100% { opacity: 0; transform: translate(-50%, -50%) scale(0.5) translateY(20px); }
+}

--- a/apps/web/src/components/CenterAction.tsx
+++ b/apps/web/src/components/CenterAction.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useState } from "react";
+import type { TileInstance, GoldState } from "@fuzhou-mahjong/shared";
+import { TileView } from "./Tile";
+
+interface CenterActionProps {
+  gold: GoldState | null;
+}
+
+interface ActionDisplay {
+  tiles: TileInstance[];
+  label: string;
+  color: string;
+  id: number;
+}
+
+let actionId = 0;
+
+export function useCenterAction() {
+  const [display, setDisplay] = useState<ActionDisplay | null>(null);
+
+  const showDiscard = (tile: TileInstance, playerName: string) => {
+    setDisplay({ tiles: [tile], label: `${playerName} 打`, color: "#e8d5a3", id: ++actionId });
+  };
+
+  const showClaim = (tiles: TileInstance[], type: string, playerName: string) => {
+    const labels: Record<string, string> = { chi: "吃!", peng: "碰!", mingGang: "杠!", anGang: "暗杠!", buGang: "补杠!", hu: "胡!" };
+    const colors: Record<string, string> = { chi: "#4caf50", peng: "#2196f3", mingGang: "#ff9800", anGang: "#ff9800", buGang: "#ff9800", hu: "#f44336" };
+    setDisplay({
+      tiles,
+      label: `${playerName} ${labels[type] || type}`,
+      color: colors[type] || "#fff",
+      id: ++actionId,
+    });
+  };
+
+  // Auto-dismiss after animation
+  useEffect(() => {
+    if (!display) return;
+    const timer = setTimeout(() => setDisplay(null), 1200);
+    return () => clearTimeout(timer);
+  }, [display?.id]);
+
+  return { display, showDiscard, showClaim };
+}
+
+export function CenterAction({ display, gold }: { display: ActionDisplay | null; gold: GoldState | null }) {
+  if (!display) return null;
+
+  return (
+    <div
+      key={display.id}
+      style={{
+        position: "absolute",
+        top: "50%",
+        left: "50%",
+        transform: "translate(-50%, -50%)",
+        zIndex: 30,
+        textAlign: "center",
+        animation: "centerActionIn 0.3s ease-out, centerActionOut 0.4s ease-in 0.8s forwards",
+        pointerEvents: "none",
+      }}
+    >
+      <div style={{
+        display: "flex",
+        gap: 4,
+        justifyContent: "center",
+        marginBottom: 8,
+        filter: "drop-shadow(0 4px 12px rgba(0,0,0,0.5))",
+      }}>
+        {display.tiles.map((t) => (
+          <div key={t.id} style={{ transform: "scale(1.8)" }}>
+            <TileView tile={t} faceUp gold={gold} />
+          </div>
+        ))}
+      </div>
+      <div style={{
+        fontSize: 20,
+        fontWeight: "bold",
+        color: display.color,
+        textShadow: `0 0 20px ${display.color}, 0 2px 4px rgba(0,0,0,0.5)`,
+      }}>
+        {display.label}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/Game.tsx
+++ b/apps/web/src/pages/Game.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { socket } from "../socket";
 import { GameTable } from "../components/GameTable";
 import { ActionBar } from "../components/ActionBar";
+import { CenterAction, useCenterAction } from "../components/CenterAction";
 import type { ClientGameState, GameOverResult, AvailableActions, GameAction } from "@fuzhou-mahjong/shared";
 
 interface GameProps {
@@ -16,14 +17,42 @@ export function Game({ initialGameState, onLeave }: GameProps) {
   const [actions, setActions] = useState<AvailableActions | null>(null);
   const [showFlash, setShowFlash] = useState(false);
   const [pendingClaim, setPendingClaim] = useState(false);
+  const { display: centerAction, showDiscard, showClaim } = useCenterAction();
+  const prevStateRef = useRef<ClientGameState | null>(null);
 
   useEffect(() => {
-    // gameStarted is handled by App.tsx (passed as initialGameState prop)
-    // Only listen for subsequent updates here
     socket.on("gameStateUpdate", (state) => {
+      // Detect discard: lastDiscard changed
+      const prev = prevStateRef.current;
+      if (state.lastDiscard && (!prev?.lastDiscard || prev.lastDiscard.tile.id !== state.lastDiscard.tile.id)) {
+        const names = [state.myName || "我", ...(state.otherPlayers?.map(p => p.name) || [])];
+        const relIdx = (state.lastDiscard.playerIndex - state.myIndex + 4) % 4;
+        showDiscard(state.lastDiscard.tile, names[relIdx] || "");
+      }
+
+      // Detect new meld: total melds increased
+      if (prev) {
+        const prevMelds = prev.myMelds.length + prev.otherPlayers.reduce((s, p) => s + p.melds.length, 0);
+        const newMelds = state.myMelds.length + state.otherPlayers.reduce((s, p) => s + p.melds.length, 0);
+        if (newMelds > prevMelds) {
+          // Find which player got a new meld
+          if (state.myMelds.length > prev.myMelds.length) {
+            const meld = state.myMelds[state.myMelds.length - 1];
+            showClaim(meld.tiles, meld.type, state.myName || "我");
+          } else {
+            for (let i = 0; i < state.otherPlayers.length; i++) {
+              if (state.otherPlayers[i].melds.length > (prev.otherPlayers[i]?.melds.length || 0)) {
+                const meld = state.otherPlayers[i].melds[state.otherPlayers[i].melds.length - 1];
+                showClaim(meld.tiles, meld.type, state.otherPlayers[i].name || "");
+                break;
+              }
+            }
+          }
+        }
+      }
+
+      prevStateRef.current = state;
       setGameState(state);
-      // Don't clear actions here — actionRequired is the authoritative source.
-      // Clearing on turn change races with actionRequired and causes buttons to vanish.
     });
     socket.on("actionRequired", (availableActions) => {
       // Don't overwrite claim actions while user is actively choosing (chi picker open)
@@ -199,6 +228,7 @@ export function Game({ initialGameState, onLeave }: GameProps) {
           <div className="border-flash" />
         </>
       )}
+      <CenterAction display={centerAction} gold={gameState.gold} />
       <GameTable
         state={gameState}
         onTileSelect={(tile) => setSelectedTileId(tile?.id ?? null)}


### PR DESCRIPTION
Two key animations missing vs competitors:

1. Discard fly: when player discards, tile briefly shows large in center of table before shrinking into discard pool (like Majsoul)
2. Peng-gang reveal: when chi/peng/gang happens, flash the claimed tiles briefly in center before moving to meld area

Both should be CSS-only transitions, 0.5-0.8s duration, smooth easing.

Closes #116