### PR TITLE
Add server-side discard validation error feedback and resync

### DIFF
--- a/apps/server/src/gameEngine.ts
+++ b/apps/server/src/gameEngine.ts
@@ -139,12 +139,17 @@ export function handlePlayerAction(
     playerIndex = botPlayerIndex;
     room = findRoom(game.roomId);
     if (!room) return;
+    // Bots don't need error feedback
   } else {
     // Human action: resolve by socket ID
     room = findRoomBySocket(socketIdOrRoomId);
     if (!room) return;
     game = getGame(room.id);
-    if (!game || game.state.phase !== GamePhase.Playing) return;
+    if (!game || game.state.phase !== GamePhase.Playing) {
+      const socket = io.sockets.sockets.get(socketIdOrRoomId);
+      socket?.emit('actionError', { message: 'Invalid game phase', code: 'WRONG_PHASE' });
+      return;
+    }
     playerIndex = game.getPlayerIndex(socketIdOrRoomId);
     if (playerIndex === -1) return;
   }
@@ -158,7 +163,13 @@ export function handlePlayerAction(
 
   // Direct actions (during player's own turn)
   const state = game.state;
-  if (state.currentTurn !== playerIndex) return;
+  if (state.currentTurn !== playerIndex) {
+    if (botPlayerIndex === undefined) {
+      const socket = io.sockets.sockets.get(socketIdOrRoomId);
+      socket?.emit('actionError', { message: 'Not your turn', code: 'WRONG_TURN' });
+    }
+    return;
+  }
 
   switch (action.type) {
     case ActionType.Discard:
@@ -192,7 +203,12 @@ function handleDiscard(
 
   // Remove tile from hand
   const tileIdx = player.hand.findIndex((t) => t.id === tile.id);
-  if (tileIdx === -1) return;
+  if (tileIdx === -1) {
+    const socketId = game.getSocketId(playerIndex);
+    const socket = io.sockets.sockets.get(socketId);
+    socket?.emit('actionError', { message: 'Tile not found in hand', code: 'TILE_NOT_FOUND' });
+    return;
+  }
   player.hand.splice(tileIdx, 1);
   player.discards.push(tile);
   state.lastDiscard = { tile, playerIndex };

--- a/apps/server/src/handlers/gameHandlers.ts
+++ b/apps/server/src/handlers/gameHandlers.ts
@@ -1,6 +1,8 @@
 import type { Server, Socket } from "socket.io";
 import type { ClientEvents, ServerEvents, GameAction } from "@fuzhou-mahjong/shared";
 import { handlePlayerAction } from "../gameEngine.js";
+import { findRoomBySocket } from "../room.js";
+import { getGame } from "../gameState.js";
 
 type GameSocket = Socket<ClientEvents, ServerEvents>;
 type GameServer = Server<ClientEvents, ServerEvents>;
@@ -8,5 +10,15 @@ type GameServer = Server<ClientEvents, ServerEvents>;
 export function registerGameHandlers(io: GameServer, socket: GameSocket): void {
   socket.on("playerAction", (action: GameAction) => {
     handlePlayerAction(io, socket.id, action);
+  });
+
+  socket.on("resyncState", () => {
+    const room = findRoomBySocket(socket.id);
+    if (!room) return;
+    const game = getGame(room.id);
+    if (!game) return;
+    const idx = game.getPlayerIndex(socket.id);
+    if (idx === -1) return;
+    socket.emit("gameStateUpdate", game.getClientGameState(idx));
   });
 }

--- a/apps/web/src/pages/Game.tsx
+++ b/apps/web/src/pages/Game.tsx
@@ -219,6 +219,10 @@ export function Game({ initialGameState, onLeave }: GameProps) {
       });
       addToast(`${event.playerName} 已重连 / reconnected`);
     });
+    socket.on("actionError", (error: { message: string; code: string }) => {
+      addToast(`操作失败: ${error.message}`);
+      socket.emit("resyncState");
+    });
 
     return () => {
       socket.off("gameStateUpdate");
@@ -226,6 +230,7 @@ export function Game({ initialGameState, onLeave }: GameProps) {
       socket.off("gameOver");
       socket.off("playerDisconnected");
       socket.off("playerReconnected");
+      socket.off("actionError");
     };
   }, []);
 

--- a/packages/shared/src/types/events.ts
+++ b/packages/shared/src/types/events.ts
@@ -109,6 +109,7 @@ export interface ClientEvents {
   listRooms: () => void;
   startGame: () => void;
   playerAction: (action: GameAction) => void;
+  resyncState: () => void;
   rejoinGame: (playerId: string) => void;
   nextRound: () => void;
   addBot: () => void;
@@ -137,6 +138,7 @@ export interface ServerEvents {
   actionRequired: (availableActions: AvailableActions) => void;
   actionResult: (result: ActionResult) => void;
   gameOver: (result: GameOverResult) => void;
+  actionError: (error: { message: string; code: string }) => void;
   error: (message: string) => void;
   playerIdAssigned: (playerId: string) => void;
   playerDisconnected: (event: PlayerDisconnectedEvent) => void;


### PR DESCRIPTION
gameEngine.ts silently returns when discard fails (tile not found, wrong turn, etc). Client has no feedback and gets stuck.

Scope:
1. Server: emit actionError event on silent-return paths in handleDiscard, handleAction etc
2. Client: listen for actionError, show toast notification
3. Add resyncState mechanism: on error, client requests fresh game state
4. Cover: tile not found, wrong turn, invalid phase

Files: apps/server/src/gameEngine.ts, apps/web/src/pages/Game.tsx, packages/shared/src/types/events.ts

Closes #206