### PR TITLE
Use SVG tile images from FluffyStuff for tile faces

### DIFF
--- a/apps/web/src/components/Tile.tsx
+++ b/apps/web/src/components/Tile.tsx
@@ -1,5 +1,7 @@
+import { useState } from "react";
 import type { TileInstance, GoldState, SuitedTile, Tile } from "@fuzhou-mahjong/shared";
 import { isGoldTile, isSuitedTile } from "@fuzhou-mahjong/shared";
+import { getTileSvgUrl, TILE_BACK_URL } from "../tileSvg";
 
 interface TileProps {
   tile: TileInstance;
@@ -54,22 +56,18 @@ export function TileView({ tile, faceUp = true, selected, claimable, onClick, on
     return (
       <div style={{
         width: w, height: h,
-        background: "linear-gradient(135deg, #2e7d32 0%, #1b5e20 50%, #2e7d32 100%)",
-        border: "1px solid #1a3c2a",
         borderRadius: 4,
         display: "inline-block",
         margin: 1,
-        boxShadow: "inset 0 0 8px rgba(0,0,0,0.3), 0 2px 4px rgba(0,0,0,0.4)",
-        position: "relative",
+        boxShadow: "0 2px 4px rgba(0,0,0,0.4)",
+        overflow: "hidden",
       }}>
-        {/* Decorative pattern on tile back */}
-        <div style={{
-          position: "absolute", top: "50%", left: "50%",
-          transform: "translate(-50%, -50%)",
-          width: w * 0.5, height: h * 0.5,
-          border: "1px solid rgba(255,255,255,0.15)",
-          borderRadius: 2,
-        }} />
+        <img
+          src={TILE_BACK_URL}
+          alt="tile back"
+          style={{ width: "100%", height: "100%", display: "block" }}
+          loading="lazy"
+        />
       </div>
     );
   }
@@ -116,28 +114,7 @@ export function TileView({ tile, faceUp = true, selected, claimable, onClick, on
         position: "relative",
       }}
     >
-      {/* Main character */}
-      <span style={{
-        fontSize,
-        fontWeight: 900,
-        color,
-        lineHeight: 1,
-        textShadow: "0 1px 0 rgba(255,255,255,0.5)",
-      }}>
-        {value}
-      </span>
-      {/* Suit label */}
-      {suit && (
-        <span style={{
-          fontSize: suitSize,
-          color,
-          opacity: 0.7,
-          lineHeight: 1,
-          marginTop: 1,
-        }}>
-          {suit}
-        </span>
-      )}
+      <TileFace tile={tile.tile} w={w} h={h} value={value} suit={suit} color={color} fontSize={fontSize} suitSize={suitSize} />
       {/* Gold shimmer overlay */}
       {isGold && (
         <div style={{
@@ -148,5 +125,44 @@ export function TileView({ tile, faceUp = true, selected, claimable, onClick, on
         }} />
       )}
     </div>
+  );
+}
+
+function TileFace({ tile, w, h, value, suit, color, fontSize, suitSize }: {
+  tile: Tile; w: number; h: number; value: string; suit: string; color: string; fontSize: number; suitSize: number;
+}) {
+  const [svgFailed, setSvgFailed] = useState(false);
+  const svgUrl = getTileSvgUrl(tile);
+
+  if (svgUrl && !svgFailed) {
+    return (
+      <img
+        src={svgUrl}
+        alt={`${value}${suit}`}
+        onError={() => setSvgFailed(true)}
+        style={{
+          width: w - 6,
+          height: h - 6,
+          objectFit: "contain",
+          pointerEvents: "none",
+        }}
+        loading="lazy"
+        draggable={false}
+      />
+    );
+  }
+
+  // Text fallback
+  return (
+    <>
+      <span style={{ fontSize, fontWeight: 900, color, lineHeight: 1, textShadow: "0 1px 0 rgba(255,255,255,0.5)" }}>
+        {value}
+      </span>
+      {suit && (
+        <span style={{ fontSize: suitSize, color, opacity: 0.7, lineHeight: 1, marginTop: 1 }}>
+          {suit}
+        </span>
+      )}
+    </>
   );
 }

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -3,6 +3,9 @@ import { createRoot } from "react-dom/client";
 import { App } from "./App";
 import "./index.css";
 import "./animations.css";
+import { preloadTileSvgs } from "./tileSvg";
+
+preloadTileSvgs();
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/apps/web/src/tileSvg.ts
+++ b/apps/web/src/tileSvg.ts
@@ -1,0 +1,40 @@
+// FluffyStuff riichi-mahjong-tiles SVGs via jsDelivr CDN
+// License: MIT (https://github.com/FluffyStuff/riichi-mahjong-tiles)
+
+const BASE = "https://cdn.jsdelivr.net/gh/FluffyStuff/riichi-mahjong-tiles@master/Regular";
+
+import type { Tile } from "@fuzhou-mahjong/shared";
+import { isSuitedTile } from "@fuzhou-mahjong/shared";
+
+const SUIT_MAP: Record<string, string> = { wan: "Man", bing: "Pin", tiao: "Sou" };
+const WIND_MAP: Record<string, string> = { east: "Ton", south: "Nan", west: "Shaa", north: "Pei" };
+const DRAGON_MAP: Record<string, string> = { red: "Chun", green: "Hatsu", white: "Haku" };
+
+export function getTileSvgUrl(tile: Tile): string | null {
+  if (isSuitedTile(tile)) {
+    const suit = SUIT_MAP[tile.suit];
+    return suit ? `${BASE}/${suit}${tile.value}.svg` : null;
+  }
+  switch (tile.kind) {
+    case "wind": return WIND_MAP[tile.windType] ? `${BASE}/${WIND_MAP[tile.windType]}.svg` : null;
+    case "dragon": return DRAGON_MAP[tile.dragonType] ? `${BASE}/${DRAGON_MAP[tile.dragonType]}.svg` : null;
+    default: return null; // Season/plant tiles don't have SVGs in this set
+  }
+}
+
+export const TILE_BACK_URL = `${BASE}/Back.svg`;
+
+// Preload common tiles
+export function preloadTileSvgs() {
+  const urls: string[] = [TILE_BACK_URL];
+  for (const suit of ["Man", "Pin", "Sou"]) {
+    for (let v = 1; v <= 9; v++) urls.push(`${BASE}/${suit}${v}.svg`);
+  }
+  for (const name of ["Ton", "Nan", "Shaa", "Pei", "Chun", "Hatsu", "Haku"]) {
+    urls.push(`${BASE}/${name}.svg`);
+  }
+  urls.forEach(url => {
+    const img = new Image();
+    img.src = url;
+  });
+}


### PR DESCRIPTION
Replace CSS text-based tile faces with professional SVG images from FluffyStuff/riichi-mahjong-tiles (MIT license, 516 stars).

Load SVGs via jsDelivr CDN. Mapping: Man=万, Pin=饼, Sou=条, Ton=东, Nan=南, Shaa=西, Pei=北, Chun=中, Hatsu=发, Haku=白, Back.svg for tile backs.

Keep text fallback for slow connections. Add preload for common tiles.

Closes #124