### PR TITLE
Add subtle UI interaction sounds for buttons and toggles

### DIFF
--- a/apps/web/src/components/Button.tsx
+++ b/apps/web/src/components/Button.tsx
@@ -1,4 +1,5 @@
 import type { ButtonHTMLAttributes } from "react";
+import { sounds } from "../sounds";
 
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: "primary" | "secondary" | "danger" | "gold";
@@ -42,6 +43,7 @@ export function Button({
   variant = "primary",
   size = "md",
   style,
+  onClick,
   ...rest
 }: ButtonProps) {
   return (
@@ -51,6 +53,10 @@ export function Button({
         ...variantStyles[variant],
         ...sizeStyles[size],
         ...style,
+      }}
+      onClick={(e) => {
+        sounds.buttonTap();
+        onClick?.(e);
       }}
       {...rest}
     />

--- a/apps/web/src/sounds.ts
+++ b/apps/web/src/sounds.ts
@@ -132,4 +132,17 @@ export const sounds = {
     playTone(880, 0.1, "sine", 0.12);
     setTimeout(() => playTone(660, 0.12, "sine", 0.1), 120);
   },
+
+  buttonTap() {
+    playTone(600, 0.04, "sine", 0.1);
+  },
+
+  confirm() {
+    playTone(800, 0.08, "sine", 0.12);
+    setTimeout(() => playTone(1000, 0.06, "sine", 0.1), 60);
+  },
+
+  toggle() {
+    playTone(500, 0.05, "triangle", 0.08);
+  },
 };


### PR DESCRIPTION
Zero UI feedback sounds — no button taps, confirmation, mute toggle. Standard in mobile mahjong games like 雀魂.

Add to sounds.ts:
- buttonTap: subtle click for all Button component clicks
- confirm: soft chime for confirmations (next round, leave confirm)
- toggle: click for mute toggle

Wire up in Button.tsx onClick wrapper and specific confirmation actions.
Keep sounds subtle (low volume, short duration).

Files: sounds.ts, Button.tsx (onClick sound wrapper), Game.tsx confirm actions

Closes #256