### PR TITLE
Add discard exit animation and fix hu announcement trigger

### DIFF
--- a/apps/web/src/animations.css
+++ b/apps/web/src/animations.css
@@ -15,6 +15,7 @@
  *   scoreReveal + meldEntrance → score/meld anim  (PlayerArea: round-end reveal)
  *   overlayFadeOut          → inline style        (ClaimOverlay: exit backdrop)
  *   overlayScaleOut         → inline style        (ClaimOverlay: exit modal + chi picker)
+ *   tileDeparting           → .tile-departing      (PlayerArea: discarded tile exit)
  *   pageFadeIn              → .page-transition    (index: page entrance)
  *   spin                    → .spinner            (index: loading spinner)
  */
@@ -63,6 +64,17 @@
 
 .discard-arrive {
   animation: discardArrive 0.3s ease-out;
+}
+
+/* Discard exit animation (tile leaves hand when discarded) */
+@keyframes tileDeparting {
+  0% { opacity: 1; transform: scale(1); }
+  100% { opacity: 0; transform: scale(0.5) translateY(20px); }
+}
+
+.tile-departing {
+  animation: tileDeparting 0.2s ease-in forwards;
+  pointer-events: none;
 }
 
 /* Hu celebration */

--- a/apps/web/src/components/GameTable.tsx
+++ b/apps/web/src/components/GameTable.tsx
@@ -31,9 +31,10 @@ interface GameTableProps {
   onBackgroundClick?: () => void;
   disconnectedPlayers?: Set<number>;
   drawAnimation?: DrawAnimationState | null;
+  departingTileId?: number | null;
 }
 
