### PR TITLE
Visual token cleanup for SessionSummary modal and Tile radius

### DIFF
--- a/apps/web/src/components/SessionSummary.tsx
+++ b/apps/web/src/components/SessionSummary.tsx
@@ -57,7 +57,7 @@ export function SessionSummary({ data, onClose }: SessionSummaryProps) {
       animation: "pageFadeIn 0.3s ease-out",
     }}>
       <div style={{
-        background: "linear-gradient(135deg, #1a1a2e 0%, #16213e 100%)",
+        background: "linear-gradient(135deg, var(--color-bg-dark) 0%, var(--color-bg-medium) 100%)",
         border: "1px solid rgba(255,215,0,0.3)",
         borderRadius: 12,
         padding: "24px 28px",
@@ -65,18 +65,18 @@ export function SessionSummary({ data, onClose }: SessionSummaryProps) {
         width: "90vw",
         maxHeight: "90dvh",
         overflowY: "auto",
-        color: "#eee",
+        color: "var(--color-text-primary)",
       }}>
-        <h2 style={{ textAlign: "center", fontSize: 22, marginBottom: 4, color: "#ffd700" }}>
+        <h2 style={{ textAlign: "center", fontSize: 22, marginBottom: 4, color: "var(--color-gold-bright)" }}>
           本场总结 / Session Summary
         </h2>
-        <div style={{ textAlign: "center", fontSize: 13, color: "#8fbc8f", marginBottom: 16 }}>
+        <div style={{ textAlign: "center", fontSize: 13, color: "var(--color-text-secondary)", marginBottom: 16 }}>
           共 {roundsPlayed} 局
         </div>
 
         {/* Final Rankings */}
         <div style={{ marginBottom: 16 }}>
-          <div style={{ fontSize: 13, color: "#aaa", marginBottom: 6 }}>最终排名 / Final Rankings</div>
+          <div style={{ fontSize: 13, color: "var(--color-text-secondary)", marginBottom: 6 }}>最终排名 / Final Rankings</div>
           {rankings.map((p, rank) => (
             <div key={p.i} className="session-rank-row" style={{
               display: "flex", justifyContent: "space-between", alignItems: "center",
@@ -90,7 +90,7 @@ export function SessionSummary({ data, onClose }: SessionSummaryProps) {
               </span>
               <span style={{
                 fontWeight: "bold", fontSize: rank === 0 ? 18 : 14,
-                color: p.score > 0 ? "#ffd700" : p.score < 0 ? "#f44336" : "#aaa",
+                color: p.score > 0 ? "var(--color-gold-bright)" : p.score < 0 ? "var(--color-error)" : "var(--color-text-secondary)",
               }}>
                 {p.score > 0 ? "+" : ""}{p.score}
               </span>
@@ -104,7 +104,7 @@ export function SessionSummary({ data, onClose }: SessionSummaryProps) {
             marginBottom: 16, padding: 10,
             background: "rgba(255,255,255,0.04)", borderRadius: 6,
           }}>
-            <div style={{ fontSize: 13, color: "#aaa", marginBottom: 6 }}>数据亮点 / Highlights</div>
+            <div style={{ fontSize: 13, color: "var(--color-text-secondary)", marginBottom: 6 }}>数据亮点 / Highlights</div>
             {mostWins > 0 && (
               <div style={{ fontSize: 13, color: "#e8d5a3", marginBottom: 4 }}>
                 🏆 最多胜场: {playerNames[mostWinsIdx]} ({mostWins}胡)
@@ -121,7 +121,7 @@ export function SessionSummary({ data, onClose }: SessionSummaryProps) {
         {/* Per-round history */}
         {roundHistory.length > 0 && (
           <div style={{ marginBottom: 16 }}>
-            <div style={{ fontSize: 13, color: "#aaa", marginBottom: 6 }}>每局记录 / Round History</div>
+            <div style={{ fontSize: 13, color: "var(--color-text-secondary)", marginBottom: 6 }}>每局记录 / Round History</div>
             <div style={{ maxHeight: 160, overflowY: "auto" }}>
               {roundHistory.map((round, ri) => (
                 <div key={ri} style={{
@@ -129,14 +129,15 @@ export function SessionSummary({ data, onClose }: SessionSummaryProps) {
                   background: "rgba(255,255,255,0.03)", borderRadius: 4,
                   display: "flex", justifyContent: "space-between", alignItems: "center",
                 }}>
-                  <span style={{ color: "#8fbc8f" }}>
+                  <span style={{ color: "var(--color-text-secondary)" }}>
                     第{ri + 1}局: {winTypeNames[round.winType] || round.winType}
                   </span>
-                  <span style={{ color: "#ccc" }}>
+                  <span style={{ color: "var(--color-text-primary)" }}>
                     {round.scores.map((s, i) => (
                       <span key={i} style={{
                         marginLeft: 8,
-                        color: s > 0 ? "#4caf50" : s < 0 ? "#f44336" : "#666",
+                        color: s > 0 ? "var(--color-success)" : s < 0 ? "var(--color-error)" : "var(--color-text-secondary)",
+                        opacity: s === 0 ? 0.6 : 1,
                       }}>
                         {s > 0 ? "+" : ""}{s}
                       </span>
@@ -152,7 +153,7 @@ export function SessionSummary({ data, onClose }: SessionSummaryProps) {
           onClick={onClose}
           style={{
             width: "100%", padding: "12px 0", fontSize: 16,
-            background: "#0f3460", color: "#eee",
+            background: "var(--color-bg-button)", color: "var(--color-text-primary)",
             border: "1px solid rgba(255,215,0,0.3)",
             borderRadius: 6, cursor: "pointer",
           }}

--- a/apps/web/src/components/Tile.tsx
+++ b/apps/web/src/components/Tile.tsx
@@ -57,7 +57,7 @@ export function TileView({ tile, faceUp = true, selected, claimable, onClick, on
     return (
       <div style={{
         width: w, height: h,
-        borderRadius: 4,
+        borderRadius: "var(--radius-sm)",
         borderBottom: "3px solid #1a3c2a",
         borderRight: "2px solid #1e4530",
         display: "inline-flex",
@@ -106,7 +106,7 @@ export function TileView({ tile, faceUp = true, selected, claimable, onClick, on
           : claimable
           ? "2px solid #00e676"
           : "1px solid #bbb",
-        borderRadius: 5,
+        borderRadius: "var(--radius-sm)",
         borderBottom: selected ? "2px solid #ff8f00" : "3px solid #a09880",
         borderRight: selected ? "2px solid #ff8f00" : "2px solid #b0a890",
         display: "inline-flex",

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -66,8 +66,10 @@ body {
   --color-bg-button: #1a5c3a;
   --color-bg-button-hover: #2e7d50;
   --color-gold: #d4a017;
+  --color-gold-bright: #ffd700;
   --color-gold-border: rgba(184, 134, 11, 0.2);
   --color-gold-border-hover: rgba(184, 134, 11, 0.4);
+  --overlay-bg: rgba(15, 30, 25, 0.97);
   --color-text-primary: #eee;
   --color-text-secondary: #8fbc8f;
   --color-text-gold: #d4a017;
@@ -539,3 +541,7 @@ button.lobby-create-btn:hover:not(:disabled) {
 .compact-discards::-webkit-scrollbar {
   display: none; /* Chrome/Safari */
 }
+
+/* Shared confirmation modal */
+.confirm-modal-backdrop { position: fixed; inset: 0; background: rgba(0,0,0,0.6); display: flex; align-items: center; justify-content: center; z-index: 50; }
+.confirm-modal { background: var(--overlay-bg); border: 2px solid var(--color-gold-border-hover); border-radius: var(--radius-lg); padding: 24px; max-width: 360px; text-align: center; max-height: calc(100dvh - 40px); overflow-y: auto; }

--- a/apps/web/src/pages/Game.tsx
+++ b/apps/web/src/pages/Game.tsx
@@ -658,8 +658,8 @@ export function Game({ initialGameState, onLeave }: GameProps) {
       )}
       {/* Leave confirmation modal */}
       {showLeaveConfirm && (
-        <div style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.6)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 50 }}>
-          <div style={{ background: 'rgba(15,30,25,0.97)', border: '2px solid rgba(184,134,11,0.4)', borderRadius: 12, padding: '24px', maxWidth: 360, textAlign: 'center', maxHeight: 'calc(100dvh - 40px)', overflowY: 'auto' }}>
+        <div className="confirm-modal-backdrop">
+          <div className="confirm-modal">
             <p style={{ fontSize: 18, marginBottom: 8 }}>确定要退出吗？</p>
             <p style={{ fontSize: 13, color: '#8fbc8f', marginBottom: 0 }}>退出后本局将由机器人代打</p>
             <div style={{ display: 'flex', gap: 12, justifyContent: 'center', marginTop: 16 }}>

--- a/apps/web/src/pages/Room.tsx
+++ b/apps/web/src/pages/Room.tsx
@@ -123,8 +123,8 @@ export function Room({ initialRoomState, sessionScores }: RoomProps) {
         </Button>
       </div>
       {showLeaveConfirm && (
-        <div style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.6)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 50 }}>
-          <div style={{ background: 'rgba(15,30,25,0.97)', border: '2px solid rgba(184,134,11,0.4)', borderRadius: 12, padding: '24px', maxWidth: 360, textAlign: 'center' }}>
+        <div className="confirm-modal-backdrop">
+          <div className="confirm-modal">
             <p style={{ fontSize: 18, marginBottom: 16 }}>确定要离开房间吗？</p>
             <div style={{ display: 'flex', gap: 12, justifyContent: 'center' }}>
               <Button variant='secondary' onClick={() => setShowLeaveConfirm(false)}>取消</Button>


### PR DESCRIPTION
Three surgical cleanups:

A. SessionSummary.tsx: replace raw hex colors with CSS variables. #0f3460 -> var(--color-bg-dark)
B. Extract shared confirmation modal styles from Room.tsx and Game.tsx into CSS class or component
C. Tile.tsx: face-down borderRadius 4 vs face-up 5 — unify to 4 (--radius-sm)

Files: SessionSummary.tsx, Room.tsx, Game.tsx, Tile.tsx, possibly new ConfirmModal component

Closes #271