### PR TITLE
Add wall-to-hand draw and supplement tile animations

### DIFF
--- a/apps/web/src/animations.css
+++ b/apps/web/src/animations.css
@@ -269,6 +269,46 @@
   100% { opacity: 0; transform: translate(-50%, -50%) scale(0.5) translateY(20px); }
 }
 
+/* Wall-to-hand draw fly animations */
+@keyframes drawFlyBottom {
+  0% { transform: translate(0, 0) scale(1); opacity: 1; }
+  100% { transform: translate(0, 120px) scale(1.2); opacity: 0; }
+}
+@keyframes drawFlyTop {
+  0% { transform: translate(0, 0) scale(1); opacity: 1; }
+  100% { transform: translate(0, -120px) scale(0.8); opacity: 0; }
+}
+@keyframes drawFlyLeft {
+  0% { transform: translate(0, 0) scale(1); opacity: 1; }
+  100% { transform: translate(-120px, 0) scale(0.8); opacity: 0; }
+}
+@keyframes drawFlyRight {
+  0% { transform: translate(0, 0) scale(1); opacity: 1; }
+  100% { transform: translate(120px, 0) scale(0.8); opacity: 0; }
+}
+
+/* Supplement draw variant — slightly different path with glow */
+@keyframes supplementFlyBottom {
+  0% { transform: translate(0, 0) scale(1); opacity: 1; filter: brightness(1); }
+  50% { filter: brightness(1.5); }
+  100% { transform: translate(0, 120px) scale(1.2); opacity: 0; filter: brightness(1); }
+}
+@keyframes supplementFlyTop {
+  0% { transform: translate(0, 0) scale(1); opacity: 1; filter: brightness(1); }
+  50% { filter: brightness(1.5); }
+  100% { transform: translate(0, -120px) scale(0.8); opacity: 0; filter: brightness(1); }
+}
+@keyframes supplementFlyLeft {
+  0% { transform: translate(0, 0) scale(1); opacity: 1; filter: brightness(1); }
+  50% { filter: brightness(1.5); }
+  100% { transform: translate(-120px, 0) scale(0.8); opacity: 0; filter: brightness(1); }
+}
+@keyframes supplementFlyRight {
+  0% { transform: translate(0, 0) scale(1); opacity: 1; filter: brightness(1); }
+  50% { filter: brightness(1.5); }
+  100% { transform: translate(120px, 0) scale(0.8); opacity: 0; filter: brightness(1); }
+}
+
 /* Tutorial slide transition */
 @keyframes tutorialSlideIn {
   0% { opacity: 0; transform: translateX(16px); }

--- a/apps/web/src/components/GameTable.tsx
+++ b/apps/web/src/components/GameTable.tsx
@@ -2,6 +2,15 @@ import type { ClientGameState, TileInstance } from "@fuzhou-mahjong/shared";
 import { PlayerArea } from "./PlayerArea";
 import { GameInfo } from "./GameInfo";
 import { TileWall } from "./TileWall";
+import { TILE_BACK_URL } from "../tileSvg";
+
+export type DrawAnimationSeat = "bottom" | "top" | "left" | "right";
+
+export interface DrawAnimationState {
+  seat: DrawAnimationSeat;
+  isSupplement: boolean;
+  key: number; // unique key to re-trigger animation
+}
 
 interface GameTableProps {
   state: ClientGameState;
@@ -20,9 +29,10 @@ interface GameTableProps {
   onBuGang?: (tileInstanceId: number) => void;
   onBackgroundClick?: () => void;
   disconnectedPlayers?: Set<number>;
+  drawAnimation?: DrawAnimationState | null;
 }
 
-export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTileId, claimableTileIds, canDiscard, onDiscard, canHu, onHu, canDraw, onDraw, kongTileIds, onAnGang, onBuGang, onBackgroundClick, disconnectedPlayers }: GameTableProps) {
+export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTileId, claimableTileIds, canDiscard, onDiscard, canHu, onHu, canDraw, onDraw, kongTileIds, onAnGang, onBuGang, onBackgroundClick, disconnectedPlayers, drawAnimation }: GameTableProps) {
   const { myHand, myFlowers, myMelds, myDiscards, myName, otherPlayers, currentTurn, myIndex, gold, dealerIndex, lianZhuangCount, wallRemaining, myHasDiscardedGold } = state;
   const lastDiscardTileId = state.lastDiscard?.tile.id ?? null;
   const lastDiscardPlayerIndex = state.lastDiscard?.playerIndex ?? -1;
@@ -148,6 +158,38 @@ export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTile
           tenpaiTiles={(state as any).tenpaiTiles}
         />
       </div>
+
+      {/* Draw fly animation overlay */}
+      {drawAnimation && (
+        <div
+          key={drawAnimation.key}
+          style={{
+            position: "absolute",
+            top: "50%",
+            left: "50%",
+            marginTop: -8,
+            marginLeft: -6,
+            pointerEvents: "none",
+            zIndex: 20,
+            animation: `${drawAnimation.isSupplement ? "supplementFly" : "drawFly"}${drawAnimation.seat.charAt(0).toUpperCase() + drawAnimation.seat.slice(1)} ${drawAnimation.seat === "bottom" ? "0.3s" : "0.2s"} ease-out forwards`,
+          }}
+        >
+          <img
+            src={TILE_BACK_URL}
+            alt=""
+            style={{
+              width: "var(--wall-tw)",
+              height: "var(--wall-th)",
+              display: "block",
+              borderRadius: 2,
+              boxShadow: drawAnimation.isSupplement
+                ? "0 0 8px rgba(255,215,0,0.6)"
+                : "0 1px 4px rgba(0,0,0,0.4)",
+            }}
+            draggable={false}
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/pages/Game.tsx
+++ b/apps/web/src/pages/Game.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { socket } from "../socket";
-import { GameTable } from "../components/GameTable";
+import { GameTable, type DrawAnimationState, type DrawAnimationSeat } from "../components/GameTable";
 import { ClaimOverlay } from "../components/ClaimOverlay";
 import { CenterAction, useCenterAction } from "../components/CenterAction";
 import { sounds, setMuted, isMuted } from "../sounds";
@@ -71,6 +71,8 @@ export function Game({ initialGameState, onLeave }: GameProps) {
   };
   const [showTutorial, setShowTutorial] = useState(false);
   const [tutorialCondensed, setTutorialCondensed] = useState(false);
+  const [drawAnimation, setDrawAnimation] = useState<DrawAnimationState | null>(null);
+  const drawAnimKeyRef = useRef(0);
 
   // First-game auto-show tutorial
   useEffect(() => {
@@ -109,6 +111,23 @@ export function Game({ initialGameState, onLeave }: GameProps) {
       // Detect draw: my hand grew without a new meld
       if (prev && state.myHand.length > prev.myHand.length && state.myMelds.length === prev.myMelds.length) {
         sounds.draw();
+      }
+
+      // Detect wall draw/supplement for fly animation
+      if (prev) {
+        const drawDelta = state.wallDrawCount - prev.wallDrawCount;
+        const suppDelta = state.wallSupplementCount - prev.wallSupplementCount;
+        if (drawDelta > 0 || suppDelta > 0) {
+          const isSupplement = suppDelta > 0;
+          // Determine which seat drew: currentTurn is the player who just drew
+          const relIdx = (state.currentTurn - state.myIndex + 4) % 4;
+          const seatMap: DrawAnimationSeat[] = ["bottom", "right", "top", "left"];
+          const seat = seatMap[relIdx];
+          const key = ++drawAnimKeyRef.current;
+          setDrawAnimation({ seat, isSupplement, key });
+          const duration = seat === "bottom" ? 300 : 200;
+          setTimeout(() => setDrawAnimation((cur) => cur?.key === key ? null : cur), duration);
+        }
       }
 
       // Detect new meld: total melds increased
@@ -497,6 +516,7 @@ export function Game({ initialGameState, onLeave }: GameProps) {
         }}
         onBackgroundClick={() => setSelectedTileId(null)}
         disconnectedPlayers={disconnectedPlayers}
+        drawAnimation={drawAnimation}
       />
       {isClaimWindow && actions && (
         <ClaimOverlay actions={actions} gameState={gameState} onAction={handleAction} />


### PR DESCRIPTION
Tiles vanish from wall with no animation when drawn. Spec says: 所有状态变化必须有流畅的动画过渡.

Scope:
1. Draw animation: face-down tile slides from wall draw position to player hand, ~300ms ease-out, then reveals as new tile
2. Supplement animation: same but from wall tail end, visually distinct path
3. Other players draws: brief tile-leaving-wall animation toward their seat area (~200ms)
4. 60fps CSS transforms only (translate, scale)

Files: TileWall.tsx, PlayerArea.tsx, animations.css, GameTable.tsx for coordinate mapping

Closes #198