### PR TITLE
Add in-game scoreboard and end-of-session summary modal

### DIFF
--- a/apps/server/src/gameState.ts
+++ b/apps/server/src/gameState.ts
@@ -8,6 +8,7 @@ import {
   sortHand,
   findTenpaiTiles,
 } from "@fuzhou-mahjong/shared";
+import { findRoom } from "./room.js";
 import type {
   GameState,
   PlayerState,
@@ -126,6 +127,8 @@ export class ServerGameState {
       });
     }
 
+    const cumulative = findRoom(this.roomId)?.getCumulativeData();
+
     return {
       phase: state.phase,
       myHand: myPlayer.hand,
@@ -146,6 +149,8 @@ export class ServerGameState {
       tenpaiTiles: findTenpaiTiles(myPlayer.hand, myPlayer.melds, state.gold),
       lastDrawnTileId: this.lastDrawnTileIds[playerIndex],
       myHasDiscardedGold: myPlayer.hasDiscardedGold,
+      cumulativeScores: cumulative?.scores ?? [0, 0, 0, 0],
+      roundsPlayed: cumulative?.roundsPlayed ?? 0,
     };
   }
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { useSocket } from "./hooks/useSocket";
 import { socket } from "./socket";
-import type { RoomState, ClientGameState } from "@fuzhou-mahjong/shared";
+import type { RoomState, ClientGameState, CumulativeData } from "@fuzhou-mahjong/shared";
 import { Lobby } from "./pages/Lobby";
 import { Room } from "./pages/Room";
 import { Game } from "./pages/Game";
