### PR TITLE
Add accessibility aria labels and keyboard support

### DIFF
--- a/apps/web/src/components/ActionBar.tsx
+++ b/apps/web/src/components/ActionBar.tsx
@@ -60,7 +60,7 @@ export function ActionBar({ actions, selectedTileId, gameState, onAction }: Acti
     : null;
 
   return (
-    <div ref={barRef} style={{
+    <div ref={barRef} role="toolbar" aria-label="游戏操作" aria-live="polite" style={{
       display: "flex",
       flexWrap: "wrap",
       justifyContent: "center",

--- a/apps/web/src/components/Tile.tsx
+++ b/apps/web/src/components/Tile.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import type { TileInstance, GoldState, SuitedTile, Tile } from "@fuzhou-mahjong/shared";
 import { isGoldTile, isSuitedTile } from "@fuzhou-mahjong/shared";
 import { getTileSvgUrl, TILE_BACK_URL } from "../tileSvg";
+import { getTileName } from "./TileTooltip";
 
 interface TileProps {
   tile: TileInstance;
@@ -77,8 +78,12 @@ export function TileView({ tile, faceUp = true, selected, claimable, onClick, on
   return (
     <div
       className={className || (claimable ? "tile-claimable" : undefined)}
+      role={onClick ? "button" : undefined}
+      tabIndex={onClick ? 0 : undefined}
+      aria-label={getTileName(tile.tile) + (isGold ? " (金牌)" : "") + (selected ? " (已选)" : "")}
       onClick={onClick}
       onDoubleClick={onDoubleClick}
+      onKeyDown={onClick ? (e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onClick(); } } : undefined}
       onTouchStart={onTouchStart}
       onTouchEnd={onTouchEnd}
       onMouseEnter={onMouseEnter}


### PR DESCRIPTION
Accessibility audit found zero aria labels and zero keyboard support.

Fix:
1. Add aria-label to tile elements (e.g. aria-label="三万")
2. Add role="button" and tabIndex to clickable tiles
3. Add onKeyDown handler for Enter/Space to select tiles
4. Add aria-live region for action prompts so screen readers announce them
5. Add aria-label to action buttons

Closes #126