### PR TITLE
Animation gaps - dead CSS classes and missing transitions

### DIFF
--- a/apps/web/src/animations.css
+++ b/apps/web/src/animations.css
@@ -4,17 +4,6 @@
   50% { transform: rotate(90deg); }
 }
 
-/* Tile discard animation */
-@keyframes discardFly {
-  0% { transform: scale(1); opacity: 1; }
-  50% { transform: scale(0.6) translateY(-30px); opacity: 0.7; }
-  100% { transform: scale(0.5) translateY(0); opacity: 1; }
-}
-
-.tile-discarding {
-  animation: discardFly 0.4s ease-out;
-}
-
 /* Tile draw-in animation (new draw slides into hand) */
 @keyframes tileDrawIn {
   0% { opacity: 0; transform: translateY(-40px) scale(0.7); }
@@ -38,17 +27,6 @@
 
 .discard-arrive {
   animation: discardArrive 0.3s ease-out;
-}
-
-/* Tile flip animation */
-@keyframes tileFlip {
-  0% { transform: rotateY(180deg); }
-  100% { transform: rotateY(0deg); }
-}
-
-.tile-flip {
-  animation: tileFlip 0.5s ease-out;
-  transform-style: preserve-3d;
 }
 
 /* Hu celebration */
@@ -121,16 +99,6 @@
 
 .current-turn {
   animation: turnGlow 1.5s ease-in-out infinite;
-}
-
-/* Claim action alert */
-@keyframes claimPulse {
-  0%, 100% { border-color: rgba(255, 165, 0, 0.4); background: rgba(255, 140, 0, 0.1); }
-  50% { border-color: rgba(255, 165, 0, 1); background: rgba(255, 140, 0, 0.25); }
-}
-
-.claim-alert {
-  animation: claimPulse 1s ease-in-out infinite;
 }
 
 /* Your turn prompt pulse */
@@ -330,4 +298,29 @@
 @keyframes tutorialSlideIn {
   0% { opacity: 0; transform: translateX(16px); }
   100% { opacity: 1; transform: translateX(0); }
+}
+
+/* Score reveal staggered animation (game-over screen) */
+@keyframes scoreReveal {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* Meld entrance animation */
+@keyframes meldEntrance {
+  from { opacity: 0; transform: scale(0.8); }
+  to { opacity: 1; transform: scale(1); }
+}
+
+.meld-new {
+  animation: meldEntrance 0.3s ease-out;
+}
+
+/* Respect reduced-motion preferences */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
 }

--- a/apps/web/src/components/PlayerArea.tsx
+++ b/apps/web/src/components/PlayerArea.tsx
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useRef, useState, useEffect } from "react";
 import type { TileInstance, Meld, GoldState } from "@fuzhou-mahjong/shared";
 import { MeldType } from "@fuzhou-mahjong/shared";
 import { TileView } from "./Tile";
@@ -83,6 +83,19 @@ export function PlayerArea({
     threshold: 40,
   });
 
