### PR TITLE
Intercept browser back navigation during active game

### DIFF
--- a/apps/web/src/pages/Game.tsx
+++ b/apps/web/src/pages/Game.tsx
@@ -93,6 +93,22 @@ export function Game({ initialGameState, onLeave }: GameProps) {
     return () => window.removeEventListener('beforeunload', handler);
   }, [gameOver]);
 
+  // Intercept browser back button / swipe-back during active game
+  useEffect(() => {
+    if (gameOver) return;
+    // Push a dummy state so back button triggers popstate instead of leaving
+    history.pushState({ game: true }, "");
+
+    const handler = () => {
+      // Back was pressed — push state again and show confirm
+      history.pushState({ game: true }, "");
+      setShowLeaveConfirm(true);
+    };
+
+    window.addEventListener("popstate", handler);
+    return () => window.removeEventListener("popstate", handler);
+  }, [gameOver]);
+
   useEffect(() => {
     socket.on("gameStateUpdate", (state) => {
       // Play game start sound on first state update


### PR DESCRIPTION
beforeunload catches tab close but not popstate (back button/swipe-back). Add history.pushState + popstate listener during active game to prevent accidental back navigation.

When active game and popstate fires: push state back and show existing leave confirmation modal.
Clean up on gameOver or component unmount.

Files: Game.tsx only (add useEffect with pushState + popstate handler)

Closes #273