### PR TITLE
Fix discard flow - tile selectable but bubble not appearing

### DIFF
--- a/apps/web/src/pages/Game.tsx
+++ b/apps/web/src/pages/Game.tsx
@@ -269,6 +269,11 @@ export function Game({ initialGameState, onLeave }: GameProps) {
     return ids;
   };
 
+  // Client-side safeguard: if actions were cleared by a race but it's our turn
+  // and no claim is pending, allow discard so the bubble still appears.
+  const effectiveCanDiscard = actions?.canDiscard
+    ?? (gameState !== null && gameState.currentTurn === gameState.myIndex && !pendingClaim);
+
   const isClaimWindow = actions
     ? (actions.canHu || actions.canPeng || actions.canMingGang || actions.chiOptions.length > 0) && !actions.canDiscard
     : false;
@@ -509,18 +514,18 @@ export function Game({ initialGameState, onLeave }: GameProps) {
         state={gameState}
         onTileSelect={(tile) => setSelectedTileId(tile?.id ?? null)}
         onTileDoubleClick={(tile) => {
-          if (actions?.canDiscard) {
+          if (effectiveCanDiscard) {
             handleAction({ type: ActionType.Discard, playerIndex: gameState.myIndex, tile });
           }
         }}
         selectedTileId={selectedTileId}
         claimableTileIds={getClaimableTileIds(actions)}
-        canDiscard={actions?.canDiscard ?? false}
+        canDiscard={effectiveCanDiscard}
         onDiscard={(tileInstanceId) => {
           const tile = gameState.myHand.find(t => t.id === tileInstanceId);
           if (tile) handleAction({ type: ActionType.Discard, playerIndex: gameState.myIndex, tile });
         }}
-        canHu={!!(actions?.canHu && actions?.canDiscard)}
+        canHu={!!(actions?.canHu && effectiveCanDiscard)}
         onHu={() => handleAction({ type: ActionType.Hu, playerIndex: gameState.myIndex })}
         canDraw={actions?.canDraw ?? false}
         onDraw={() => handleAction({ type: ActionType.Draw, playerIndex: gameState.myIndex })}


### PR DESCRIPTION
用户报告：能选中牌但出牌气泡不出现。需要全局检查出牌流程。

Symptom: Tile can be selected (highlighted) but the discard bubble button does not appear.

Possible causes to investigate:
1. handleTap double-tap logic (#108) may interfere — 300ms window might cause selectedTileId to toggle before bubble renders
2. canDiscard may not be set correctly in actions state
3. Swipe gesture touch handlers on outer div may consume click events on desktop
4. Race condition: gameStateUpdate may clear actions before user can interact
5. The onDoubleClick removal in #108 may have broken the click -> select -> bubble flow on web

Full audit needed:
- Trace the complete flow: click tile -> selectedTileId set -> showBubble evaluated -> bubble rendered -> click discard button -> onDiscard called
- Check if actions.canDiscard is true when it should be
- Check if selectedTileId stays set long enough for bubble to appear
- Test on both desktop (mouse click) and mobile (touch)
- Check console for errors

Files: PlayerArea.tsx (handleTap, showBubble, swipe handlers), Game.tsx (actions state, selectedTileId), useSwipeGesture.ts

Closes #205