### PR TITLE
Quick start should not require name input

### DIFF
--- a/apps/web/src/pages/Lobby.tsx
+++ b/apps/web/src/pages/Lobby.tsx
@@ -35,10 +35,10 @@ export function Lobby({ onJoined }: LobbyProps) {
   }, [onJoined]);
 
   const handleQuickStart = () => {
-    if (!name.trim()) return;
+    const playerName = name.trim() || `玩家${Math.floor(1000 + Math.random() * 9000)}`;
     setError("");
     setQuickStarting(true);
-    socket.emit("quickStart", name.trim());
+    socket.emit("quickStart", playerName);
   };
 
   const handleCreate = () => {
@@ -78,7 +78,7 @@ export function Lobby({ onJoined }: LobbyProps) {
         variant="gold"
         size="lg"
         onClick={handleQuickStart}
-        disabled={!name.trim() || quickStarting}
+        disabled={quickStarting}
         className="lobby-create-btn"
         style={{ width: "100%", background: "linear-gradient(135deg, var(--color-bg-button) 0%, #2a6f4a 100%)", border: "2px solid rgba(212, 160, 23, 0.8)", boxShadow: "0 0 12px rgba(212, 160, 23, 0.3)" }}
       >


### PR DESCRIPTION
用户反馈：快速开始不应该要求输入名字。

当前 Lobby.tsx 的快速开始按钮在 name 为空时是 disabled 的。应该改为：如果没输入名字，自动生成一个默认名字（如 玩家XXXX 或 Player + 随机4位数）直接开始。

Files: apps/web/src/pages/Lobby.tsx — remove name requirement for quick start, generate default name

Closes #209