### PR TITLE
Add viewport-fit cover and safe-area insets for notched devices

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="description" content="福州麻将在线游戏 - Fuzhou Mahjong Online">
     <meta property="og:title" content="福州麻将 - Fuzhou Mahjong">
     <meta property="og:description" content="福州麻将在线游戏 - Fuzhou Mahjong Online">

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -27,6 +27,9 @@ body {
   flex-direction: column;
   flex: 1;
   min-height: 0;
+  padding-left: env(safe-area-inset-left, 0px);
+  padding-right: env(safe-area-inset-right, 0px);
+  padding-bottom: env(safe-area-inset-bottom, 0px);
 }
 
 /* Portrait rotate overlay — shown on mobile in portrait orientation */

--- a/apps/web/src/pages/Game.tsx
+++ b/apps/web/src/pages/Game.tsx
@@ -568,7 +568,7 @@ export function Game({ initialGameState, onLeave }: GameProps) {
       {/* Toast notifications */}
       <div style={{
         position: "fixed",
-        ...(isCompactMain ? { bottom: 60 } : { top: 16 }),
+        ...(isCompactMain ? { bottom: "calc(60px + env(safe-area-inset-bottom, 0px))" } : { top: 16 }),
         left: "50%", transform: "translateX(-50%)",
         zIndex: 9000, display: "flex", flexDirection: "column", gap: 8, alignItems: "center",
         pointerEvents: "none",
@@ -629,7 +629,7 @@ export function Game({ initialGameState, onLeave }: GameProps) {
       <TileCounter gameState={gameState} />
       {/* Help & Leave buttons — compact: top-right row; normal: bottom-right stacked */}
       {isCompactMain ? (
-        <div style={{ position: 'fixed', top: 8, right: 8, display: 'flex', gap: 4, zIndex: 20 }}>
+        <div style={{ position: 'fixed', top: 'calc(8px + env(safe-area-inset-top, 0px))', right: 'calc(8px + env(safe-area-inset-right, 0px))', display: 'flex', gap: 4, zIndex: 20 }}>
           <button
             onClick={() => { setTutorialCondensed(false); setShowTutorial(true); }}
             aria-label="How to play"
@@ -662,7 +662,7 @@ export function Game({ initialGameState, onLeave }: GameProps) {
               onClick={() => setShowLeaveConfirm(true)}
               aria-label="Leave game"
               style={{
-                position: "fixed", bottom: 56, right: 12,
+                position: "fixed", bottom: "calc(56px + env(safe-area-inset-bottom, 0px))", right: "calc(12px + env(safe-area-inset-right, 0px))",
                 width: 44, height: 44, minHeight: 44, borderRadius: "50%",
                 background: "rgba(15,30,25,0.85)", border: "1px solid rgba(184,134,11,0.4)",
                 color: "#ff5252", fontSize: 18, fontWeight: 700,
@@ -675,7 +675,7 @@ export function Game({ initialGameState, onLeave }: GameProps) {
             onClick={() => { setTutorialCondensed(false); setShowTutorial(true); }}
             aria-label="How to play"
             style={{
-              position: "fixed", bottom: 12, right: 12,
+              position: "fixed", bottom: "calc(12px + env(safe-area-inset-bottom, 0px))", right: "calc(12px + env(safe-area-inset-right, 0px))",
               width: 44, height: 44, minHeight: 44, borderRadius: "50%",
               background: "rgba(15,30,25,0.85)", border: "1px solid rgba(184,134,11,0.4)",
               color: "#8fbc8f", fontSize: 18, fontWeight: 700,


### PR DESCRIPTION
Missing viewport-fit=cover on meta tag. No safe-area awareness for notched iPhones.

1. Add viewport-fit=cover to index.html meta viewport
2. Add env(safe-area-inset-*) padding to game container in index.css
3. Update fixed-position buttons in Game.tsx to account for safe-area-inset-right/bottom
4. Toast positioning should respect safe areas
5. Falls back to 0 on non-notched devices

Files: index.html, index.css, Game.tsx fixed elements

Closes #276