### PR TITLE
Compress opponent PlayerArea on mobile landscape to eliminate scrolling

### DIFF
--- a/apps/web/src/components/GameTable.tsx
+++ b/apps/web/src/components/GameTable.tsx
@@ -3,6 +3,7 @@ import { PlayerArea } from "./PlayerArea";
 import { GameInfo } from "./GameInfo";
 import { TileWall } from "./TileWall";
 import { TILE_BACK_URL } from "../tileSvg";
+import { useIsCompactLandscape } from "../hooks/useIsMobile";
 
 export type DrawAnimationSeat = "bottom" | "top" | "left" | "right";
 
@@ -33,6 +34,7 @@ interface GameTableProps {
 }
 
 export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTileId, claimableTileIds, canDiscard, onDiscard, canHu, onHu, canDraw, onDraw, kongTileIds, onAnGang, onBuGang, onBackgroundClick, disconnectedPlayers, drawAnimation }: GameTableProps) {
+  const isCompact = useIsCompactLandscape();
   const { myHand, myFlowers, myMelds, myDiscards, myName, otherPlayers, currentTurn, myIndex, gold, dealerIndex, lianZhuangCount, wallRemaining, myHasDiscardedGold } = state;
   const lastDiscardTileId = state.lastDiscard?.tile.id ?? null;
   const lastDiscardPlayerIndex = state.lastDiscard?.playerIndex ?? -1;
@@ -76,6 +78,7 @@ export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTile
           lastDiscardedTileId={lastDiscardPlayerIndex === (myIndex + 2) % 4 ? lastDiscardTileId : null}
           hasDiscardedGold={otherPlayers[1]?.hasDiscardedGold}
           isDisconnected={disconnectedPlayers?.has((myIndex + 2) % 4)}
+          compact={isCompact}
         />
       </div>
 
@@ -94,6 +97,7 @@ export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTile
           lastDiscardedTileId={lastDiscardPlayerIndex === (myIndex + 3) % 4 ? lastDiscardTileId : null}
           hasDiscardedGold={otherPlayers[2]?.hasDiscardedGold}
           isDisconnected={disconnectedPlayers?.has((myIndex + 3) % 4)}
+          compact={isCompact}
         />
       </div>
 
@@ -126,6 +130,7 @@ export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTile
           lastDiscardedTileId={lastDiscardPlayerIndex === (myIndex + 1) % 4 ? lastDiscardTileId : null}
           hasDiscardedGold={otherPlayers[0]?.hasDiscardedGold}
           isDisconnected={disconnectedPlayers?.has((myIndex + 1) % 4)}
+          compact={isCompact}
         />
       </div>
 

--- a/apps/web/src/components/PlayerArea.tsx
+++ b/apps/web/src/components/PlayerArea.tsx
@@ -32,6 +32,7 @@ interface PlayerAreaProps {
   onBuGang?: (tileInstanceId: number) => void;
   hasDiscardedGold?: boolean;
   isDisconnected?: boolean;
+  compact?: boolean;
 }
 
 const BUBBLE_BTN = {
@@ -46,7 +47,7 @@ export function PlayerArea({
   isCurrentTurn, isDealer, gold, selectedTileId, onTileClick, label,
   claimableTileIds, onTileDoubleClick, lastDrawnTileId, lastDiscardedTileId, tenpaiTiles,
   canDiscard, onDiscard, canHu, onHu, kongTileIds, onAnGang, onBuGang, hasDiscardedGold,
-  isDisconnected,
+  isDisconnected, compact,
 }: PlayerAreaProps) {
   const { onTouchStart: lpTouchStart, onTouchEnd: lpTouchEnd, onMouseEnter, onMouseLeave, Tooltip } = useLongPress(gold);
 
@@ -80,6 +81,74 @@ export function PlayerArea({
     enabled: !!canDiscard,
     threshold: 40,
   });
+
+  // Compact single-row layout for opponents on mobile landscape
+  if (compact) {
+    return (
+      <div
+        className={`player-area-card${isCurrentTurn ? " current-turn" : ""} compact-opponent`}
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 6,
+          padding: "2px 8px",
+          background: isCurrentTurn ? "rgba(255,255,255,0.08)" : "rgba(0,0,0,0.3)",
+          border: isCurrentTurn ? "2px solid #ffd700" : undefined,
+          borderRadius: 4,
+          borderLeft: isCurrentTurn ? "3px solid #ffd700" : "3px solid transparent",
+          opacity: isDisconnected ? 0.5 : 1,
+          overflow: "hidden",
+          minHeight: 0,
+        }}
+      >
+        {/* Name + badges */}
+        <span style={{ fontSize: "var(--label-font)", fontWeight: "bold", color: "#e8d5a3", whiteSpace: "nowrap", flexShrink: 0 }}>
+          {label}
+        </span>
+        {isDealer && <span style={{ fontSize: 9, background: "#b71c1c", color: "#ffd700", padding: "0 4px", borderRadius: 3, fontWeight: "bold", flexShrink: 0 }}>庄</span>}
+        {isDisconnected && <span style={{ fontSize: 9, background: "#ff5722", color: "#fff", padding: "0 4px", borderRadius: 3, fontWeight: "bold", flexShrink: 0 }}>断线</span>}
+        {hasDiscardedGold && <span style={{ fontSize: 9, background: "#c41e3a", color: "#fff", padding: "0 4px", borderRadius: 3, fontWeight: "bold", flexShrink: 0 }}>弃金</span>}
+        {isCurrentTurn && <span style={{ fontSize: 9, background: "rgba(255,215,0,0.2)", color: "#ffd700", padding: "0 4px", borderRadius: 3, border: "1px solid #ffd700", flexShrink: 0 }}>出牌</span>}
+
+        {/* Hand count */}
+        <span style={{ fontSize: 11, color: "#8fbc8f", flexShrink: 0 }}>{handCount ?? 0}张</span>
+
+        {/* Melds (small tiles inline) */}
+        {melds.length > 0 && (
+          <div style={{ display: "flex", gap: 4, flexShrink: 0 }}>
+            {melds.map((m, mi) => (
+              <div key={mi} style={{ display: "flex", gap: 0 }}>
+                {m.tiles.map((t, ti) => (
+                  <TileView key={ti} tile={t} faceUp={m.type !== MeldType.AnGang} gold={gold} small />
+                ))}
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Discards (tiny, single row, scrollable) */}
+        {discards.length > 0 && (
+          <div className="compact-discards" style={{
+            display: "flex",
+            gap: 1,
+            overflowX: "auto",
+            overflowY: "hidden",
+            flex: 1,
+            minWidth: 0,
+          }}>
+            {discards.map((d) => (
+              <TileView key={d.id} tile={d} faceUp gold={gold} small
+                className={lastDiscardedTileId === d.id ? "discard-arrive" : undefined}
+              />
+            ))}
+          </div>
+        )}
+
+        {/* Flower count */}
+        <span style={{ fontSize: 11, color: "#8fbc8f", flexShrink: 0, marginLeft: "auto" }}>🌸{flowers.length}</span>
+      </div>
+    );
+  }
 
   return (
     <>

--- a/apps/web/src/hooks/useIsMobile.ts
+++ b/apps/web/src/hooks/useIsMobile.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 
 const MOBILE_BREAKPOINT = 600;
+const COMPACT_HEIGHT_BREAKPOINT = 500;
 
 export function useIsMobile(): boolean {
   const [isMobile, setIsMobile] = useState(() => window.innerWidth <= MOBILE_BREAKPOINT);
@@ -12,4 +13,16 @@ export function useIsMobile(): boolean {
   }, []);
 
   return isMobile;
+}
+
+export function useIsCompactLandscape(): boolean {
+  const [isCompact, setIsCompact] = useState(() => window.innerHeight <= COMPACT_HEIGHT_BREAKPOINT);
+
+  useEffect(() => {
+    const onResize = () => setIsCompact(window.innerHeight <= COMPACT_HEIGHT_BREAKPOINT);
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, []);
+
+  return isCompact;
 }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -496,3 +496,12 @@ button.lobby-create-btn:hover:not(:disabled) {
 .chi-picker-scroll::-webkit-scrollbar {
   display: none; /* Chrome/Safari */
 }
+
+/* Compact opponent discards — hide scrollbar */
+.compact-discards {
+  scrollbar-width: none; /* Firefox */
+  -ms-overflow-style: none; /* IE/Edge */
+}
+.compact-discards::-webkit-scrollbar {
+  display: none; /* Chrome/Safari */
+}


### PR DESCRIPTION
最高优先级：手机横屏需要滚动是因为对手区域占太多空间。

问题根源：gridTemplateRows: auto 1fr auto — top/bottom PlayerArea 按内容撑开不会被压缩。对手的弃牌区、花牌区、副露区全部展开，加起来超出视口。

修复方案（不改架构，纯 responsive）：
1. 手机横屏时(max-height: 500px)，对手 PlayerArea 只显示紧凑信息：名字 + 手牌数 + 副露（单行），隐藏弃牌区和花牌详情
2. 用 useIsMobile hook 或 CSS media query 控制
3. 自己的底部 PlayerArea 保持完整展示
4. 牌墙在手机上缩小或简化
5. 目标：iPhone 12 Pro 横屏 (844x390) 零滚动，所有内容 fit 在视口内

Files: PlayerArea.tsx (conditional compact mode), GameTable.tsx (possible grid adjustment), index.css (landscape media queries)

Closes #201