### PR TITLE
Mobile first-person grid overhaul for GameTable

### DIFF
--- a/apps/web/src/components/GameTable.tsx
+++ b/apps/web/src/components/GameTable.tsx
@@ -54,8 +54,8 @@ export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTile
         "left center right"
         ". bottom ."
       `,
-      gridTemplateColumns: "1fr 2fr 1fr",
-      gridTemplateRows: isCompact ? "minmax(0, 50px) minmax(0, 60px) 1fr" : "auto 1fr auto",
+      gridTemplateColumns: isCompact ? "80px 1fr 80px" : "1fr 2fr 1fr",
+      gridTemplateRows: isCompact ? "36px 40px 1fr" : "auto 1fr auto",
       flex: 1,
       minHeight: 0,
       gap: "var(--game-gap)",

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -162,8 +162,8 @@ body {
 
 @media (orientation: landscape) and (max-height: 500px) {
   :root {
-    --tile-w: 32px;
-    --tile-h: 44px;
+    --tile-w: 40px;
+    --tile-h: 54px;
     --tile-font: 11px;
     --tile-suit-font: 8px;
     --wall-tw: 9px;


### PR DESCRIPTION
GameTable grid must give bottom player 55-60pct of viewport on mobile landscape.

Requirements:
- Top opponent: max 36px row
- Left/right: max 80px columns, vertical labels only
- Center: ~40px band
- Bottom hand: 1fr (55-60% viewport)
- Hand tiles >= 40px wide on mobile (larger, not smaller)
- Grid: rows 36px 40px 1fr, columns 80px 1fr 80px
- Test: iPhone SE 667x375, zero scroll

Do NOT touch: PlayerArea internals, animations, gestures
Files: GameTable.tsx, index.css only

Closes #233