+  // Track newest meld index for entrance animation
+  const [newestMeldIdx, setNewestMeldIdx] = useState<number | null>(null);
+  const prevMeldCountRef = useRef(melds.length);
+  useEffect(() => {
+    if (melds.length > prevMeldCountRef.current) {
+      const idx = melds.length - 1;
+      setNewestMeldIdx(idx);
+      const timer = setTimeout(() => setNewestMeldIdx(null), 400);
+      return () => clearTimeout(timer);
+    }
+    prevMeldCountRef.current = melds.length;
+  }, [melds.length]);
+
   // Compact single-row layout for opponents on mobile landscape
   if (compact) {
     return (
@@ -109,7 +122,7 @@ export function PlayerArea({
         {isDealer && <span style={{ fontSize: 9, background: "#b71c1c", color: "#ffd700", padding: "0 4px", borderRadius: 3, fontWeight: "bold", flexShrink: 0 }}>庄</span>}
         {isDisconnected && <span style={{ fontSize: 9, background: "#ff5722", color: "#fff", padding: "0 4px", borderRadius: 3, fontWeight: "bold", flexShrink: 0 }}>断线</span>}
         {hasDiscardedGold && <span style={{ fontSize: 9, background: "#c41e3a", color: "#fff", padding: "0 4px", borderRadius: 3, fontWeight: "bold", flexShrink: 0 }}>弃金</span>}
-        {isCurrentTurn && <span style={{ fontSize: 9, background: "rgba(255,215,0,0.2)", color: "#ffd700", padding: "0 4px", borderRadius: 3, border: "1px solid #ffd700", flexShrink: 0 }}>出牌</span>}
+        {isCurrentTurn && <span className="your-turn-prompt" style={{ fontSize: 9, background: "rgba(255,215,0,0.2)", color: "#ffd700", padding: "0 4px", borderRadius: 3, border: "1px solid #ffd700", flexShrink: 0 }}>出牌</span>}
 
         {/* Hand count */}
         <span style={{ fontSize: 11, color: "#8fbc8f", flexShrink: 0 }}>{handCount ?? 0}张</span>
@@ -118,7 +131,7 @@ export function PlayerArea({
         {melds.length > 0 && (
           <div style={{ display: "flex", gap: 4, flexShrink: 0 }}>
             {melds.map((m, mi) => (
-              <div key={mi} style={{ display: "flex", gap: 0 }}>
+              <div key={mi} className={newestMeldIdx === mi ? "meld-new" : undefined} style={{ display: "flex", gap: 0 }}>
                 {m.tiles.map((t, ti) => (
                   <TileView key={ti} tile={t} faceUp={m.type !== MeldType.AnGang} gold={gold} small />
                 ))}
@@ -139,7 +152,7 @@ export function PlayerArea({
           }}>
             {discards.map((d) => (
               <TileView key={d.id} tile={d} faceUp gold={gold} small
-                className={lastDiscardedTileId === d.id ? "discard-arrive" : undefined}
+                className={lastDiscardedTileId === d.id ? "discard-arrive last-discard" : undefined}
               />
             ))}
           </div>
@@ -187,7 +200,7 @@ export function PlayerArea({
         {isDealer && <span style={{ fontSize: 10, background: "#b71c1c", color: "#ffd700", padding: "1px 5px", borderRadius: 3, fontWeight: "bold" }}>庄</span>}
         {isDisconnected && <span style={{ fontSize: 10, background: "#ff5722", color: "#fff", padding: "1px 5px", borderRadius: 3, fontWeight: "bold", animation: "disconnectPulse 2s ease-in-out infinite" }}>断线</span>}
         {hasDiscardedGold && <span style={{ fontSize: 10, background: "#c41e3a", color: "#fff", padding: "1px 5px", borderRadius: 3, fontWeight: "bold" }}>弃金</span>}
-        {isCurrentTurn && <span style={{ fontSize: 10, background: "rgba(255,215,0,0.2)", color: "#ffd700", padding: "1px 5px", borderRadius: 3, border: "1px solid #ffd700" }}>出牌</span>}
+        {isCurrentTurn && <span className="your-turn-prompt" style={{ fontSize: 10, background: "rgba(255,215,0,0.2)", color: "#ffd700", padding: "1px 5px", borderRadius: 3, border: "1px solid #ffd700" }}>出牌</span>}
         <span style={{ fontSize: 11, color: "#8fbc8f", marginLeft: "auto" }}>
           🌸{flowers.length}
         </span>
@@ -325,7 +338,7 @@ export function PlayerArea({
       {melds.length > 0 && (
         <div style={{ display: "flex", gap: 8, marginBottom: 4 }}>
           {melds.map((m, mi) => (
-            <div key={mi} style={{ display: "flex", gap: 0 }}>
+            <div key={mi} className={newestMeldIdx === mi ? "meld-new" : undefined} style={{ display: "flex", gap: 0 }}>
               {m.tiles.map((t, ti) => (
                 <TileView
                   key={ti}
@@ -362,7 +375,7 @@ export function PlayerArea({
         }}>
           {discards.map((d) => (
             <TileView key={d.id} tile={d} faceUp gold={gold} small
-              className={lastDiscardedTileId === d.id ? "discard-arrive" : undefined}
+              className={lastDiscardedTileId === d.id ? "discard-arrive last-discard" : undefined}
             />
           ))}
         </div>

--- a/apps/web/src/pages/Game.tsx
+++ b/apps/web/src/pages/Game.tsx
@@ -389,6 +389,7 @@ export function Game({ initialGameState, onLeave }: GameProps) {
                 padding: "6px 16px", marginBottom: 4, borderRadius: 4,
                 background: p.score > 0 ? "rgba(76,175,80,0.15)" : p.score < 0 ? "rgba(244,67,54,0.1)" : "transparent",
                 border: rank === 0 && p.score > 0 ? "1px solid var(--color-success)" : "1px solid transparent",
+                animation: `scoreReveal 0.3s ease-out ${rank * 0.1}s both`,
               }}>
                 <span>
                   {rank === 0 && p.score > 0 ? "🏆 " : `${rank + 1}. `}
@@ -416,6 +417,7 @@ export function Game({ initialGameState, onLeave }: GameProps) {
                   padding: "6px 16px", marginBottom: 4, borderRadius: 4,
                   background: rank === 0 ? "rgba(255,215,0,0.12)" : "transparent",
                   border: rank === 0 ? "1px solid rgba(255,215,0,0.4)" : "1px solid transparent",
+                  animation: `scoreReveal 0.3s ease-out ${rank * 0.1}s both`,
                 }}>
                   <span>
                     {rank === 0 ? "👑 " : `${rank + 1}. `}


### PR DESCRIPTION
6 dead CSS classes, missing transitions.

1. Wire up or remove dead animations: .tile-discarding, .tile-flip, .claim-alert, .your-turn-prompt, .last-discard
2. Add score reveal staggered fade-in animation on game over
3. Add meld entrance animation (slide-in when chi/pong/kong resolves)
4. Add @media (prefers-reduced-motion: reduce) block

CSS + minor component className additions.

Closes #222