### PR TITLE
Add tile counter and improve wall remaining display

### DIFF
--- a/apps/web/src/animations.css
+++ b/apps/web/src/animations.css
@@ -83,6 +83,16 @@
   animation: pulse 1.5s ease-in-out infinite;
 }
 
+/* Wall remaining low pulse */
+@keyframes wallLowPulse {
+  0%, 100% { opacity: 0.7; transform: scale(1); }
+  50% { opacity: 1; transform: scale(1.08); }
+}
+
+.wall-low-pulse {
+  animation: wallLowPulse 1.5s ease-in-out infinite;
+}
+
 /* Turn indicator glow */
 @keyframes turnGlow {
   0%, 100% { border-color: rgba(255, 215, 0, 0.4); }

--- a/apps/web/src/components/PlayerArea.tsx
+++ b/apps/web/src/components/PlayerArea.tsx
@@ -39,6 +39,7 @@ export function PlayerArea({
         background: isCurrentTurn ? "rgba(255,255,255,0.08)" : "transparent",
         borderRadius: 8,
         border: isCurrentTurn ? "2px solid #ffd700" : "1px solid transparent",
+        overflow: "visible",
       }}
     >
       {/* Player info panel */}
@@ -60,7 +61,7 @@ export function PlayerArea({
       </div>
 
       {/* Hand */}
-      <div style={{ display: "flex", flexWrap: "wrap", gap: 1, marginBottom: 4, alignItems: "flex-end" }}>
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 1, marginBottom: 4, alignItems: "flex-end", paddingTop: isMe ? 18 : 0, overflow: "visible", position: "relative" }}>
         {isMe && hand ? (
           hand.map((t, idx) => (
             <div key={t.id} style={{

--- a/apps/web/src/components/TileCounter.tsx
+++ b/apps/web/src/components/TileCounter.tsx
@@ -1,0 +1,131 @@
+import { useState, useMemo } from "react";
+import type { ClientGameState, TileInstance, GoldState } from "@fuzhou-mahjong/shared";
+import { isSuitedTile } from "@fuzhou-mahjong/shared";
+
+interface TileCounterProps {
+  gameState: ClientGameState;
+}
+
+const SUITS = ["wan", "bing", "tiao"] as const;
+const SUIT_LABELS: Record<string, string> = { wan: "万", bing: "饼", tiao: "条" };
+const SUIT_COLORS: Record<string, string> = { wan: "#b71c1c", bing: "#0d47a1", tiao: "#1b5e20" };
+
+/**
+ * Count all tiles visible to the current player:
+ * - Own hand
+ * - Own flowers
+ * - Own melds
+ * - Own discards
+ * - Other players' discards
+ * - Other players' melds (face-up)
+ * - Other players' flowers
+ * - Gold indicator tile
+ */
+function countVisibleTiles(state: ClientGameState): Map<string, number> {
+  const counts = new Map<string, number>();
+
+  const countTile = (t: TileInstance) => {
+    if (!isSuitedTile(t.tile)) return;
+    const key = `${t.tile.suit}-${t.tile.value}`;
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  };
+
+  // My tiles
+  state.myHand.forEach(countTile);
+  state.myDiscards.forEach(countTile);
+  state.myMelds.forEach(m => m.tiles.forEach(countTile));
+  state.myFlowers.forEach(countTile);
+
+  // Other players' visible tiles
+  for (const p of state.otherPlayers) {
+    p.discards.forEach(countTile);
+    p.melds.forEach(m => m.tiles.forEach(countTile));
+    p.flowers.forEach(countTile);
+  }
+
+  // Gold indicator
+  if (state.gold) countTile(state.gold.indicatorTile);
+
+  return counts;
+}
+
+export function TileCounter({ gameState }: TileCounterProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  const visible = useMemo(() => countVisibleTiles(gameState), [gameState]);
+
+  return (
+    <div style={{ marginTop: 8 }}>
+      <button
+        onClick={() => setExpanded(!expanded)}
+        style={{
+          width: "100%",
+          padding: "6px 12px",
+          fontSize: 12,
+          background: "rgba(0,0,0,0.3)",
+          border: "1px solid rgba(184,134,11,0.3)",
+          color: "#e8d5a3",
+          borderRadius: 4,
+          minHeight: "auto",
+          cursor: "pointer",
+        }}
+      >
+        {expanded ? "▼ 记牌器" : "▶ 记牌器"}
+      </button>
+
+      {expanded && (
+        <div style={{
+          marginTop: 4,
+          padding: 8,
+          background: "rgba(0,0,0,0.4)",
+          borderRadius: 6,
+          fontSize: 12,
+        }}>
+          {SUITS.map(suit => (
+            <div key={suit} style={{ marginBottom: 6 }}>
+              <div style={{ color: SUIT_COLORS[suit], fontWeight: "bold", marginBottom: 2 }}>
+                {SUIT_LABELS[suit]}
+              </div>
+              <div style={{ display: "flex", gap: 2, flexWrap: "wrap" }}>
+                {[1, 2, 3, 4, 5, 6, 7, 8, 9].map(value => {
+                  const key = `${suit}-${value}`;
+                  const seen = visible.get(key) ?? 0;
+                  const remaining = 4 - seen;
+                  return (
+                    <div
+                      key={value}
+                      style={{
+                        width: 28,
+                        height: 28,
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        borderRadius: 3,
+                        fontSize: 11,
+                        fontWeight: "bold",
+                        background: remaining === 0
+                          ? "rgba(244,67,54,0.2)"
+                          : remaining <= 1
+                          ? "rgba(255,167,38,0.15)"
+                          : "rgba(255,255,255,0.05)",
+                        color: remaining === 0
+                          ? "#f44336"
+                          : remaining <= 1
+                          ? "#ffa726"
+                          : "#8fbc8f",
+                        border: remaining === 0 ? "1px solid rgba(244,67,54,0.3)" : "1px solid rgba(255,255,255,0.1)",
+                      }}
+                      title={`${value}${SUIT_LABELS[suit]}: 已见${seen}/4 剩余${remaining}`}
+                    >
+                      {value}<sub style={{ fontSize: 8 }}>{remaining}</sub>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/TileWall.tsx
+++ b/apps/web/src/components/TileWall.tsx
@@ -75,7 +75,24 @@ export function TileWall({ wallRemaining, gold }: TileWallProps) {
             <TileView tile={gold.indicatorTile} faceUp gold={null} small />
           </div>
         )}
-        <div style={{ fontSize: 12, color: "#aaa" }}>
+        <div
+          className={wallRemaining <= 20 ? "wall-low-pulse" : ""}
+          style={{
+            fontSize: wallRemaining <= 10 ? 22 : wallRemaining <= 20 ? 20 : 18,
+            fontWeight: "bold",
+            color: wallRemaining <= 10 ? "#f44336" : wallRemaining <= 20 ? "#ffa726" : "#8fbc8f",
+            padding: "4px 12px",
+            borderRadius: 6,
+            background: wallRemaining <= 10
+              ? "rgba(244,67,54,0.15)"
+              : wallRemaining <= 20
+              ? "rgba(255,167,38,0.12)"
+              : "transparent",
+            border: wallRemaining <= 20
+              ? `1px solid ${wallRemaining <= 10 ? "rgba(244,67,54,0.4)" : "rgba(255,167,38,0.3)"}`
+              : "1px solid transparent",
+          }}
+        >
           余 {wallRemaining}
         </div>
       </div>

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -8,8 +8,8 @@ body {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   background: #0a2e1a;
   color: #eee;
-  min-height: 100vh;
-  overflow-x: hidden;
+  height: 100vh;
+  overflow: hidden;
 }
 
 /* Tile sizing CSS variables — small sizes derived via calc() */
@@ -44,7 +44,9 @@ body {
 /* Game area gets felt table background */
 .game-table {
   background: radial-gradient(ellipse at center, #1a4a2e 0%, #0d3320 60%, #082818 100%);
-  min-height: 100vh;
+  height: 100vh;
+  max-height: 100vh;
+  overflow: hidden;
   border: 2px solid rgba(184, 134, 11, 0.3);
   transform-style: preserve-3d;
   position: relative;
@@ -118,7 +120,8 @@ hr {
 /* Lobby/Room pages keep dark theme */
 .lobby-page, .room-page {
   background: #0a2e1a;
-  min-height: 100vh;
+  height: 100vh;
+  overflow-y: auto;
 }
 
 /* Loading spinner */

--- a/apps/web/src/pages/Game.tsx
+++ b/apps/web/src/pages/Game.tsx
@@ -4,6 +4,7 @@ import { GameTable } from "../components/GameTable";
 import { ActionBar } from "../components/ActionBar";
 import { CenterAction, useCenterAction } from "../components/CenterAction";
 import { sounds, setMuted, isMuted } from "../sounds";
+import { TileCounter } from "../components/TileCounter";
 import type { ClientGameState, GameOverResult, AvailableActions, GameAction } from "@fuzhou-mahjong/shared";
 
 const MUTE_KEY = "fuzhou-mahjong-muted";
@@ -288,6 +289,7 @@ export function Game({ initialGameState, onLeave }: GameProps) {
         gameState={gameState}
         onAction={handleAction}
       />
+      <TileCounter gameState={gameState} />
     </div>
   );
 }


### PR DESCRIPTION
Three improvements:

1. Fix overlay: PlayerArea new-tile label clips at top, add overflow visible or adjust position
2. Wall remaining: make it larger, add pulse animation when low (under 20), change color to warn
3. Tile counter (记牌器): track all visible tiles per player (discards from all players + own hand + flowers + melds + gold indicator) and show remaining count per tile type. Display as a collapsible panel.

Closes #138