### PR TITLE
Fix focus outline and CSS cleanup for polish

### DIFF
--- a/apps/web/src/components/GameTable.tsx
+++ b/apps/web/src/components/GameTable.tsx
@@ -36,7 +36,7 @@ export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTile
       padding: 8,
     }}>
       {/* Top player (index 2 in otherPlayers = across from me) */}
-      <div style={{ gridArea: "top" }}>
+      <div style={{ gridArea: "top", position: "relative", zIndex: 1 }}>
         <PlayerArea
           isMe={false}
           handCount={otherPlayers[1]?.handCount ?? 0}
@@ -51,7 +51,7 @@ export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTile
       </div>
 
       {/* Left player */}
-      <div style={{ gridArea: "left" }}>
+      <div style={{ gridArea: "left", position: "relative", zIndex: 1 }}>
         <PlayerArea
           isMe={false}
           handCount={otherPlayers[2]?.handCount ?? 0}
@@ -66,7 +66,7 @@ export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTile
       </div>
 
       {/* Center - game info */}
-      <div style={{ gridArea: "center", display: "flex", alignItems: "center", justifyContent: "center" }}>
+      <div style={{ gridArea: "center", display: "flex", alignItems: "center", justifyContent: "center", position: "relative", zIndex: 1 }}>
         <TileWall wallRemaining={wallRemaining} gold={gold} />
         <GameInfo
           gold={null}
@@ -80,7 +80,7 @@ export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTile
       </div>
 
       {/* Right player */}
-      <div style={{ gridArea: "right" }}>
+      <div style={{ gridArea: "right", position: "relative", zIndex: 1 }}>
         <PlayerArea
           isMe={false}
           handCount={otherPlayers[0]?.handCount ?? 0}
@@ -95,7 +95,7 @@ export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTile
       </div>
 
       {/* Bottom - my area */}
-      <div style={{ gridArea: "bottom" }}>
+      <div style={{ gridArea: "bottom", position: "relative", zIndex: 1 }}>
         <PlayerArea
           isMe
           hand={myHand}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -62,6 +62,13 @@ input::placeholder {
   color: #8fbc8f;
 }
 
+/* Keyboard focus outline for tiles and buttons */
+[role="button"]:focus-visible,
+button:focus-visible {
+  outline: 2px solid #4fc3f7;
+  outline-offset: 2px;
+}
+
 hr {
   border: none;
   border-top: 1px solid rgba(184, 134, 11, 0.2);

--- a/apps/web/src/pages/Lobby.tsx
+++ b/apps/web/src/pages/Lobby.tsx
@@ -46,7 +46,7 @@ export function Lobby({ onJoined }: LobbyProps) {
   };
 
   return (
-    <div style={{ maxWidth: 500, margin: "0 auto", padding: 20 }}>
+    <div className="lobby-page" style={{ maxWidth: 500, margin: "0 auto", padding: 20 }}>
       <h1>福州麻将</h1>
       <h2>Fuzhou Mahjong</h2>
 

--- a/apps/web/src/pages/Room.tsx
+++ b/apps/web/src/pages/Room.tsx
@@ -33,7 +33,7 @@ export function Room({ initialRoomState }: RoomProps) {
   };
 
   return (
-    <div style={{ maxWidth: 400, margin: "0 auto", padding: 20 }}>
+    <div className="room-page" style={{ maxWidth: 400, margin: "0 auto", padding: 20 }}>
       <h2>房间 / Room</h2>
 
       <div style={{


### PR DESCRIPTION
1. Add focus-visible outline for keyboard navigation on tiles
2. Apply lobby-page and room-page classes to Lobby and Room components
3. Add position:relative and z-index:1 to GameTable grid children so they render above pseudo-elements
4. Remove unused CSS if any

Closes #130