### PR TITLE
Unify responsive breakpoints into shared constants

### DIFF
--- a/apps/web/src/components/TutorialModal.tsx
+++ b/apps/web/src/components/TutorialModal.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { TileView } from "./Tile";
 import type { TileInstance } from "@fuzhou-mahjong/shared";
 import { Suit } from "@fuzhou-mahjong/shared";
+import { BREAKPOINTS } from "../hooks/useIsMobile";
 
 /* Helper to create demo TileInstance objects for display */
 function demoTile(id: number, tile: TileInstance["tile"]): TileInstance {
@@ -219,7 +220,7 @@ export function TutorialModal({ open, onClose, condensed }: TutorialModalProps) 
 
   if (!open) return null;
 
-  const isCompact = window.innerHeight <= 500;
+  const isCompact = window.innerHeight <= BREAKPOINTS.COMPACT_HEIGHT;
   const slide = slides[currentSlide];
   const isFirst = currentSlide === 0;
   const isLast = currentSlide === slides.length - 1;

--- a/apps/web/src/hooks/useIsMobile.ts
+++ b/apps/web/src/hooks/useIsMobile.ts
@@ -1,12 +1,18 @@
 import { useState, useEffect } from "react";
 
-const COMPACT_HEIGHT_BREAKPOINT = 500;
+export const BREAKPOINTS = {
+  COMPACT_HEIGHT: 500,
+  SMALL_PHONE_HEIGHT: 390,
+  TABLET_WIDTH: 768,
+  PHONE_WIDTH: 480,
+  TINY_WIDTH: 360,
+} as const;
 
 export function useIsCompactLandscape(): boolean {
-  const [isCompact, setIsCompact] = useState(() => window.innerHeight <= COMPACT_HEIGHT_BREAKPOINT);
+  const [isCompact, setIsCompact] = useState(() => window.innerHeight <= BREAKPOINTS.COMPACT_HEIGHT);
 
   useEffect(() => {
-    const onResize = () => setIsCompact(window.innerHeight <= COMPACT_HEIGHT_BREAKPOINT);
+    const onResize = () => setIsCompact(window.innerHeight <= BREAKPOINTS.COMPACT_HEIGHT);
     window.addEventListener("resize", onResize);
     return () => window.removeEventListener("resize", onResize);
   }, []);

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -14,7 +14,6 @@ body {
   background: var(--color-bg-dark);
   color: var(--color-text-primary);
   width: 100%;
-  min-height: 100vh;
   min-height: 100dvh;
   display: flex;
   flex-direction: column;
@@ -45,6 +44,7 @@ body {
   gap: 20px;
 }
 
+/* BREAKPOINTS.TABLET_WIDTH */
 @media (orientation: portrait) and (max-width: 768px) {
   .portrait-rotate-overlay {
     display: flex;
@@ -114,6 +114,7 @@ body {
   --tile-margin: 1px;
 }
 
+/* BREAKPOINTS.TABLET_WIDTH */
 @media (max-width: 768px) {
   :root {
     --game-gap: 6px;
@@ -122,6 +123,7 @@ body {
   }
 }
 
+/* BREAKPOINTS.PHONE_WIDTH */
 @media (max-width: 480px) {
   :root {
     --tile-w: 34px;
@@ -145,6 +147,7 @@ body {
   }
 }
 
+/* BREAKPOINTS.TINY_WIDTH */
 @media (max-width: 360px) {
   :root {
     --tile-w: 28px;
@@ -165,6 +168,7 @@ body {
   }
 }
 
+/* BREAKPOINTS.COMPACT_HEIGHT */
 @media (orientation: landscape) and (max-height: 500px) {
   :root {
     --tile-w: 36px;
@@ -186,6 +190,7 @@ body {
   }
 }
 
+/* BREAKPOINTS.SMALL_PHONE_HEIGHT */
 @media (orientation: landscape) and (max-height: 390px) {
   :root {
     --game-gap: 1px;
@@ -196,7 +201,7 @@ body {
   }
 }
 
-/* Landscape compact layout for lobby/room */
+/* Landscape compact layout for lobby/room — BREAKPOINTS.COMPACT_HEIGHT */
 @media (orientation: landscape) and (max-height: 500px) {
   .lobby-page, .room-page {
     padding: 12px 20px;
@@ -343,7 +348,6 @@ hr {
 .lobby-page, .room-page {
   width: 100%;
   background: radial-gradient(ellipse at center, var(--color-bg-medium) 0%, var(--color-bg-dark) 70%);
-  min-height: 100vh;
   min-height: 100dvh;
   overflow-y: auto;
   position: relative;
@@ -483,6 +487,7 @@ button.lobby-create-btn:hover:not(:disabled) {
   }
 }
 
+/* BREAKPOINTS.PHONE_WIDTH */
 @media (max-width: 480px) {
   .seat-layout {
     gap: 6px;

--- a/apps/web/src/pages/Game.tsx
+++ b/apps/web/src/pages/Game.tsx
@@ -6,6 +6,7 @@ import { CenterAction, useCenterAction } from "../components/CenterAction";
 import { sounds } from "../sounds";
 import { TileCounter } from "../components/TileCounter";
 import { TutorialModal } from "../components/TutorialModal";
+import { BREAKPOINTS } from "../hooks/useIsMobile";
 import { TileView } from "../components/Tile";
 import { SessionSummary, type SessionData } from "../components/SessionSummary";
 import { Button } from "../components/Button";
@@ -313,7 +314,7 @@ export function Game({ initialGameState, onLeave }: GameProps) {
     ? (actions.canHu || actions.canPeng || actions.canMingGang || actions.chiOptions.length > 0) && !actions.canDiscard
     : false;
 
-  const isCompactMain = window.innerHeight <= 500;
+  const isCompactMain = window.innerHeight <= BREAKPOINTS.COMPACT_HEIGHT;
 
   const handleAction = (action: GameAction) => {
     socket.emit("playerAction", action);
@@ -345,7 +346,7 @@ export function Game({ initialGameState, onLeave }: GameProps) {
     };
 
     const [showAllHands, setShowAllHands] = useState(false);
-    const isCompact = window.innerHeight <= 500;
+    const isCompact = window.innerHeight <= BREAKPOINTS.COMPACT_HEIGHT;
 
     const isWin = gameOver.winnerId !== null;
     const confettiColors = ["#ff6b6b", "#ffd700", "#4caf50", "#2196f3", "#ff9800", "#e91e63"];


### PR DESCRIPTION
Scattered breakpoints: useIsMobile.ts (500), index.css (500/480/360/768), Game.tsx inline (500). Consolidate before mobile layout rewrite.

- CSS custom properties or shared constants for all breakpoints
- JS runtime checks use shared constants from useIsMobile.ts
- CSS media queries use consistent matching values
- Remove 100vh fallback, keep only 100dvh
- Pure refactor, no behavior changes

Files: useIsMobile.ts, index.css, Game.tsx (inline checks)

Closes #277