@@ -18,6 +18,7 @@ export function App() {
   const [disconnectedAt, setDisconnectedAt] = useState<number | null>(null);
   const [initialRoomState, setInitialRoomState] = useState<RoomState | null>(null);
   const [initialGameState, setInitialGameState] = useState<ClientGameState | null>(null);
+  const [sessionScores, setSessionScores] = useState<CumulativeData | null>(null);
 
   // Store playerId when assigned
   useEffect(() => {
@@ -57,6 +58,9 @@ export function App() {
   useEffect(() => {
     const handler = (state: ClientGameState) => {
       setInitialGameState(state);
+      if (state.roundsPlayed > 0) {
+        setSessionScores({ scores: state.cumulativeScores, roundsPlayed: state.roundsPlayed });
+      }
       setReconnecting(false);
       setDisconnectedAt(null);
       setView("game");
@@ -99,9 +103,9 @@ export function App() {
       case "lobby":
         return <Lobby onJoined={(roomState) => { setInitialRoomState(roomState); setView("room"); }} />;
       case "room":
-        return <Room initialRoomState={initialRoomState} />;
+        return <Room initialRoomState={initialRoomState} sessionScores={sessionScores} />;
       case "game":
-        return <Game initialGameState={initialGameState} onLeave={() => { localStorage.removeItem(PLAYER_ID_KEY); setInitialGameState(null); setView("lobby"); }} />;
+        return <Game initialGameState={initialGameState} onLeave={() => { localStorage.removeItem(PLAYER_ID_KEY); setInitialGameState(null); setSessionScores(null); setView("lobby"); }} />;
     }
   })();
 

--- a/apps/web/src/animations.css
+++ b/apps/web/src/animations.css
@@ -309,6 +309,23 @@
   100% { transform: translate(120px, 0) scale(0.8); opacity: 0; filter: brightness(1); }
 }
 
+/* Score flash animation */
+@keyframes scoreFlash {
+  0% { opacity: 0; transform: translateY(4px) scale(0.9); }
+  30% { opacity: 1; transform: translateY(0) scale(1.1); }
+  100% { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+/* Session summary rank row entrance */
+@keyframes sessionRankRow {
+  0% { opacity: 0; transform: translateX(-12px); }
+  100% { opacity: 1; transform: translateX(0); }
+}
+
+.session-rank-row {
+  animation: sessionRankRow 0.3s ease-out both;
+}
+
 /* Tutorial slide transition */
 @keyframes tutorialSlideIn {
   0% { opacity: 0; transform: translateX(16px); }

--- a/apps/web/src/components/GameTable.tsx
+++ b/apps/web/src/components/GameTable.tsx
@@ -35,7 +35,7 @@ interface GameTableProps {
 
 export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTileId, claimableTileIds, canDiscard, onDiscard, canHu, onHu, canDraw, onDraw, kongTileIds, onAnGang, onBuGang, onBackgroundClick, disconnectedPlayers, drawAnimation }: GameTableProps) {
   const isCompact = useIsCompactLandscape();
-  const { myHand, myFlowers, myMelds, myDiscards, myName, otherPlayers, currentTurn, myIndex, gold, dealerIndex, lianZhuangCount, wallRemaining, myHasDiscardedGold } = state;
+  const { myHand, myFlowers, myMelds, myDiscards, myName, otherPlayers, currentTurn, myIndex, gold, dealerIndex, lianZhuangCount, wallRemaining, myHasDiscardedGold, cumulativeScores, roundsPlayed } = state;
   const lastDiscardTileId = state.lastDiscard?.tile.id ?? null;
   const lastDiscardPlayerIndex = state.lastDiscard?.playerIndex ?? -1;
   const botLabel = (name: string, isBot?: boolean) => isBot ? `${name} 🤖` : name;
@@ -79,6 +79,7 @@ export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTile
           hasDiscardedGold={otherPlayers[1]?.hasDiscardedGold}
           isDisconnected={disconnectedPlayers?.has((myIndex + 2) % 4)}
           compact={isCompact}
+          cumulativeScore={roundsPlayed > 0 ? cumulativeScores[(myIndex + 2) % 4] : undefined}
         />
       </div>
 
@@ -98,6 +99,7 @@ export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTile
           hasDiscardedGold={otherPlayers[2]?.hasDiscardedGold}
           isDisconnected={disconnectedPlayers?.has((myIndex + 3) % 4)}
           compact={isCompact}
+          cumulativeScore={roundsPlayed > 0 ? cumulativeScores[(myIndex + 3) % 4] : undefined}
         />
       </div>
 
@@ -132,6 +134,7 @@ export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTile
           hasDiscardedGold={otherPlayers[0]?.hasDiscardedGold}
           isDisconnected={disconnectedPlayers?.has((myIndex + 1) % 4)}
           compact={isCompact}
+          cumulativeScore={roundsPlayed > 0 ? cumulativeScores[(myIndex + 1) % 4] : undefined}
         />
       </div>
 
@@ -162,6 +165,7 @@ export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTile
           lastDrawnTileId={(state as any).lastDrawnTileId}
           lastDiscardedTileId={lastDiscardPlayerIndex === myIndex ? lastDiscardTileId : null}
           tenpaiTiles={(state as any).tenpaiTiles}
+          cumulativeScore={roundsPlayed > 0 ? cumulativeScores[myIndex] : undefined}
         />
       </div>
 

--- a/apps/web/src/components/PlayerArea.tsx
+++ b/apps/web/src/components/PlayerArea.tsx
@@ -33,6 +33,7 @@ interface PlayerAreaProps {
   hasDiscardedGold?: boolean;
   isDisconnected?: boolean;
   compact?: boolean;
+  cumulativeScore?: number;
 }
 
 const BUBBLE_BTN = {
@@ -47,7 +48,7 @@ export function PlayerArea({
   isCurrentTurn, isDealer, gold, selectedTileId, onTileClick, label,
   claimableTileIds, onTileDoubleClick, lastDrawnTileId, lastDiscardedTileId, tenpaiTiles,
   canDiscard, onDiscard, canHu, onHu, kongTileIds, onAnGang, onBuGang, hasDiscardedGold,
-  isDisconnected, compact,
+  isDisconnected, compact, cumulativeScore,
 }: PlayerAreaProps) {
   const { onTouchStart: lpTouchStart, onTouchEnd: lpTouchEnd, onMouseEnter, onMouseLeave, Tooltip } = useLongPress(gold);
 
@@ -146,6 +147,15 @@ export function PlayerArea({
 
         {/* Flower count */}
         <span style={{ fontSize: 11, color: "#8fbc8f", flexShrink: 0, marginLeft: "auto" }}>🌸{flowers.length}</span>
+        {cumulativeScore != null && (
+          <span className="cumulative-score-badge" style={{
+            fontSize: 11, fontWeight: "bold",
+            color: cumulativeScore > 0 ? "#ffd700" : cumulativeScore < 0 ? "#f44336" : "#8fbc8f",
+            padding: "1px 6px", borderRadius: 3, background: "rgba(0,0,0,0.3)",
+          }}>
+            {cumulativeScore > 0 ? "+" : ""}{cumulativeScore}
+          </span>
+        )}
       </div>
     );
   }
@@ -181,6 +191,15 @@ export function PlayerArea({
         <span style={{ fontSize: 11, color: "#8fbc8f", marginLeft: "auto" }}>
           🌸{flowers.length}
         </span>
+        {cumulativeScore != null && (
+          <span className="cumulative-score-badge" style={{
+            fontSize: 11, fontWeight: "bold",
+            color: cumulativeScore > 0 ? "#ffd700" : cumulativeScore < 0 ? "#f44336" : "#8fbc8f",
+            padding: "1px 6px", borderRadius: 3, background: "rgba(0,0,0,0.3)",
+          }}>
+            {cumulativeScore > 0 ? "+" : ""}{cumulativeScore}
+          </span>
+        )}
       </div>
 
       {/* Hand */}

--- a/apps/web/src/components/SessionSummary.tsx
+++ b/apps/web/src/components/SessionSummary.tsx
@@ -1,0 +1,165 @@
+import type { GameOverResult } from "@fuzhou-mahjong/shared";
+
+interface RoundRecord {
+  scores: number[];
+  winnerId: number | null;
+  winType: string;
+}
+
+export interface SessionData {
+  playerNames: string[];
+  cumulativeScores: number[];
+  roundsPlayed: number;
+  roundHistory: RoundRecord[];
+}
+
+interface SessionSummaryProps {
+  data: SessionData;
+  onClose: () => void;
+}
+
+const winTypeNames: Record<string, string> = {
+  normal: "普通胡", tianHu: "天胡", grabGold: "抢金",
+  pingHu0: "平胡(无花)", pingHu1: "平胡(一花)",
+  threeGoldDown: "三金倒", goldSparrow: "金雀", goldDragon: "金龙",
+  duiDuiHu: "对对胡", qingYiSe: "清一色", draw: "流局",
+};
+
+export function SessionSummary({ data, onClose }: SessionSummaryProps) {
+  const { playerNames, cumulativeScores, roundsPlayed, roundHistory } = data;
+
+  // Rankings sorted by cumulative score
+  const rankings = cumulativeScores
+    .map((score, i) => ({ name: playerNames[i] || `玩家${i}`, score, i }))
+    .sort((a, b) => b.score - a.score);
+
+  // MVP stats
+  const winCounts = [0, 0, 0, 0];
+  let highestRoundScore = -Infinity;
+  let highestRoundPlayer = 0;
+  for (const round of roundHistory) {
+    if (round.winnerId != null) winCounts[round.winnerId]++;
+    for (let i = 0; i < round.scores.length; i++) {
+      if (round.scores[i] > highestRoundScore) {
+        highestRoundScore = round.scores[i];
+        highestRoundPlayer = i;
+      }
+    }
+  }
+  const mostWinsIdx = winCounts.indexOf(Math.max(...winCounts));
+  const mostWins = winCounts[mostWinsIdx];
+
+  return (
+    <div style={{
+      position: "fixed", inset: 0, zIndex: 9999,
+      background: "rgba(0,0,0,0.85)",
+      display: "flex", alignItems: "center", justifyContent: "center",
+      animation: "pageFadeIn 0.3s ease-out",
+    }}>
+      <div style={{
+        background: "linear-gradient(135deg, #1a1a2e 0%, #16213e 100%)",
+        border: "1px solid rgba(255,215,0,0.3)",
+        borderRadius: 12,
+        padding: "24px 28px",
+        maxWidth: 440,
+        width: "90vw",
+        maxHeight: "85vh",
+        overflowY: "auto",
+        color: "#eee",
+      }}>
+        <h2 style={{ textAlign: "center", fontSize: 22, marginBottom: 4, color: "#ffd700" }}>
+          本场总结 / Session Summary
+        </h2>
+        <div style={{ textAlign: "center", fontSize: 13, color: "#8fbc8f", marginBottom: 16 }}>
+          共 {roundsPlayed} 局
+        </div>
+
+        {/* Final Rankings */}
+        <div style={{ marginBottom: 16 }}>
+          <div style={{ fontSize: 13, color: "#aaa", marginBottom: 6 }}>最终排名 / Final Rankings</div>
+          {rankings.map((p, rank) => (
+            <div key={p.i} className="session-rank-row" style={{
+              display: "flex", justifyContent: "space-between", alignItems: "center",
+              padding: "8px 14px", marginBottom: 4, borderRadius: 6,
+              background: rank === 0 ? "rgba(255,215,0,0.12)" : "rgba(255,255,255,0.04)",
+              border: rank === 0 ? "1px solid rgba(255,215,0,0.4)" : "1px solid transparent",
+            }}>
+              <span style={{ fontSize: rank === 0 ? 16 : 14 }}>
+                {rank === 0 ? "👑 " : `${rank + 1}. `}
+                {p.name}
+              </span>
+              <span style={{
+                fontWeight: "bold", fontSize: rank === 0 ? 18 : 14,
+                color: p.score > 0 ? "#ffd700" : p.score < 0 ? "#f44336" : "#aaa",
+              }}>
+                {p.score > 0 ? "+" : ""}{p.score}
+              </span>
+            </div>
+          ))}
+        </div>
+
+        {/* MVP Stats */}
+        {roundHistory.length > 0 && (
+          <div style={{
+            marginBottom: 16, padding: 10,
+            background: "rgba(255,255,255,0.04)", borderRadius: 6,
+          }}>
+            <div style={{ fontSize: 13, color: "#aaa", marginBottom: 6 }}>数据亮点 / Highlights</div>
+            {mostWins > 0 && (
+              <div style={{ fontSize: 13, color: "#e8d5a3", marginBottom: 4 }}>
+                🏆 最多胜场: {playerNames[mostWinsIdx]} ({mostWins}胡)
+              </div>
+            )}
+            {highestRoundScore > 0 && (
+              <div style={{ fontSize: 13, color: "#e8d5a3" }}>
+                🎯 单局最高: {playerNames[highestRoundPlayer]} (+{highestRoundScore})
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Per-round history */}
+        {roundHistory.length > 0 && (
+          <div style={{ marginBottom: 16 }}>
+            <div style={{ fontSize: 13, color: "#aaa", marginBottom: 6 }}>每局记录 / Round History</div>
+            <div style={{ maxHeight: 160, overflowY: "auto" }}>
+              {roundHistory.map((round, ri) => (
+                <div key={ri} style={{
+                  fontSize: 12, padding: "6px 10px", marginBottom: 2,
+                  background: "rgba(255,255,255,0.03)", borderRadius: 4,
+                  display: "flex", justifyContent: "space-between", alignItems: "center",
+                }}>
+                  <span style={{ color: "#8fbc8f" }}>
+                    第{ri + 1}局: {winTypeNames[round.winType] || round.winType}
+                  </span>
+                  <span style={{ color: "#ccc" }}>
+                    {round.scores.map((s, i) => (
+                      <span key={i} style={{
+                        marginLeft: 8,
+                        color: s > 0 ? "#4caf50" : s < 0 ? "#f44336" : "#666",
+                      }}>
+                        {s > 0 ? "+" : ""}{s}
+                      </span>
+                    ))}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        <button
+          onClick={onClose}
+          style={{
+            width: "100%", padding: "12px 0", fontSize: 16,
+            background: "#0f3460", color: "#eee",
+            border: "1px solid rgba(255,215,0,0.3)",
+            borderRadius: 6, cursor: "pointer",
+          }}
+        >
+          返回大厅 / Back to Lobby
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/Game.tsx
+++ b/apps/web/src/pages/Game.tsx
@@ -7,6 +7,7 @@ import { sounds, setMuted, isMuted } from "../sounds";
 import { TileCounter } from "../components/TileCounter";
 import { TutorialModal } from "../components/TutorialModal";
 import { TileView } from "../components/Tile";
+import { SessionSummary, type SessionData } from "../components/SessionSummary";
 import { Button } from "../components/Button";
 import { ActionType, MeldType } from "@fuzhou-mahjong/shared";
 import type { ClientGameState, GameOverResult, AvailableActions, GameAction, PlayerDisconnectedEvent, PlayerReconnectedEvent } from "@fuzhou-mahjong/shared";
@@ -70,6 +71,8 @@ export function Game({ initialGameState, onLeave }: GameProps) {
     setToasts((prev) => [...prev, { id, message }]);
     setTimeout(() => setToasts((prev) => prev.filter((t) => t.id !== id)), 4000);
   };
+  const [roundHistory, setRoundHistory] = useState<{ scores: number[]; winnerId: number | null; winType: string }[]>([]);
+  const [sessionSummary, setSessionSummary] = useState<SessionData | null>(null);
   const [showTutorial, setShowTutorial] = useState(false);
   const [tutorialCondensed, setTutorialCondensed] = useState(false);
   const [drawAnimation, setDrawAnimation] = useState<DrawAnimationState | null>(null);
@@ -215,6 +218,11 @@ export function Game({ initialGameState, onLeave }: GameProps) {
     });
     socket.on("gameOver", (result) => {
       setGameOver(result);
+      setRoundHistory((prev) => [...prev, {
+        scores: result.scores,
+        winnerId: result.winnerId,
+        winType: result.winType,
+      }]);
       if (result.winnerId !== null) sounds.hu();
       else sounds.gameDraw();
     });
@@ -476,11 +484,34 @@ export function Game({ initialGameState, onLeave }: GameProps) {
           下一局 / Next Round
         </Button>
         {onLeave && (
-          <Button variant="secondary" onClick={() => { socket.emit("leaveRoom"); onLeave(); }} style={{ marginLeft: 10 }}>
+          <Button variant="secondary" onClick={() => {
+              const cum = gameOver.cumulative;
+              if (cum && cum.roundsPlayed > 0) {
+                setSessionSummary({
+                  playerNames: gameOver.playerNames ?? [],
+                  cumulativeScores: cum.scores,
+                  roundsPlayed: cum.roundsPlayed,
+                  roundHistory,
+                });
+              } else {
+                socket.emit("leaveRoom");
+                onLeave();
+              }
+            }} style={{ marginLeft: 10 }}>
             离开 / Leave
           </Button>
         )}
       </div>
+      {sessionSummary && (
+        <SessionSummary
+          data={sessionSummary}
+          onClose={() => {
+            setSessionSummary(null);
+            socket.emit("leaveRoom");
+            onLeave?.();
+          }}
+        />
+      )}
       </div>
     );
   }

--- a/apps/web/src/pages/Room.tsx
+++ b/apps/web/src/pages/Room.tsx
@@ -1,15 +1,16 @@
 import { useEffect, useState } from "react";
 import { socket } from "../socket";
-import type { RoomState } from "@fuzhou-mahjong/shared";
+import type { RoomState, CumulativeData } from "@fuzhou-mahjong/shared";
 import { Button } from "../components/Button";
 
 interface RoomProps {
   initialRoomState: RoomState | null;
+  sessionScores?: CumulativeData | null;
 }
 
 const WIND_LABELS = ["东 East", "南 South", "西 West", "北 North"];
 
-export function Room({ initialRoomState }: RoomProps) {
+export function Room({ initialRoomState, sessionScores }: RoomProps) {
   const [room, setRoom] = useState<RoomState | null>(initialRoomState);
   const [showLeaveConfirm, setShowLeaveConfirm] = useState(false);
 
@@ -55,11 +56,11 @@ export function Room({ initialRoomState }: RoomProps) {
       <div className="seat-layout">
         {/* Top seat */}
         <div className="seat-slot" style={{ gridArea: "top" }}>
-          <SeatCard seat={seats[2]} />
+          <SeatCard seat={seats[2]} score={sessionScores?.scores[2]} />
         </div>
         {/* Left seat */}
         <div className="seat-slot" style={{ gridArea: "left" }}>
-          <SeatCard seat={seats[3]} />
+          <SeatCard seat={seats[3]} score={sessionScores?.scores[3]} />
         </div>
         {/* Center: room ID */}
         <div className="table-center" style={{ gridArea: "center" }}>
@@ -70,14 +71,19 @@ export function Room({ initialRoomState }: RoomProps) {
           <div style={{ fontSize: 12, color: "var(--color-text-secondary)", marginTop: 6 }}>
             {room.players.length}/4 玩家
           </div>
+          {sessionScores && sessionScores.roundsPlayed > 0 && (
+            <div style={{ fontSize: 11, color: "var(--color-text-gold)", marginTop: 4 }}>
+              已完成 {sessionScores.roundsPlayed} 局
+            </div>
+          )}
         </div>
         {/* Right seat */}
         <div className="seat-slot" style={{ gridArea: "right" }}>
-          <SeatCard seat={seats[1]} />
+          <SeatCard seat={seats[1]} score={sessionScores?.scores[1]} />
         </div>
         {/* Bottom seat */}
         <div className="seat-slot" style={{ gridArea: "bottom" }}>
-          <SeatCard seat={seats[0]} />
+          <SeatCard seat={seats[0]} score={sessionScores?.scores[0]} />
         </div>
       </div>
 
@@ -132,7 +138,7 @@ export function Room({ initialRoomState }: RoomProps) {
   );
 }
 
-function SeatCard({ seat }: { seat: { index: number; player: { name: string; isBot?: boolean } | null; wind: string } }) {
+function SeatCard({ seat, score }: { seat: { index: number; player: { name: string; isBot?: boolean } | null; wind: string }; score?: number }) {
   const { player, wind } = seat;
   const isEmpty = !player;
 
@@ -145,6 +151,14 @@ function SeatCard({ seat }: { seat: { index: number; player: { name: string; isB
             {player.name}
           </div>
           {player.isBot && <div style={{ fontSize: 11, color: "var(--color-text-secondary)", marginTop: 2 }}>🤖 Bot</div>}
+          {score != null && (
+            <div style={{
+              fontSize: 12, fontWeight: "bold", marginTop: 2,
+              color: score > 0 ? "#ffd700" : score < 0 ? "#f44336" : "#8fbc8f",
+            }}>
+              {score > 0 ? "+" : ""}{score}
+            </div>
+          )}
         </>
       ) : (
         <div style={{ fontSize: 13, color: "rgba(143,188,143,0.5)" }}>空位 / Empty</div>

--- a/packages/shared/src/types/events.ts
+++ b/packages/shared/src/types/events.ts
@@ -43,6 +43,8 @@ export interface ClientGameState {
   tenpaiTiles: import('../types/tile.js').SuitedTile[];
   lastDrawnTileId: number | null;
   myHasDiscardedGold: boolean;
+  cumulativeScores: number[];
+  roundsPlayed: number;
 }
 
 // ─── Actions ─────────────────────────────────────────────────────


### PR DESCRIPTION
Cumulative scoring exists (#91) but only shows on game-over screen. Missing:
1. In-game scoreboard: small unobtrusive panel showing each players running session total near their name area, updates with animation after each round
2. End-of-session summary: when player leaves or room closes, show modal with final standings, per-round breakdown, MVP stats (most wins, biggest hand)
3. Room page: show current session scores in waiting area

Builds on existing cumulative scoring from room.ts (cumulativeScores, roundsPlayed).
Files: Game.tsx, Room.tsx, PlayerArea.tsx, new SessionSummary component

Closes #199