### PR TITLE
Fix pendingClaim blocking all future actions

### DIFF
--- a/apps/web/src/pages/Game.tsx
+++ b/apps/web/src/pages/Game.tsx
@@ -85,6 +85,13 @@ export function Game({ initialGameState, onLeave }: GameProps) {
         }
       }
 
+      // Clear pendingClaim when the game state moves on (turn changed or lastDiscard cleared)
+      // so stale claim actions don't block future actionRequired events
+      if (prev && (state.currentTurn !== prev.currentTurn || (!state.lastDiscard && prev.lastDiscard))) {
+        setPendingClaim(false);
+        setActions(null);
+      }
+
       prevStateRef.current = state;
       setGameState(state);
     });


### PR DESCRIPTION
pendingClaim is set to true when claim actions appear but only cleared by handleAction. If the action window resolves without user input (timeout or another player claims), pendingClaim stays true forever and blocks all future actionRequired events including canDiscard.

Fix: also clear pendingClaim on gameStateUpdate when the game state moves on (turn changes or lastDiscard clears). The pendingClaim should only protect during active claim selection, not persist across turns.

Closes #120