-export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTileId, claimableTileIds, canDiscard, onDiscard, canHu, onHu, canDraw, onDraw, kongTileIds, onAnGang, onBuGang, onBackgroundClick, disconnectedPlayers, drawAnimation }: GameTableProps) {
+export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTileId, claimableTileIds, canDiscard, onDiscard, canHu, onHu, canDraw, onDraw, kongTileIds, onAnGang, onBuGang, onBackgroundClick, disconnectedPlayers, drawAnimation, departingTileId }: GameTableProps) {
   const isCompact = useIsCompactLandscape();
   const { myHand, myFlowers, myMelds, myDiscards, myName, otherPlayers, currentTurn, myIndex, gold, dealerIndex, lianZhuangCount, wallRemaining, myHasDiscardedGold, cumulativeScores, roundsPlayed } = state;
   const lastDiscardTileId = state.lastDiscard?.tile.id ?? null;
@@ -164,6 +165,7 @@ export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTile
           hasDiscardedGold={myHasDiscardedGold}
           lastDrawnTileId={state.lastDrawnTileId}
           lastDiscardedTileId={lastDiscardPlayerIndex === myIndex ? lastDiscardTileId : null}
+          departingTileId={departingTileId}
           tenpaiTiles={state.tenpaiTiles}
           cumulativeScore={roundsPlayed > 0 ? cumulativeScores[myIndex] : undefined}
         />

--- a/apps/web/src/components/PlayerArea.tsx
+++ b/apps/web/src/components/PlayerArea.tsx
@@ -31,6 +31,7 @@ interface PlayerAreaProps {
   kongTileIds?: Set<number>;
   onAnGang?: (tileInstanceId: number) => void;
   onBuGang?: (tileInstanceId: number) => void;
+  departingTileId?: number | null;
   hasDiscardedGold?: boolean;
   isDisconnected?: boolean;
   compact?: boolean;
@@ -48,7 +49,7 @@ export function PlayerArea({
   isMe, hand, handCount, melds, flowers, discards,
   isCurrentTurn, isDealer, gold, selectedTileId, onTileClick, label,
   claimableTileIds, onTileDoubleClick, lastDrawnTileId, lastDiscardedTileId, tenpaiTiles,
-  canDiscard, onDiscard, canHu, onHu, kongTileIds, onAnGang, onBuGang, hasDiscardedGold,
+  canDiscard, onDiscard, canHu, onHu, kongTileIds, onAnGang, onBuGang, departingTileId, hasDiscardedGold,
   isDisconnected, compact, cumulativeScore,
 }: PlayerAreaProps) {
   const { onTouchStart: lpTouchStart, onTouchEnd: lpTouchEnd, onMouseEnter, onMouseLeave, Tooltip } = useLongPress(gold);
@@ -312,7 +313,7 @@ export function PlayerArea({
                 gold={gold}
                 selected={selectedTileId === t.id}
                 claimable={claimableTileIds?.has(t.id) || !!isKong}
-                className={lastDrawnTileId === t.id ? "tile-new" : undefined}
+                className={departingTileId === t.id ? "tile-departing" : lastDrawnTileId === t.id ? "tile-new" : undefined}
                 onTouchStart={(e) => lpTouchStart(t, e)}
                 onTouchEnd={lpTouchEnd}
                 onMouseEnter={(e) => onMouseEnter(t, e)}

--- a/apps/web/src/pages/Game.tsx
+++ b/apps/web/src/pages/Game.tsx
@@ -71,6 +71,7 @@ export function Game({ initialGameState, onLeave }: GameProps) {
   const [drawAnimation, setDrawAnimation] = useState<DrawAnimationState | null>(null);
   const drawAnimKeyRef = useRef(0);
   const [showLeaveConfirm, setShowLeaveConfirm] = useState(false);
+  const [departingTileId, setDepartingTileId] = useState<number | null>(null);
 
   // First-game auto-show tutorial
   useEffect(() => {
@@ -198,6 +199,7 @@ export function Game({ initialGameState, onLeave }: GameProps) {
         }
       }
 
+      setDepartingTileId(null);
       prevStateRef.current = state;
       setGameState(state);
     });
@@ -219,14 +221,20 @@ export function Game({ initialGameState, onLeave }: GameProps) {
       });
     });
     socket.on("gameOver", (result) => {
+      // Show hu announcement in center before transitioning to game-over screen
+      if (result.winnerId !== null) {
+        const winnerName = (result.playerNames ?? [])[result.winnerId] || `玩家${result.winnerId}`;
+        showClaim([], "hu", winnerName);
+        sounds.hu();
+      } else {
+        sounds.gameDraw();
+      }
       setGameOver(result);
       setRoundHistory((prev) => [...prev, {
         scores: result.scores,
         winnerId: result.winnerId,
         winType: result.winType,
       }]);
-      if (result.winnerId !== null) sounds.hu();
-      else sounds.gameDraw();
     });
     socket.on("playerDisconnected", (event: PlayerDisconnectedEvent) => {
       setDisconnectedPlayers((prev) => new Set(prev).add(event.playerIndex));
@@ -583,6 +591,7 @@ export function Game({ initialGameState, onLeave }: GameProps) {
         onTileSelect={(tile) => setSelectedTileId(tile?.id ?? null)}
         onTileDoubleClick={(tile) => {
           if (effectiveCanDiscard) {
+            setDepartingTileId(tile.id);
             handleAction({ type: ActionType.Discard, playerIndex: gameState.myIndex, tile });
           }
         }}
@@ -591,7 +600,10 @@ export function Game({ initialGameState, onLeave }: GameProps) {
         canDiscard={effectiveCanDiscard}
         onDiscard={(tileInstanceId) => {
           const tile = gameState.myHand.find(t => t.id === tileInstanceId);
-          if (tile) handleAction({ type: ActionType.Discard, playerIndex: gameState.myIndex, tile });
+          if (tile) {
+            setDepartingTileId(tileInstanceId);
+            handleAction({ type: ActionType.Discard, playerIndex: gameState.myIndex, tile });
+          }
         }}
         canHu={!!(actions?.canHu && effectiveCanDiscard)}
         onHu={() => handleAction({ type: ActionType.Hu, playerIndex: gameState.myIndex })}
@@ -609,6 +621,7 @@ export function Game({ initialGameState, onLeave }: GameProps) {
         onBackgroundClick={() => setSelectedTileId(null)}
         disconnectedPlayers={disconnectedPlayers}
         drawAnimation={drawAnimation}
+        departingTileId={departingTileId}
       />
       {isClaimWindow && actions && (
         <ClaimOverlay actions={actions} gameState={gameState} onAction={handleAction} />


### PR DESCRIPTION
Two high-visibility animation fixes:

A. Hand tile exit animation on discard — tile should fade+shrink before vanishing. Add .tile-departing CSS class.
B. Fix hu CenterAction never triggering — detect gameOver with winnerId and fire showClaim before overlay.

Files: PlayerArea.tsx, Game.tsx, CenterAction.tsx, animations.css

Closes #270