### PR TITLE
Remove as-any casts in Game tsx and delete unused useIsMobile

### DIFF
--- a/apps/web/src/components/GameTable.tsx
+++ b/apps/web/src/components/GameTable.tsx
@@ -162,9 +162,9 @@ export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTile
           onAnGang={onAnGang}
           onBuGang={onBuGang}
           hasDiscardedGold={myHasDiscardedGold}
-          lastDrawnTileId={(state as any).lastDrawnTileId}
+          lastDrawnTileId={state.lastDrawnTileId}
           lastDiscardedTileId={lastDiscardPlayerIndex === myIndex ? lastDiscardTileId : null}
-          tenpaiTiles={(state as any).tenpaiTiles}
+          tenpaiTiles={state.tenpaiTiles}
           cumulativeScore={roundsPlayed > 0 ? cumulativeScores[myIndex] : undefined}
         />
       </div>

--- a/apps/web/src/hooks/useIsMobile.ts
+++ b/apps/web/src/hooks/useIsMobile.ts
@@ -1,19 +1,6 @@
 import { useState, useEffect } from "react";
 
-const MOBILE_BREAKPOINT = 600;
 const COMPACT_HEIGHT_BREAKPOINT = 500;
-
-export function useIsMobile(): boolean {
-  const [isMobile, setIsMobile] = useState(() => window.innerWidth <= MOBILE_BREAKPOINT);
-
-  useEffect(() => {
-    const onResize = () => setIsMobile(window.innerWidth <= MOBILE_BREAKPOINT);
-    window.addEventListener("resize", onResize);
-    return () => window.removeEventListener("resize", onResize);
-  }, []);
-
-  return isMobile;
-}
 
 export function useIsCompactLandscape(): boolean {
   const [isCompact, setIsCompact] = useState(() => window.innerHeight <= COMPACT_HEIGHT_BREAKPOINT);


### PR DESCRIPTION
Type safety cleanup:
1. Game.tsx uses (state as any).lastDrawnTileId and (state as any).tenpaiTiles — add missing fields to shared ClientGameState type, remove casts
2. useIsMobile() in useIsMobile.ts is defined but never imported — delete it

Zero behavior change. Pure type safety + dead code removal.
Files: packages/shared/src/types/events.ts, apps/web/src/pages/Game.tsx, apps/web/src/hooks/useIsMobile.ts

Closes #268