### PR TITLE
Add accurate server-side wall position tracking for draw and supplement

### DIFF
--- a/apps/server/src/gameState.ts
+++ b/apps/server/src/gameState.ts
@@ -25,6 +25,8 @@ export class ServerGameState {
   botIndices: Set<number> = new Set();
   lastDrawnTileIds: (number | null)[] = [null, null, null, null];
   firstActionTaken = false;
+  initialWallLength = 0;
+  initialWallTailLength = 0;
 
   constructor(roomId: string, playerSocketIds: string[], playerNames?: string[], botIndices?: number[], dealerIndex?: number, lianZhuangCount?: number) {
     this.roomId = roomId;
@@ -70,6 +72,9 @@ export class ServerGameState {
     for (const p of players) {
       p.hand = sortHand(p.hand, goldResult.gold);
     }
+
+    this.initialWallLength = remainingWall.length;
+    this.initialWallTailLength = goldResult.wallTail.length;
 
     this.state = {
       wall: remainingWall,
@@ -135,6 +140,8 @@ export class ServerGameState {
       lianZhuangCount: state.lianZhuangCount,
       gold: state.gold,
       wallRemaining: state.wall.length + state.wallTail.length,
+      wallDrawCount: this.initialWallLength - state.wall.length,
+      wallSupplementCount: this.initialWallTailLength - state.wallTail.length,
       lastDiscard: state.lastDiscard,
       tenpaiTiles: findTenpaiTiles(myPlayer.hand, myPlayer.melds, state.gold),
       lastDrawnTileId: this.lastDrawnTileIds[playerIndex],

--- a/apps/web/src/components/GameTable.tsx
+++ b/apps/web/src/components/GameTable.tsx
@@ -89,7 +89,7 @@ export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTile
 
       {/* Center - game info */}
       <div className="table-center-area" style={{ gridArea: "center", display: "flex", alignItems: "center", justifyContent: "center", position: "relative", zIndex: 1 }}>
-        <TileWall wallRemaining={wallRemaining} gold={gold} canDraw={canDraw} onDraw={onDraw} />
+        <TileWall wallRemaining={wallRemaining} wallDrawCount={state.wallDrawCount} wallSupplementCount={state.wallSupplementCount} gold={gold} canDraw={canDraw} onDraw={onDraw} />
         <GameInfo
           gold={null}
           wallRemaining={wallRemaining}

--- a/apps/web/src/components/TileWall.tsx
+++ b/apps/web/src/components/TileWall.tsx
@@ -5,6 +5,8 @@ import { TILE_BACK_URL } from "../tileSvg";
 
 interface TileWallProps {
   wallRemaining: number;
+  wallDrawCount: number;
+  wallSupplementCount: number;
   gold: GoldState | null;
   canDraw?: boolean;
   onDraw?: () => void;
@@ -16,28 +18,24 @@ const TOTAL_STACKS = STACKS_PER_SIDE * 4;
 interface StackState { hasUpper: boolean; hasLower: boolean; }
 
 /**
- * Given wallRemaining, compute which stacks still have tiles.
+ * Given actual draw and supplement counts from the server,
+ * compute which stacks still have tiles.
  * Draw end depletes from head (stack 0 forward), supplement from tail (stack 71 backward).
- * Roughly 85% drawn from head, 15% supplement from tail.
  */
-function computeWallStacks(wallRemaining: number): StackState[][] {
-  const tilesGone = 144 - wallRemaining;
+function computeWallStacks(drawCount: number, supplementCount: number): StackState[][] {
   const stacks: StackState[] = Array.from({ length: TOTAL_STACKS }, () => ({
     hasUpper: true, hasLower: true,
   }));
 
-  const supplementRemoved = Math.min(Math.floor(tilesGone * 0.15), tilesGone);
-  const drawRemoved = tilesGone - supplementRemoved;
-
   // Remove from draw end (head): upper first at each stack, then lower
-  let rem = drawRemoved;
+  let rem = drawCount;
   for (let i = 0; i < TOTAL_STACKS && rem > 0; i++) {
     if (stacks[i].hasUpper) { stacks[i].hasUpper = false; rem--; }
     if (rem > 0 && stacks[i].hasLower) { stacks[i].hasLower = false; rem--; }
   }
 
   // Remove from supplement end (tail): upper first, then lower
-  rem = supplementRemoved;
+  rem = supplementCount;
   for (let i = TOTAL_STACKS - 1; i >= 0 && rem > 0; i--) {
     if (stacks[i].hasUpper) { stacks[i].hasUpper = false; rem--; }
     if (rem > 0 && stacks[i].hasLower) { stacks[i].hasLower = false; rem--; }
@@ -174,8 +172,8 @@ function WallSegment({ side, stacks, drawStack, canDraw, onDraw }: {
   );
 }
 
-export function TileWall({ wallRemaining, gold, canDraw, onDraw }: TileWallProps) {
-  const sides = useMemo(() => computeWallStacks(wallRemaining), [wallRemaining]);
+export function TileWall({ wallRemaining, wallDrawCount, wallSupplementCount, gold, canDraw, onDraw }: TileWallProps) {
+  const sides = useMemo(() => computeWallStacks(wallDrawCount, wallSupplementCount), [wallDrawCount, wallSupplementCount]);
   const drawIndex = useMemo(() => findDrawStackIndex(sides), [sides]);
 
   return (

--- a/packages/shared/src/types/events.ts
+++ b/packages/shared/src/types/events.ts
@@ -37,6 +37,8 @@ export interface ClientGameState {
   lianZhuangCount: number;
   gold: GoldState | null;
   wallRemaining: number;
+  wallDrawCount: number;
+  wallSupplementCount: number;
   lastDiscard: { tile: TileInstance; playerIndex: number } | null;
   tenpaiTiles: import('../types/tile.js').SuitedTile[];
   lastDrawnTileId: number | null;


### PR DESCRIPTION
TileWall uses a fake 85/15 draw/supplement split heuristic. The server knows exact positions but only sends wallRemaining number.

Fix:
- Server: track drawHead and supplementTail indices in wall state
- Send these to clients in gameStateUpdate alongside wallRemaining
- Client TileWall: use actual indices in computeWallStacks instead of estimate
- Touches: gameState.ts (server), shared types, TileWall.tsx (client)

Spec requirement: 每次摸牌/补牌后牌墙实时更新，玩家能直观看到哪里被摸走了

Closes #193