### PR TITLE
Add disconnect reconnect UX with grace period and status indicators

### DIFF
--- a/apps/server/src/handlers/roomHandlers.ts
+++ b/apps/server/src/handlers/roomHandlers.ts
@@ -77,7 +77,7 @@ export function registerRoomHandlers(io: GameServer, socket: GameSocket): void {
       game.updateSocketId(playerIndex, socket.id);
       socket.emit("playerIdAssigned", playerId);
       socket.emit("gameStarted", game.getClientGameState(playerIndex));
-      io.to(room.id).emit("playerReconnected", playerIndex);
+      io.to(room.id).emit("playerReconnected", { playerIndex, playerName: player.name });
       console.log(`Player ${player.name} reconnected to room ${room.id}`);
     } else {
       socket.emit("roomJoined", room.getState());
@@ -247,7 +247,7 @@ export function registerRoomHandlers(io: GameServer, socket: GameSocket): void {
       if (!player) return;
 
       const playerIndex = room.getPlayerIndexByPlayerId(player.playerId);
-      io.to(room.id).emit("playerDisconnected", playerIndex);
+      io.to(room.id).emit("playerDisconnected", { playerIndex, playerName: player.name, timeoutMs: RECONNECT_TIMEOUT_MS });
       io.to(room.id).emit("roomUpdated", room.getState());
       console.log(`Player ${player.name} disconnected from game in room ${room.id}`);
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -5,15 +5,17 @@ import type { RoomState, ClientGameState } from "@fuzhou-mahjong/shared";
 import { Lobby } from "./pages/Lobby";
 import { Room } from "./pages/Room";
 import { Game } from "./pages/Game";
+import { ConnectionStatus } from "./components/ConnectionStatus";
 
 type View = "lobby" | "room" | "game";
 
 const PLAYER_ID_KEY = "fuzhou-mahjong-playerId";
 
 export function App() {
-  const { connected } = useSocket();
+  const { connected, connectionState, reconnectAttempt } = useSocket();
   const [view, setView] = useState<View>("lobby");
   const [reconnecting, setReconnecting] = useState(false);
+  const [disconnectedAt, setDisconnectedAt] = useState<number | null>(null);
   const [initialRoomState, setInitialRoomState] = useState<RoomState | null>(null);
   const [initialGameState, setInitialGameState] = useState<ClientGameState | null>(null);
 
@@ -29,7 +31,10 @@ export function App() {
   // Detect disconnect during game
   useEffect(() => {
     const handler = () => {
-      if (view === "game") setReconnecting(true);
+      if (view === "game") {
+        setReconnecting(true);
+        setDisconnectedAt(Date.now());
+      }
     };
     socket.on("disconnect", handler);
     return () => { socket.off("disconnect", handler); };
@@ -53,6 +58,7 @@ export function App() {
     const handler = (state: ClientGameState) => {
       setInitialGameState(state);
       setReconnecting(false);
+      setDisconnectedAt(null);
       setView("game");
     };
     socket.on("gameStarted", handler);
@@ -79,11 +85,11 @@ export function App() {
     return () => { socket.off("error", handler); };
   }, []);
 
-  if (!connected) {
+  if (!connected && !reconnecting) {
     return (
       <div className="loading-state" style={{ minHeight: "80vh" }}>
         <div className="spinner" />
-        {reconnecting ? "重新连接中... / Reconnecting..." : "连接服务器中... / Connecting..."}
+        连接服务器中... / Connecting...
       </div>
     );
   }
@@ -99,5 +105,17 @@ export function App() {
     }
   })();
 
-  return <div key={view} className="page-transition" style={{ display: "flex", flexDirection: "column", flex: 1 }}>{content}</div>;
+  return (
+    <div key={view} className="page-transition" style={{ display: "flex", flexDirection: "column", flex: 1 }}>
+      {content}
+      {reconnecting && (
+        <ConnectionStatus
+          connectionState={connectionState}
+          reconnectAttempt={reconnectAttempt}
+          timeoutMs={60000}
+          disconnectedAt={disconnectedAt}
+        />
+      )}
+    </div>
+  );
 }

--- a/apps/web/src/components/ConnectionStatus.tsx
+++ b/apps/web/src/components/ConnectionStatus.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useState } from "react";
+import type { ConnectionState } from "../hooks/useSocket";
+
+interface ConnectionStatusProps {
+  connectionState: ConnectionState;
+  reconnectAttempt: number;
+  timeoutMs: number;
+  disconnectedAt: number | null;
+}
+
+export function ConnectionStatus({ connectionState, reconnectAttempt, timeoutMs, disconnectedAt }: ConnectionStatusProps) {
+  const [elapsed, setElapsed] = useState(0);
+
+  useEffect(() => {
+    if (!disconnectedAt) { setElapsed(0); return; }
+    const tick = () => setElapsed(Date.now() - disconnectedAt);
+    tick();
+    const id = setInterval(tick, 1000);
+    return () => clearInterval(id);
+  }, [disconnectedAt]);
+
+  if (connectionState === "connected" || !disconnectedAt) return null;
+
+  const remaining = Math.max(0, Math.ceil((timeoutMs - elapsed) / 1000));
+  const progress = Math.min(1, elapsed / timeoutMs);
+
+  return (
+    <div style={{
+      position: "fixed",
+      inset: 0,
+      zIndex: 10000,
+      background: "rgba(10, 46, 26, 0.95)",
+      display: "flex",
+      flexDirection: "column",
+      alignItems: "center",
+      justifyContent: "center",
+      gap: 16,
+    }}>
+      <div className="spinner" style={{ width: 40, height: 40, borderWidth: 4 }} />
+
+      <div style={{ fontSize: 20, color: "#e8d5a3", fontWeight: "bold" }}>
+        {connectionState === "reconnecting" ? "重新连接中... / Reconnecting..." : "连接已断开 / Disconnected"}
+      </div>
+
+      <div style={{ fontSize: 16, color: "#8fbc8f" }}>
+        {remaining > 0
+          ? `${remaining}s 内重连可恢复游戏 / ${remaining}s to reconnect`
+          : "超时 / Timed out"
+        }
+      </div>
+
+      {reconnectAttempt > 0 && (
+        <div style={{ fontSize: 13, color: "#6a9a6a" }}>
+          重试 #{reconnectAttempt}
+        </div>
+      )}
+
+      {/* Progress bar */}
+      <div style={{
+        width: "min(280px, 80vw)",
+        height: 6,
+        background: "rgba(255,255,255,0.1)",
+        borderRadius: 3,
+        overflow: "hidden",
+      }}>
+        <div style={{
+          width: `${(1 - progress) * 100}%`,
+          height: "100%",
+          background: remaining > 10 ? "#4caf50" : remaining > 5 ? "#ff9800" : "#f44336",
+          borderRadius: 3,
+          transition: "width 1s linear, background 0.5s ease",
+        }} />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/GameTable.tsx
+++ b/apps/web/src/components/GameTable.tsx
@@ -19,9 +19,10 @@ interface GameTableProps {
   onAnGang?: (tileInstanceId: number) => void;
   onBuGang?: (tileInstanceId: number) => void;
   onBackgroundClick?: () => void;
+  disconnectedPlayers?: Set<number>;
 }
 
-export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTileId, claimableTileIds, canDiscard, onDiscard, canHu, onHu, canDraw, onDraw, kongTileIds, onAnGang, onBuGang, onBackgroundClick }: GameTableProps) {
+export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTileId, claimableTileIds, canDiscard, onDiscard, canHu, onHu, canDraw, onDraw, kongTileIds, onAnGang, onBuGang, onBackgroundClick, disconnectedPlayers }: GameTableProps) {
   const { myHand, myFlowers, myMelds, myDiscards, myName, otherPlayers, currentTurn, myIndex, gold, dealerIndex, lianZhuangCount, wallRemaining, myHasDiscardedGold } = state;
   const lastDiscardTileId = state.lastDiscard?.tile.id ?? null;
   const lastDiscardPlayerIndex = state.lastDiscard?.playerIndex ?? -1;
@@ -64,6 +65,7 @@ export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTile
           label={labels[2]}
           lastDiscardedTileId={lastDiscardPlayerIndex === (myIndex + 2) % 4 ? lastDiscardTileId : null}
           hasDiscardedGold={otherPlayers[1]?.hasDiscardedGold}
+          isDisconnected={disconnectedPlayers?.has((myIndex + 2) % 4)}
         />
       </div>
 
@@ -81,6 +83,7 @@ export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTile
           label={labels[3]}
           lastDiscardedTileId={lastDiscardPlayerIndex === (myIndex + 3) % 4 ? lastDiscardTileId : null}
           hasDiscardedGold={otherPlayers[2]?.hasDiscardedGold}
+          isDisconnected={disconnectedPlayers?.has((myIndex + 3) % 4)}
         />
       </div>
 
@@ -112,6 +115,7 @@ export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTile
           label={labels[1]}
           lastDiscardedTileId={lastDiscardPlayerIndex === (myIndex + 1) % 4 ? lastDiscardTileId : null}
           hasDiscardedGold={otherPlayers[0]?.hasDiscardedGold}
+          isDisconnected={disconnectedPlayers?.has((myIndex + 1) % 4)}
         />
       </div>
 

--- a/apps/web/src/components/PlayerArea.tsx
+++ b/apps/web/src/components/PlayerArea.tsx
@@ -29,6 +29,7 @@ interface PlayerAreaProps {
   onAnGang?: (tileInstanceId: number) => void;
   onBuGang?: (tileInstanceId: number) => void;
   hasDiscardedGold?: boolean;
+  isDisconnected?: boolean;
 }
 
 const BUBBLE_BTN = {
@@ -43,6 +44,7 @@ export function PlayerArea({
   isCurrentTurn, isDealer, gold, selectedTileId, onTileClick, label,
   claimableTileIds, onTileDoubleClick, lastDrawnTileId, lastDiscardedTileId, tenpaiTiles,
   canDiscard, onDiscard, canHu, onHu, kongTileIds, onAnGang, onBuGang, hasDiscardedGold,
+  isDisconnected,
 }: PlayerAreaProps) {
   const { onTouchStart, onTouchEnd, onMouseEnter, onMouseLeave, Tooltip } = useLongPress(gold);
 
@@ -57,6 +59,8 @@ export function PlayerArea({
         borderRadius: 8,
         border: isCurrentTurn ? "2px solid #ffd700" : "1px solid transparent",
         overflow: "visible",
+        opacity: isDisconnected ? 0.5 : 1,
+        transition: "opacity 0.3s ease",
       }}
     >
       {/* Player info panel */}
@@ -71,6 +75,7 @@ export function PlayerArea({
           {label}
         </span>
         {isDealer && <span style={{ fontSize: 10, background: "#b71c1c", color: "#ffd700", padding: "1px 5px", borderRadius: 3, fontWeight: "bold" }}>庄</span>}
+        {isDisconnected && <span style={{ fontSize: 10, background: "#ff5722", color: "#fff", padding: "1px 5px", borderRadius: 3, fontWeight: "bold", animation: "disconnectPulse 2s ease-in-out infinite" }}>断线</span>}
         {hasDiscardedGold && <span style={{ fontSize: 10, background: "#c41e3a", color: "#fff", padding: "1px 5px", borderRadius: 3, fontWeight: "bold" }}>弃金</span>}
         {isCurrentTurn && <span style={{ fontSize: 10, background: "rgba(255,215,0,0.2)", color: "#ffd700", padding: "1px 5px", borderRadius: 3, border: "1px solid #ffd700" }}>出牌</span>}
         <span style={{ fontSize: 11, color: "#8fbc8f", marginLeft: "auto" }}>

--- a/apps/web/src/hooks/useSocket.ts
+++ b/apps/web/src/hooks/useSocket.ts
@@ -1,20 +1,47 @@
 import { useEffect, useState } from "react";
 import { socket } from "../socket";
 
+export type ConnectionState = "connected" | "disconnected" | "reconnecting";
+
 export function useSocket() {
-  const [connected, setConnected] = useState(socket.connected);
+  const [connectionState, setConnectionState] = useState<ConnectionState>(
+    socket.connected ? "connected" : "disconnected"
+  );
+  const [reconnectAttempt, setReconnectAttempt] = useState(0);
 
   useEffect(() => {
     socket.connect();
 
-    socket.on("connect", () => setConnected(true));
-    socket.on("disconnect", () => setConnected(false));
+    const onConnect = () => {
+      setConnectionState("connected");
+      setReconnectAttempt(0);
+    };
+
+    const onDisconnect = () => {
+      setConnectionState("disconnected");
+    };
+
+    const onReconnectAttempt = (attempt: number) => {
+      setConnectionState("reconnecting");
+      setReconnectAttempt(attempt);
+    };
+
+    const onReconnectError = () => {
+      setConnectionState("reconnecting");
+    };
+
+    socket.on("connect", onConnect);
+    socket.on("disconnect", onDisconnect);
+    socket.io.on("reconnect_attempt", onReconnectAttempt);
+    socket.io.on("reconnect_error", onReconnectError);
 
     return () => {
-      socket.off("connect");
-      socket.off("disconnect");
+      socket.off("connect", onConnect);
+      socket.off("disconnect", onDisconnect);
+      socket.io.off("reconnect_attempt", onReconnectAttempt);
+      socket.io.off("reconnect_error", onReconnectError);
     };
   }, []);
 
-  return { socket, connected };
+  return { socket, connected: connectionState === "connected", connectionState, reconnectAttempt };
 }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -432,6 +432,12 @@ button.lobby-create-btn:hover:not(:disabled) {
   }
 }
 
+/* Disconnect pulse animation */
+@keyframes disconnectPulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
 /* Chi picker horizontal scroll — hide scrollbar */
 .chi-picker-scroll {
   scrollbar-width: none; /* Firefox */

--- a/apps/web/src/pages/Game.tsx
+++ b/apps/web/src/pages/Game.tsx
@@ -7,7 +7,7 @@ import { sounds, setMuted, isMuted } from "../sounds";
 import { TileCounter } from "../components/TileCounter";
 import { TileView } from "../components/Tile";
 import { ActionType, MeldType } from "@fuzhou-mahjong/shared";
-import type { ClientGameState, GameOverResult, AvailableActions, GameAction } from "@fuzhou-mahjong/shared";
+import type { ClientGameState, GameOverResult, AvailableActions, GameAction, PlayerDisconnectedEvent, PlayerReconnectedEvent } from "@fuzhou-mahjong/shared";
 
 const MUTE_KEY = "fuzhou-mahjong-muted";
 
@@ -59,6 +59,15 @@ export function Game({ initialGameState, onLeave }: GameProps) {
     return false;
   });
   const gameStartedRef = useRef(false);
+  const [disconnectedPlayers, setDisconnectedPlayers] = useState<Set<number>>(new Set());
+  const [toasts, setToasts] = useState<{ id: number; message: string }[]>([]);
+  const toastIdRef = useRef(0);
+
+  const addToast = (message: string) => {
+    const id = ++toastIdRef.current;
+    setToasts((prev) => [...prev, { id, message }]);
+    setTimeout(() => setToasts((prev) => prev.filter((t) => t.id !== id)), 4000);
+  };
 
   const toggleMute = () => {
     const next = !soundMuted;
@@ -147,11 +156,25 @@ export function Game({ initialGameState, onLeave }: GameProps) {
       setGameOver(result);
       if (result.winnerId !== null) sounds.hu();
     });
+    socket.on("playerDisconnected", (event: PlayerDisconnectedEvent) => {
+      setDisconnectedPlayers((prev) => new Set(prev).add(event.playerIndex));
+      addToast(`${event.playerName} 断线了 / disconnected`);
+    });
+    socket.on("playerReconnected", (event: PlayerReconnectedEvent) => {
+      setDisconnectedPlayers((prev) => {
+        const next = new Set(prev);
+        next.delete(event.playerIndex);
+        return next;
+      });
+      addToast(`${event.playerName} 已重连 / reconnected`);
+    });
 
     return () => {
       socket.off("gameStateUpdate");
       socket.off("actionRequired");
       socket.off("gameOver");
+      socket.off("playerDisconnected");
+      socket.off("playerReconnected");
     };
   }, []);
 
@@ -412,6 +435,24 @@ export function Game({ initialGameState, onLeave }: GameProps) {
           <div className="border-flash" />
         </>
       )}
+      {/* Toast notifications */}
+      <div style={{
+        position: "fixed", top: 16, left: "50%", transform: "translateX(-50%)",
+        zIndex: 9000, display: "flex", flexDirection: "column", gap: 8, alignItems: "center",
+        pointerEvents: "none",
+      }}>
+        {toasts.map((t) => (
+          <div key={t.id} style={{
+            background: "rgba(0,0,0,0.85)", color: "#e8d5a3", padding: "8px 20px",
+            borderRadius: 8, fontSize: 14, fontWeight: "bold",
+            border: "1px solid rgba(232,213,163,0.3)",
+            animation: "pageFadeIn 0.3s ease-out",
+            whiteSpace: "nowrap",
+          }}>
+            {t.message}
+          </div>
+        ))}
+      </div>
       <CenterAction display={centerAction} gold={gameState.gold} />
       <GameTable
         state={gameState}
@@ -442,6 +483,7 @@ export function Game({ initialGameState, onLeave }: GameProps) {
           if (tile) handleAction({ type: ActionType.BuGang, playerIndex: gameState.myIndex, tile });
         }}
         onBackgroundClick={() => setSelectedTileId(null)}
+        disconnectedPlayers={disconnectedPlayers}
       />
       {isClaimWindow && actions && (
         <ClaimOverlay actions={actions} gameState={gameState} onAction={handleAction} />

--- a/packages/shared/src/types/events.ts
+++ b/packages/shared/src/types/events.ts
@@ -114,6 +114,17 @@ export interface ClientEvents {
   quickStart: (playerName: string) => void;
 }
 
+export interface PlayerDisconnectedEvent {
+  playerIndex: number;
+  playerName: string;
+  timeoutMs: number;
+}
+
+export interface PlayerReconnectedEvent {
+  playerIndex: number;
+  playerName: string;
+}
+
 export interface ServerEvents {
   roomCreated: (roomId: string) => void;
   roomJoined: (roomState: RoomState) => void;
@@ -126,6 +137,6 @@ export interface ServerEvents {
   gameOver: (result: GameOverResult) => void;
   error: (message: string) => void;
   playerIdAssigned: (playerId: string) => void;
-  playerDisconnected: (playerIndex: number) => void;
-  playerReconnected: (playerIndex: number) => void;
+  playerDisconnected: (event: PlayerDisconnectedEvent) => void;
+  playerReconnected: (event: PlayerReconnectedEvent) => void;
 }

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -52,4 +52,6 @@ export type {
   CumulativeData,
   ClientEvents,
   ServerEvents,
+  PlayerDisconnectedEvent,
+  PlayerReconnectedEvent,
 } from './events.js';


### PR DESCRIPTION
Currently useSocket.ts is bare-bones — just tracks connected state with no reconnection UX. When a player disconnects mid-game there is no visual indicator to other players, no auto-reconnect with game state restoration, no grace period UI, and no connection status banner.

Scope:
- Server: 30-second grace period before seat is abandoned (room.ts already has RECONNECT_TIMEOUT_MS=60s and disconnectTimers). Broadcast disconnect/reconnect events to other players.
- Client: ConnectionStatus component showing reconnect banner with countdown when disconnected. Toast/notification to other players when someone disconnects/reconnects.
- useSocket.ts: Add reconnection state management, auto-rejoin logic, connection quality indicator.
- App.tsx: Show connection status overlay during reconnection attempts.

Files: apps/web/src/hooks/useSocket.ts, apps/web/src/App.tsx, apps/server/src/handlers/roomHandlers.ts, apps/server/src/room.ts, new ConnectionStatus component

Closes #173