### PR TITLE
Fix landscape viewport fill and overflow on Lobby Room and Game

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -4,10 +4,16 @@
   box-sizing: border-box;
 }
 
+html {
+  width: 100%;
+  height: 100%;
+}
+
 body {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   background: var(--color-bg-dark);
   color: var(--color-text-primary);
+  width: 100%;
   min-height: 100vh;
   min-height: 100dvh;
   display: flex;
@@ -43,6 +49,7 @@ body {
 }
 
 #root {
+  width: 100%;
   display: flex;
   flex-direction: column;
   flex: 1;
@@ -169,6 +176,21 @@ body {
   }
 }
 
+/* Landscape compact layout for lobby/room */
+@media (orientation: landscape) and (max-height: 500px) {
+  .lobby-page, .room-page {
+    padding: 16px 20px;
+  }
+  .lobby-page h1 { font-size: 24px; }
+  .lobby-page h2 { font-size: 13px; }
+  .lobby-page input, .lobby-page button,
+  .room-page input, .room-page button {
+    min-height: 36px;
+    padding: 6px 12px;
+  }
+  .lobby-page hr, .room-page hr { margin: 8px 0; }
+}
+
 /* Game area gets felt table background */
 .game-table {
   background: radial-gradient(ellipse at center, var(--color-bg-card) 0%, var(--color-bg-medium) 60%, #082818 100%);
@@ -247,6 +269,7 @@ hr {
 
 /* Lobby/Room pages keep dark theme */
 .lobby-page, .room-page {
+  width: 100%;
   background: var(--color-bg-dark);
   min-height: 100vh;
   min-height: 100dvh;
@@ -362,8 +385,6 @@ button.lobby-create-btn:hover:not(:disabled) {
 
 @media (min-width: 1440px) {
   .lobby-page, .room-page {
-    max-width: 720px;
-    margin: 0 auto;
     padding: 60px 40px;
   }
 

--- a/apps/web/src/pages/Lobby.tsx
+++ b/apps/web/src/pages/Lobby.tsx
@@ -55,7 +55,8 @@ export function Lobby({ onJoined }: LobbyProps) {
   };
 
   return (
-    <div className="lobby-page" style={{ maxWidth: 560, margin: "0 auto", padding: "40px 20px", display: "flex", flexDirection: "column", gap: 20 }}>
+    <div className="lobby-page" style={{ display: "flex", justifyContent: "center", padding: "40px 20px" }}>
+    <div style={{ maxWidth: 560, width: "100%", display: "flex", flexDirection: "column", gap: 20 }}>
       <div style={{ textAlign: "center", marginBottom: 8 }}>
         <h1 style={{ fontSize: 36, color: "var(--color-text-primary)", marginBottom: 4 }}>福州麻将</h1>
         <h2 style={{ fontSize: 16, color: "var(--color-text-secondary)", fontWeight: 400 }}>Fuzhou Mahjong</h2>
@@ -160,6 +161,7 @@ export function Lobby({ onJoined }: LobbyProps) {
       </div>
 
       {error && <p className="error-msg">{error}</p>}
+    </div>
     </div>
   );
 }

--- a/apps/web/src/pages/Room.tsx
+++ b/apps/web/src/pages/Room.tsx
@@ -46,7 +46,8 @@ export function Room({ initialRoomState }: RoomProps) {
   });
 
   return (
-    <div className="room-page" style={{ maxWidth: 480, margin: "0 auto", padding: "40px 20px" }}>
+    <div className="room-page" style={{ display: "flex", justifyContent: "center", padding: "40px 20px" }}>
+    <div style={{ maxWidth: 480, width: "100%" }}>
       <h2 style={{ textAlign: "center", color: "var(--color-text-secondary)", fontSize: 15, fontWeight: 400, marginBottom: 20 }}>房间 / Room</h2>
 
       {/* Mahjong table seat layout */}
@@ -114,6 +115,7 @@ export function Room({ initialRoomState }: RoomProps) {
           离开 / Leave
         </Button>
       </div>
+    </div>
     </div>
   );
 }


### PR DESCRIPTION
紧急：iPhone横屏(844x390)下Lobby页面没有填满视口，左右大片灰色空白，内容被截断。

问题：
1. Lobby/Room根容器没有width:100vw，没铺满屏幕
2. html/body/#root可能缺少min-height:100vh/margin:0设置
3. 横屏390px高度内容纵向溢出但没有滚动
4. 输入框和按钮在横屏时太大
5. GameTable同样需要检查

修复标准：
- 所有页面铺满整个视口，无灰色空白
- 横屏时内容不溢出，必要时缩小或启用滚动
- 测试844x390和667x375

Closes #187