### PR TITLE
Add hover effects to action buttons via CSS classes

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -46,8 +46,18 @@ button:disabled {
   cursor: not-allowed;
 }
 
+button:hover:not(:disabled) {
+  filter: brightness(1.2);
+}
+
 button:active:not(:disabled) {
   transform: scale(0.97);
+  filter: brightness(0.9);
+}
+
+/* Action button transitions */
+button {
+  transition: filter 0.15s ease, transform 0.1s ease;
 }
 
 input {


### PR DESCRIPTION
Action buttons (胡/碰/杠/吃/出牌/过) use inline styles which override CSS hover. Convert to CSS classes so hover/active states work properly with brightness filter.

Closes #132