### PR TITLE
Animate wall tiles with deal and draw visual effects

### DIFF
--- a/apps/web/src/components/TileWall.tsx
+++ b/apps/web/src/components/TileWall.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from "react";
 import type { GoldState } from "@fuzhou-mahjong/shared";
 import { TileView } from "./Tile";
 
@@ -6,45 +7,65 @@ interface TileWallProps {
   gold: GoldState | null;
 }
 
-const TOTAL_TILES = 144;
-const TILES_PER_WALL = 36; // each wall has 18 stacks × 2 tiles
+const MAX_STACKS_PER_SIDE = 18;
 
 export function TileWall({ wallRemaining, gold }: TileWallProps) {
-  // Distribute remaining tiles across 4 walls (simplified)
-  const tilesPerSide = Math.ceil(wallRemaining / 4);
-  const stacksPerSide = Math.ceil(tilesPerSide / 2);
+  const prevRef = useRef(wallRemaining);
+  const [flash, setFlash] = useState(false);
 
-  const wallStyle = (side: "top" | "bottom" | "left" | "right"): React.CSSProperties => {
-    const isHorizontal = side === "top" || side === "bottom";
-    return {
-      display: "flex",
-      flexDirection: isHorizontal ? "row" : "column",
-      justifyContent: "center",
-      gap: 1,
-      position: "absolute" as const,
-      ...(side === "top" && { top: 0, left: "50%", transform: "translateX(-50%)" }),
-      ...(side === "bottom" && { bottom: 0, left: "50%", transform: "translateX(-50%)" }),
-      ...(side === "left" && { left: 0, top: "50%", transform: "translateY(-50%)" }),
-      ...(side === "right" && { right: 0, top: "50%", transform: "translateY(-50%)" }),
-    };
-  };
+  // Flash animation when a tile is drawn
+  useEffect(() => {
+    if (wallRemaining < prevRef.current) {
+      setFlash(true);
+      const t = setTimeout(() => setFlash(false), 400);
+      prevRef.current = wallRemaining;
+      return () => clearTimeout(t);
+    }
+    prevRef.current = wallRemaining;
+  }, [wallRemaining]);
+
+  const tilesPerSide = Math.ceil(wallRemaining / 4);
+  const stacksPerSide = Math.min(Math.ceil(tilesPerSide / 2), MAX_STACKS_PER_SIDE);
 
   const renderWall = (stacks: number, side: "top" | "bottom" | "left" | "right") => {
-    const isHorizontal = side === "top" || side === "bottom";
+    const isH = side === "top" || side === "bottom";
+    const isDrawSide = side === "top"; // head side for drawing
+
     return (
-      <div style={wallStyle(side)}>
-        {Array.from({ length: Math.min(stacks, 18) }).map((_, i) => (
-          <div
-            key={i}
-            style={{
-              width: isHorizontal ? 10 : 16,
-              height: isHorizontal ? 16 : 10,
-              background: "#2a5c3a",
-              border: "1px solid #1a3c2a",
-              borderRadius: 1,
-            }}
-          />
-        ))}
+      <div style={{
+        display: "flex",
+        flexDirection: isH ? "row" : "column",
+        justifyContent: "center",
+        gap: 1,
+        position: "absolute" as const,
+        transition: "all 0.5s ease-out",
+        ...(side === "top" && { top: 0, left: "50%", transform: "translateX(-50%)" }),
+        ...(side === "bottom" && { bottom: 0, left: "50%", transform: "translateX(-50%)" }),
+        ...(side === "left" && { left: 0, top: "50%", transform: "translateY(-50%)" }),
+        ...(side === "right" && { right: 0, top: "50%", transform: "translateY(-50%)" }),
+      }}>
+        {Array.from({ length: stacks }).map((_, i) => {
+          const isEdgeTile = isDrawSide && i === stacks - 1;
+          return (
+            <div
+              key={`${side}-${i}`}
+              style={{
+                width: isH ? 10 : 16,
+                height: isH ? 16 : 10,
+                background: isEdgeTile && flash
+                  ? "rgba(255,215,0,0.6)"
+                  : "linear-gradient(135deg, #2e7d32 0%, #1b5e20 100%)",
+                border: "1px solid #1a3c2a",
+                borderRadius: 1,
+                borderBottom: isH ? "2px solid #0d3320" : undefined,
+                borderRight: !isH ? "2px solid #0d3320" : undefined,
+                transition: "all 0.3s ease-out",
+                transform: isEdgeTile && flash ? "scale(0.5)" : "scale(1)",
+                opacity: isEdgeTile && flash ? 0 : 1,
+              }}
+            />
+          );
+        })}
       </div>
     );
   };
@@ -55,22 +76,25 @@ export function TileWall({ wallRemaining, gold }: TileWallProps) {
       width: 220,
       height: 220,
       margin: "0 auto",
+      flexShrink: 0,
     }}>
       {renderWall(stacksPerSide, "top")}
       {renderWall(stacksPerSide, "right")}
       {renderWall(stacksPerSide, "bottom")}
       {renderWall(stacksPerSide, "left")}
 
-      {/* Center: gold indicator + info */}
+      {/* Center: gold + remaining */}
       <div style={{
         position: "absolute",
-        top: "50%",
-        left: "50%",
+        top: "50%", left: "50%",
         transform: "translate(-50%, -50%)",
-        textAlign: "center",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: 4,
       }}>
         {gold && (
-          <div style={{ marginBottom: 4 }}>
+          <div style={{ display: "flex", flexDirection: "column", alignItems: "center" }}>
             <div style={{ fontSize: 10, color: "#ffd700", marginBottom: 2 }}>金</div>
             <TileView tile={gold.indicatorTile} faceUp gold={null} small />
           </div>
@@ -91,13 +115,14 @@ export function TileWall({ wallRemaining, gold }: TileWallProps) {
             border: wallRemaining <= 20
               ? `1px solid ${wallRemaining <= 10 ? "rgba(244,67,54,0.4)" : "rgba(255,167,38,0.3)"}`
               : "1px solid transparent",
+            transition: "all 0.3s ease",
           }}
         >
           余 {wallRemaining}
         </div>
       </div>
 
-      {/* Labels */}
+      {/* Direction labels */}
       <div style={{ position: "absolute", top: 18, left: "50%", transform: "translateX(-50%)", fontSize: 9, color: "#8a9a8a" }}>摸牌 →</div>
       <div style={{ position: "absolute", bottom: 18, left: "50%", transform: "translateX(-50%)", fontSize: 9, color: "#8a9a8a" }}>← 补牌</div>
     </div>


### PR DESCRIPTION
Current TileWall shows static small rectangles. Make it dynamic:

1. Wall tiles should shrink smoothly when a tile is drawn (animate removal)
2. When wallRemaining decreases, the corresponding wall section visually shrinks with a slide animation
3. Add a brief flip animation on the draw position to simulate tile being taken
4. Wall sections should feel like real stacked tiles being consumed
5. Keep the gold indicator and remaining count display

Closes #146