### PR TITLE
Unified tile rendering size audit and fix

### DIFF
--- a/apps/web/src/components/Tile.tsx
+++ b/apps/web/src/components/Tile.tsx
@@ -50,7 +50,7 @@ export function TileView({ tile, faceUp = true, selected, claimable, onClick, on
   const w = small ? "var(--tile-w-sm)" : "var(--tile-w)";
   const h = small ? "var(--tile-h-sm)" : "var(--tile-h)";
   const fontSize = small ? "var(--tile-font-sm)" : "var(--tile-font)";
-  const suitSize = small ? "var(--tile-suit-font)" : "var(--tile-suit-font)";
+  const suitSize = small ? "var(--tile-suit-font-sm)" : "var(--tile-suit-font)";
   const isGold = gold && isSuitedTile(tile.tile) && isGoldTile(tile, gold);
 
   if (!faceUp) {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -89,6 +89,7 @@ body {
   --tile-w-sm: calc(var(--tile-w) * 0.68);
   --tile-h-sm: calc(var(--tile-h) * 0.67);
   --tile-font-sm: calc(var(--tile-font) * 0.72);
+  --tile-suit-font-sm: calc(var(--tile-suit-font) * 0.72);
   /* Wall tile sizing — small face-down tiles for the wall display */
   --wall-tw: 11px;
   --wall-th: 15px;

--- a/apps/web/src/tileSvg.ts
+++ b/apps/web/src/tileSvg.ts
@@ -11,7 +11,8 @@ const WIND_MAP: Record<string, string> = { east: "Ton", south: "Nan", west: "Sha
 const DRAGON_MAP: Record<string, string> = { red: "Chun", green: "Hatsu", white: "Haku" };
 
 function makeFlowerSvg(char: string, color: string, label: string, labelColor: string): string {
-  const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 110"><text x="40" y="58" text-anchor="middle" dominant-baseline="central" font-family="serif" font-size="48" font-weight="bold" fill="${color}">${char}</text><text x="40" y="96" text-anchor="middle" font-family="sans-serif" font-size="14" fill="${labelColor}" opacity="0.7">${label}</text></svg>`;
+  // viewBox matches FluffyStuff tiles (300×400) for consistent proportions
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 400"><text x="150" y="210" text-anchor="middle" dominant-baseline="central" font-family="serif" font-size="170" font-weight="bold" fill="${color}">${char}</text><text x="150" y="350" text-anchor="middle" font-family="sans-serif" font-size="50" fill="${labelColor}" opacity="0.7">${label}</text></svg>`;
   return `data:image/svg+xml,${encodeURIComponent(svg)}`;
 }
 


### PR DESCRIPTION
Audit every tile rendering context for visual consistency.

- All tile faces (万/饼/条/风/箭/花) same dimensions within same context
- Verify CSS variables --tile-w/h/w-sm/h-sm used consistently, no hardcoded pixels
- Flower and honor tiles must not appear larger/smaller than suited tiles
- Check SVG viewBox sizing for all tile types renders uniformly
- Fix inconsistencies

Files: PlayerArea.tsx, Tile.tsx, TileWall.tsx, index.css, tileSvg.ts

Closes #228