### PR TITLE
Mobile layout verification and overflow fixes for 13-tile hands

### DIFF
--- a/apps/web/src/components/PlayerArea.tsx
+++ b/apps/web/src/components/PlayerArea.tsx
@@ -388,7 +388,7 @@ export function PlayerArea({
           padding: "var(--game-padding)",
           background: isMe ? "rgba(0,100,200,0.08)" : "rgba(255,255,255,0.03)",
           borderRadius: 4,
-          maxWidth: "min(300px, 90vw)",
+          ...(!isMe && { maxWidth: "min(300px, 90vw)" }),
         }}>
           {discards.map((d) => (
             <TileView key={d.id} tile={d} faceUp gold={gold} small

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -162,7 +162,7 @@ body {
 
 @media (orientation: landscape) and (max-height: 500px) {
   :root {
-    --tile-w: 40px;
+    --tile-w: 36px;
     --tile-h: 54px;
     --tile-font: 11px;
     --tile-suit-font: 8px;


### PR DESCRIPTION
Verify mobile layout at actual target sizes.

Check at 667x375 (iPhone SE landscape) and 844x390 (iPhone 16 landscape):
1. Does 13+ tile hand overflow or wrap awkwardly in bottom area?
2. Are 80px side columns enough for compact opponent info?
3. Does discard maxWidth min(300px,90vw) cause clipping?
4. Do melds + hand + discards all fit without scroll?

Fix any overflow issues found. Adjust tile sizes or layout constraints as needed.

Files: PlayerArea.tsx, GameTable.tsx, index.css

Closes #257