### PR TITLE
Add gold tile discard warning and penalty indicator

### DIFF
--- a/apps/server/src/gameState.ts
+++ b/apps/server/src/gameState.ts
@@ -117,6 +117,7 @@ export class ServerGameState {
         melds: p.melds,
         handCount: p.hand.length,
         discards: p.discards,
+        hasDiscardedGold: p.hasDiscardedGold,
       });
     }
 
@@ -137,6 +138,7 @@ export class ServerGameState {
       lastDiscard: state.lastDiscard,
       tenpaiTiles: findTenpaiTiles(myPlayer.hand, myPlayer.melds, state.gold),
       lastDrawnTileId: this.lastDrawnTileIds[playerIndex],
+      myHasDiscardedGold: myPlayer.hasDiscardedGold,
     };
   }
 

--- a/apps/web/src/animations.css
+++ b/apps/web/src/animations.css
@@ -198,6 +198,16 @@
   animation: tileHighlight 0.8s ease-in-out infinite;
 }
 
+/* Gold discard warning pulse */
+@keyframes goldWarningPulse {
+  0%, 100% { box-shadow: 0 2px 8px rgba(196,30,58,0.5); transform: scale(1); }
+  50% { box-shadow: 0 2px 16px rgba(196,30,58,0.9), 0 0 24px rgba(255,0,0,0.4); transform: scale(1.05); }
+}
+
+.gold-warning-pulse {
+  animation: goldWarningPulse 0.8s ease-in-out infinite;
+}
+
 /* Discard bubble fade-in */
 @keyframes bubbleFadeIn {
   0% { opacity: 0; transform: translateX(-50%) translateY(4px); }

--- a/apps/web/src/components/GameTable.tsx
+++ b/apps/web/src/components/GameTable.tsx
@@ -22,7 +22,7 @@ interface GameTableProps {
 }
 
 export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTileId, claimableTileIds, canDiscard, onDiscard, canHu, onHu, canDraw, onDraw, kongTileIds, onAnGang, onBuGang, onBackgroundClick }: GameTableProps) {
-  const { myHand, myFlowers, myMelds, myDiscards, myName, otherPlayers, currentTurn, myIndex, gold, dealerIndex, lianZhuangCount, wallRemaining } = state;
+  const { myHand, myFlowers, myMelds, myDiscards, myName, otherPlayers, currentTurn, myIndex, gold, dealerIndex, lianZhuangCount, wallRemaining, myHasDiscardedGold } = state;
   const lastDiscardTileId = state.lastDiscard?.tile.id ?? null;
   const lastDiscardPlayerIndex = state.lastDiscard?.playerIndex ?? -1;
   const botLabel = (name: string, isBot?: boolean) => isBot ? `${name} 🤖` : name;
@@ -63,6 +63,7 @@ export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTile
           gold={gold}
           label={labels[2]}
           lastDiscardedTileId={lastDiscardPlayerIndex === (myIndex + 2) % 4 ? lastDiscardTileId : null}
+          hasDiscardedGold={otherPlayers[1]?.hasDiscardedGold}
         />
       </div>
 
@@ -79,6 +80,7 @@ export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTile
           gold={gold}
           label={labels[3]}
           lastDiscardedTileId={lastDiscardPlayerIndex === (myIndex + 3) % 4 ? lastDiscardTileId : null}
+          hasDiscardedGold={otherPlayers[2]?.hasDiscardedGold}
         />
       </div>
 
@@ -109,6 +111,7 @@ export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTile
           gold={gold}
           label={labels[1]}
           lastDiscardedTileId={lastDiscardPlayerIndex === (myIndex + 1) % 4 ? lastDiscardTileId : null}
+          hasDiscardedGold={otherPlayers[0]?.hasDiscardedGold}
         />
       </div>
 
@@ -135,6 +138,7 @@ export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTile
           kongTileIds={kongTileIds}
           onAnGang={onAnGang}
           onBuGang={onBuGang}
+          hasDiscardedGold={myHasDiscardedGold}
           lastDrawnTileId={(state as any).lastDrawnTileId}
           lastDiscardedTileId={lastDiscardPlayerIndex === myIndex ? lastDiscardTileId : null}
           tenpaiTiles={(state as any).tenpaiTiles}

--- a/apps/web/src/components/PlayerArea.tsx
+++ b/apps/web/src/components/PlayerArea.tsx
@@ -28,6 +28,7 @@ interface PlayerAreaProps {
   kongTileIds?: Set<number>;
   onAnGang?: (tileInstanceId: number) => void;
   onBuGang?: (tileInstanceId: number) => void;
+  hasDiscardedGold?: boolean;
 }
 
 const BUBBLE_BTN = {
@@ -41,7 +42,7 @@ export function PlayerArea({
   isMe, hand, handCount, melds, flowers, discards,
   isCurrentTurn, isDealer, gold, selectedTileId, onTileClick, label,
   claimableTileIds, onTileDoubleClick, lastDrawnTileId, lastDiscardedTileId, tenpaiTiles,
-  canDiscard, onDiscard, canHu, onHu, kongTileIds, onAnGang, onBuGang,
+  canDiscard, onDiscard, canHu, onHu, kongTileIds, onAnGang, onBuGang, hasDiscardedGold,
 }: PlayerAreaProps) {
   const { onTouchStart, onTouchEnd, onMouseEnter, onMouseLeave, Tooltip } = useLongPress(gold);
 
@@ -70,6 +71,7 @@ export function PlayerArea({
           {label}
         </span>
         {isDealer && <span style={{ fontSize: 10, background: "#b71c1c", color: "#ffd700", padding: "1px 5px", borderRadius: 3, fontWeight: "bold" }}>庄</span>}
+        {hasDiscardedGold && <span style={{ fontSize: 10, background: "#c41e3a", color: "#fff", padding: "1px 5px", borderRadius: 3, fontWeight: "bold" }}>弃金</span>}
         {isCurrentTurn && <span style={{ fontSize: 10, background: "rgba(255,215,0,0.2)", color: "#ffd700", padding: "1px 5px", borderRadius: 3, border: "1px solid #ffd700" }}>出牌</span>}
         <span style={{ fontSize: 11, color: "#8fbc8f", marginLeft: "auto" }}>
           🌸{flowers.length}
@@ -83,6 +85,7 @@ export function PlayerArea({
             const isSelected = selectedTileId === t.id;
             const isKong = kongTileIds?.has(t.id);
             const showBubble = isSelected && (canDiscard || canHu || isKong);
+            const isGoldTile = !!(gold && t.tile.kind === "suited" && t.tile.suit === gold.wildTile.suit && t.tile.value === gold.wildTile.value);
             const isAnGang = !!(isKong && onAnGang);
             const isBuGang = !!(isKong && onBuGang);
             return (
@@ -121,10 +124,16 @@ export function PlayerArea({
                   )}
                   {canDiscard && (
                     <button
-                      style={{ ...BUBBLE_BTN, background: "#00b894", color: "#fff", boxShadow: "0 2px 8px rgba(0,184,148,0.5)" }}
+                      className={isGoldTile ? "gold-warning-pulse" : undefined}
+                      style={{
+                        ...BUBBLE_BTN,
+                        background: isGoldTile ? "#c41e3a" : "#00b894",
+                        color: "#fff",
+                        boxShadow: isGoldTile ? "0 2px 8px rgba(196,30,58,0.5)" : "0 2px 8px rgba(0,184,148,0.5)",
+                      }}
                       onClick={(e) => { e.stopPropagation(); onDiscard?.(t.id); }}
                     >
-                      出牌
+                      {isGoldTile ? "弃金!" : "出牌"}
                     </button>
                   )}
                   {isAnGang && (

--- a/packages/shared/src/types/events.ts
+++ b/packages/shared/src/types/events.ts
@@ -20,6 +20,7 @@ export interface OtherPlayerView {
   melds: Meld[];
   handCount: number;
   discards: TileInstance[];
+  hasDiscardedGold: boolean;
 }
 
 export interface ClientGameState {
@@ -39,6 +40,7 @@ export interface ClientGameState {
   lastDiscard: { tile: TileInstance; playerIndex: number } | null;
   tenpaiTiles: import('../types/tile.js').SuitedTile[];
   lastDrawnTileId: number | null;
+  myHasDiscardedGold: boolean;
 }
 
 // ─── Actions ─────────────────────────────────────────────────────


### PR DESCRIPTION
The spec says: 金牌弃牌惩罚有没有提前警告用户. Currently when a player discards a gold tile, there is a penalty but no warning beforehand.

Add:
1. When a player selects a gold tile from their hand, show a warning indicator (e.g. red outline, warning icon, or tooltip) BEFORE they confirm the discard
2. The discard bubble button should change color/text to indicate danger (e.g. red background, text: 出牌⚠️ or 弃金!)
3. After discarding gold, the hasDiscardedGold flag is already tracked in PlayerState — make sure this is visually indicated on the player info panel (e.g. a small badge)
4. Brief explanation tooltip on first gold discard attempt explaining the penalty

Files: apps/web/src/components/PlayerArea.tsx (discard button, tile selection), apps/web/src/pages/Game.tsx (gold state access), shared types already have hasDiscardedGold

Closes #166