### PR TITLE
Add quick start button for single player with bots

### DIFF
--- a/apps/server/src/handlers/roomHandlers.ts
+++ b/apps/server/src/handlers/roomHandlers.ts
@@ -110,6 +110,45 @@ export function registerRoomHandlers(io: GameServer, socket: GameSocket): void {
     }
   });
 
+  socket.on("quickStart", (playerName: string) => {
+    try {
+      leaveCurrentRoom(io, socket);
+
+      const room = createRoom();
+      const player = room.addPlayer(socket.id, playerName);
+      registerPlayerRoom(player.playerId, room.id);
+      socket.join(room.id);
+
+      socket.emit("playerIdAssigned", player.playerId);
+
+      // Add 3 bots
+      for (let i = 0; i < 3; i++) {
+        room.addBot();
+      }
+
+      // Start game
+      room.gameStarted = true;
+      broadcastRoomList(io);
+      console.log(`Quick start: room ${room.id} created by ${playerName} with 3 bots`);
+
+      const socketIds = room.players.map((p) => p.socketId ?? `bot-${p.playerId}`);
+      const playerNames = room.players.map((p) => p.name);
+      const botIndices = room.players.map((p, i) => p.isBot ? i : -1).filter((i) => i >= 0);
+      const game = createGame(room.id, socketIds, playerNames, botIndices);
+
+      for (let i = 0; i < 4; i++) {
+        if (!game.isBot(i) && room.players[i].socketId) {
+          io.to(room.players[i].socketId!).emit("gameStarted", game.getClientGameState(i));
+        }
+      }
+
+      triggerDealerAction(io, game, room);
+    } catch (err) {
+      console.error("quickStart error:", err);
+      socket.emit("error", "Failed to quick start game");
+    }
+  });
+
   socket.on("leaveRoom", () => {
     leaveCurrentRoom(io, socket);
     broadcastRoomList(io);

--- a/apps/web/src/pages/Lobby.tsx
+++ b/apps/web/src/pages/Lobby.tsx
@@ -11,6 +11,7 @@ export function Lobby({ onJoined }: LobbyProps) {
   const [roomCode, setRoomCode] = useState("");
   const [error, setError] = useState("");
   const [rooms, setRooms] = useState<RoomListItem[]>([]);
+  const [quickStarting, setQuickStarting] = useState(false);
 
   useEffect(() => {
     socket.emit("listRooms");
@@ -29,6 +30,13 @@ export function Lobby({ onJoined }: LobbyProps) {
       socket.off("roomList", onRoomList);
     };
   }, [onJoined]);
+
+  const handleQuickStart = () => {
+    if (!name.trim()) return;
+    setError("");
+    setQuickStarting(true);
+    socket.emit("quickStart", name.trim());
+  };
 
   const handleCreate = () => {
     if (!name.trim()) return;
@@ -63,6 +71,18 @@ export function Lobby({ onJoined }: LobbyProps) {
       </div>
 
       <button
+        onClick={handleQuickStart}
+        disabled={!name.trim() || quickStarting}
+        className="lobby-create-btn"
+        style={{ width: "100%", padding: "16px 12px", fontSize: 20, fontWeight: 700, border: "2px solid rgba(212, 160, 23, 0.8)", background: "linear-gradient(135deg, #1a5c3a 0%, #2a6f4a 100%)", boxShadow: "0 0 12px rgba(212, 160, 23, 0.3)" }}
+      >
+        {quickStarting ? "启动中... / Starting..." : "⚡ 快速开始 / Quick Start"}
+      </button>
+      <p style={{ color: "#8fbc8f", fontSize: 13, textAlign: "center", marginTop: -12 }}>
+        一键开局，自动匹配 3 个机器人
+      </p>
+
+      <button
         onClick={handleCreate}
         disabled={!name.trim()}
         className="lobby-create-btn"
@@ -71,7 +91,7 @@ export function Lobby({ onJoined }: LobbyProps) {
         创建房间 / Create Room
       </button>
       <p style={{ color: "#8fbc8f", fontSize: 13, textAlign: "center", marginTop: -12 }}>
-        一个人也能玩！创建房间后可添加机器人凑满 4 人
+        创建房间后可邀请朋友或添加机器人
       </p>
 
       <hr />

--- a/packages/shared/src/types/events.ts
+++ b/packages/shared/src/types/events.ts
@@ -106,6 +106,7 @@ export interface ClientEvents {
   nextRound: () => void;
   addBot: () => void;
   removeBot: () => void;
+  quickStart: (playerName: string) => void;
 }
 
 export interface ServerEvents {


### PR DESCRIPTION
Add a one-click Quick Start button on the Lobby page that automatically: creates a room, adds 3 bots, and starts the game immediately. No need to manually create room, add bots one by one, then click start.

Flow: User enters name -> clicks Quick Start -> automatically creates room, fills with 3 bots, starts game. Should take <2 seconds from click to game board.

UI: Prominent button on Lobby page, styled distinctly from Create Room (e.g. gold accent, larger). Text: 快速开始 / Quick Start

Implementation: Client-side orchestration via socket events (createRoom -> addBot x3 -> startGame), or a new single server event quickStart that handles it all server-side.

Closes #170