### PR TITLE
GPU-accelerate pulse animations replacing box-shadow

### DIFF
--- a/apps/web/src/animations.css
+++ b/apps/web/src/animations.css
@@ -45,8 +45,8 @@
 }
 
 @keyframes tileGlow {
-  0% { box-shadow: 0 0 12px rgba(106,90,205,0.6); }
-  100% { box-shadow: none; }
+  0% { filter: drop-shadow(0 0 12px rgba(106,90,205,0.6)); }
+  100% { filter: drop-shadow(0 0 0 transparent); }
 }
 
 .tile-new {
@@ -65,9 +65,9 @@
 
 /* Hu celebration */
 @keyframes huGlow {
-  0% { box-shadow: 0 0 20px rgba(255, 215, 0, 0.3); }
-  50% { box-shadow: 0 0 60px rgba(255, 215, 0, 0.8), 0 0 100px rgba(255, 140, 0, 0.4); }
-  100% { box-shadow: 0 0 20px rgba(255, 215, 0, 0.3); }
+  0% { filter: drop-shadow(0 0 20px rgba(255, 215, 0, 0.3)); }
+  50% { filter: drop-shadow(0 0 60px rgba(255, 215, 0, 0.8)) drop-shadow(0 0 100px rgba(255, 140, 0, 0.4)); }
+  100% { filter: drop-shadow(0 0 20px rgba(255, 215, 0, 0.3)); }
 }
 
 @keyframes huScale {
@@ -127,8 +127,8 @@
 
 /* Turn indicator glow */
 @keyframes turnGlow {
-  0%, 100% { border-color: rgba(255, 215, 0, 0.4); }
-  50% { border-color: rgba(255, 215, 0, 1); }
+  0%, 100% { filter: drop-shadow(0 0 4px rgba(255, 215, 0, 0.4)); }
+  50% { filter: drop-shadow(0 0 8px rgba(255, 215, 0, 1)); }
 }
 
 .current-turn {
@@ -147,8 +147,8 @@
 
 /* Last discard highlight */
 @keyframes discardHighlight {
-  0%, 100% { box-shadow: 0 0 8px rgba(255, 165, 0, 0.4); }
-  50% { box-shadow: 0 0 16px rgba(255, 165, 0, 0.8); }
+  0%, 100% { filter: drop-shadow(0 0 8px rgba(255, 165, 0, 0.4)); }
+  50% { filter: drop-shadow(0 0 16px rgba(255, 165, 0, 0.8)); }
 }
 
 .last-discard {
@@ -175,8 +175,8 @@
 
 /* Screen border flash */
 @keyframes borderFlash {
-  0% { box-shadow: inset 0 0 60px rgba(255,165,0,0.6); }
-  100% { box-shadow: inset 0 0 0 transparent; }
+  0% { opacity: 1; }
+  100% { opacity: 0; }
 }
 
 .border-flash {
@@ -187,13 +187,14 @@
   bottom: 0;
   pointer-events: none;
   z-index: 49;
+  box-shadow: inset 0 0 60px rgba(255,165,0,0.6);
   animation: borderFlash 1.5s ease-out forwards;
 }
 
 /* Highlight tiles that can be used in claim */
 @keyframes tileHighlight {
-  0%, 100% { box-shadow: 0 0 6px rgba(0,255,136,0.4); }
-  50% { box-shadow: 0 0 14px rgba(0,255,136,0.9); }
+  0%, 100% { filter: drop-shadow(0 0 6px rgba(0,255,136,0.4)); }
+  50% { filter: drop-shadow(0 0 14px rgba(0,255,136,0.9)); }
 }
 
 .tile-claimable {
@@ -202,8 +203,8 @@
 
 /* Gold discard warning pulse */
 @keyframes goldWarningPulse {
-  0%, 100% { box-shadow: 0 2px 8px rgba(196,30,58,0.5); transform: scale(1); }
-  50% { box-shadow: 0 2px 16px rgba(196,30,58,0.9), 0 0 24px rgba(255,0,0,0.4); transform: scale(1.05); }
+  0%, 100% { filter: drop-shadow(0 2px 8px rgba(196,30,58,0.5)); transform: scale(1); }
+  50% { filter: drop-shadow(0 2px 16px rgba(196,30,58,0.9)) drop-shadow(0 0 24px rgba(255,0,0,0.4)); transform: scale(1.05); }
 }
 
 .gold-warning-pulse {
@@ -218,8 +219,8 @@
 
 /* Draw button pulse */
 @keyframes drawPulse {
-  0%, 100% { box-shadow: 0 0 8px rgba(106,90,205,0.4); }
-  50% { box-shadow: 0 0 20px rgba(106,90,205,0.8); }
+  0%, 100% { filter: drop-shadow(0 0 8px rgba(106,90,205,0.4)); }
+  50% { filter: drop-shadow(0 0 20px rgba(106,90,205,0.8)); }
 }
 
 .draw-button-pulse {
@@ -251,8 +252,8 @@
 
 /* Gold indicator shimmer */
 @keyframes goldShimmer {
-  0%, 100% { box-shadow: 0 0 8px rgba(255,215,0,0.4); }
-  50% { box-shadow: 0 0 16px rgba(255,215,0,0.7), 0 0 24px rgba(255,215,0,0.3); }
+  0%, 100% { filter: drop-shadow(0 0 8px rgba(255,215,0,0.4)); }
+  50% { filter: drop-shadow(0 0 16px rgba(255,215,0,0.7)) drop-shadow(0 0 24px rgba(255,215,0,0.3)); }
 }
 
 .gold-indicator-glow {


### PR DESCRIPTION
8+ pulse animations use box-shadow which triggers paint. Replace with GPU-composited transform+opacity on pseudo-elements or filter drop-shadow.

Files: animations.css, component styles referencing affected keyframes
Target: every @keyframes animating box-shadow.

Closes #263