### PR TITLE
Mobile first-person GameTable grid with 60pct bottom hand area

### DIFF
--- a/apps/web/src/components/GameTable.tsx
+++ b/apps/web/src/components/GameTable.tsx
@@ -3,7 +3,7 @@ import { PlayerArea } from "./PlayerArea";
 import { GameInfo } from "./GameInfo";
 import { TileWall } from "./TileWall";
 import { TILE_BACK_URL } from "../tileSvg";
-import { useIsCompactLandscape } from "../hooks/useIsMobile";
+import { useIsCompactLandscape, useIsFirstPersonMobile } from "../hooks/useIsMobile";
 
 export type DrawAnimationSeat = "bottom" | "top" | "left" | "right";
 
@@ -36,6 +36,7 @@ interface GameTableProps {
 
 export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTileId, claimableTileIds, canDiscard, onDiscard, canHu, onHu, canDraw, onDraw, kongTileIds, onAnGang, onBuGang, onBackgroundClick, disconnectedPlayers, drawAnimation, departingTileId }: GameTableProps) {
   const isCompact = useIsCompactLandscape();
+  const isFirstPersonMobile = useIsFirstPersonMobile();
   const { myHand, myFlowers, myMelds, myDiscards, myName, otherPlayers, currentTurn, myIndex, gold, dealerIndex, lianZhuangCount, wallRemaining, myHasDiscardedGold, cumulativeScores, roundsPlayed } = state;
   const lastDiscardTileId = state.lastDiscard?.tile.id ?? null;
   const lastDiscardPlayerIndex = state.lastDiscard?.playerIndex ?? -1;
@@ -50,13 +51,11 @@ export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTile
   return (
     <div className="game-table" onClick={(e) => { if (e.target === e.currentTarget) onBackgroundClick?.(); }} style={{
       display: "grid",
-      gridTemplateAreas: `
-        ". top ."
-        "left center right"
-        ". bottom ."
-      `,
-      gridTemplateColumns: isCompact ? "60px 1fr 60px" : "1fr 2fr 1fr",
-      gridTemplateRows: isCompact ? "28px 40px 1fr" : "auto 1fr auto",
+      gridTemplateAreas: isFirstPersonMobile
+        ? `"left top right" "left center right" "bottom bottom bottom"`
+        : `". top ." "left center right" ". bottom ."`,
+      gridTemplateColumns: isFirstPersonMobile ? "44px 1fr 44px" : isCompact ? "60px 1fr 60px" : "1fr 2fr 1fr",
+      gridTemplateRows: isFirstPersonMobile ? "24px 1fr minmax(55%, 65%)" : isCompact ? "28px 40px 1fr" : "auto 1fr auto",
       flex: 1,
       minHeight: 0,
       gap: "var(--game-gap)",
@@ -80,6 +79,7 @@ export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTile
           hasDiscardedGold={otherPlayers[1]?.hasDiscardedGold}
           isDisconnected={disconnectedPlayers?.has((myIndex + 2) % 4)}
           compact={isCompact}
+          ultraCompact={isFirstPersonMobile}
           cumulativeScore={roundsPlayed > 0 ? cumulativeScores[(myIndex + 2) % 4] : undefined}
         />
       </div>
@@ -100,6 +100,7 @@ export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTile
           hasDiscardedGold={otherPlayers[2]?.hasDiscardedGold}
           isDisconnected={disconnectedPlayers?.has((myIndex + 3) % 4)}
           compact={isCompact}
+          ultraCompact={isFirstPersonMobile}
           cumulativeScore={roundsPlayed > 0 ? cumulativeScores[(myIndex + 3) % 4] : undefined}
         />
       </div>
@@ -135,6 +136,7 @@ export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTile
           hasDiscardedGold={otherPlayers[0]?.hasDiscardedGold}
           isDisconnected={disconnectedPlayers?.has((myIndex + 1) % 4)}
           compact={isCompact}
+          ultraCompact={isFirstPersonMobile}
           cumulativeScore={roundsPlayed > 0 ? cumulativeScores[(myIndex + 1) % 4] : undefined}
         />
       </div>
@@ -167,6 +169,7 @@ export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTile
           lastDiscardedTileId={lastDiscardPlayerIndex === myIndex ? lastDiscardTileId : null}
           departingTileId={departingTileId}
           tenpaiTiles={state.tenpaiTiles}
+          firstPerson={isFirstPersonMobile}
           cumulativeScore={roundsPlayed > 0 ? cumulativeScores[myIndex] : undefined}
         />
       </div>

--- a/apps/web/src/components/PlayerArea.tsx
+++ b/apps/web/src/components/PlayerArea.tsx
@@ -35,6 +35,8 @@ interface PlayerAreaProps {
   hasDiscardedGold?: boolean;
   isDisconnected?: boolean;
   compact?: boolean;
+  ultraCompact?: boolean;
+  firstPerson?: boolean;
   cumulativeScore?: number;
 }
 
@@ -50,7 +52,7 @@ export function PlayerArea({
   isCurrentTurn, isDealer, gold, selectedTileId, onTileClick, label,
   claimableTileIds, onTileDoubleClick, lastDrawnTileId, lastDiscardedTileId, tenpaiTiles,
   canDiscard, onDiscard, canHu, onHu, kongTileIds, onAnGang, onBuGang, departingTileId, hasDiscardedGold,
-  isDisconnected, compact, cumulativeScore,
+  isDisconnected, compact, ultraCompact, firstPerson, cumulativeScore,
 }: PlayerAreaProps) {
   const { onTouchStart: lpTouchStart, onTouchEnd: lpTouchEnd, onMouseEnter, onMouseLeave, Tooltip } = useLongPress(gold);
   const isCompactLandscape = useIsCompactLandscape();
@@ -98,6 +100,58 @@ export function PlayerArea({
     }
     prevMeldCountRef.current = melds.length;
   }, [melds.length]);
+
+  // Ultra-compact layout for opponents in first-person mobile mode
+  if (ultraCompact) {
+    return (
+      <div
+        className={`player-area-card${isCurrentTurn ? " current-turn" : ""} compact-opponent ultra-compact-opponent`}
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: 1,
+          padding: "2px",
+          background: isCurrentTurn ? "rgba(255,255,255,0.08)" : "rgba(0,0,0,0.3)",
+          border: isCurrentTurn ? "1px solid var(--color-gold-bright)" : undefined,
+          borderRadius: 3,
+          opacity: isDisconnected ? 0.5 : 1,
+          overflow: "hidden",
+          minHeight: 0,
+          fontSize: 8,
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 2 }}>
+          <span style={{ fontSize: 9, fontWeight: "bold", color: "#e8d5a3", whiteSpace: "nowrap" }}>{label}</span>
+          {isDealer && <span style={{ fontSize: 7, background: "#b71c1c", color: "var(--color-gold-bright)", padding: "0 2px", borderRadius: 2, fontWeight: "bold" }}>庄</span>}
+          {isCurrentTurn && <span style={{ fontSize: 7, background: "rgba(255,215,0,0.2)", color: "var(--color-gold-bright)", padding: "0 2px", borderRadius: 2 }}>出牌</span>}
+          <span style={{ fontSize: 8, color: "#8fbc8f", marginLeft: "auto" }}>{handCount ?? 0}张 🌸{flowers.length}</span>
+        </div>
+        {melds.length > 0 && (
+          <div style={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
+            {melds.map((m, mi) => (
+              <div key={mi} className={newestMeldIdx === mi ? "meld-new" : undefined} style={{ display: "flex", gap: 0 }}>
+                {m.tiles.map((t, ti) => (
+                  <TileView key={ti} tile={t} faceUp={m.type !== MeldType.AnGang} gold={gold} small
+                    style={{ width: "var(--fp-opponent-tile-w)", height: "var(--fp-opponent-tile-h)", fontSize: 6 }}
+                  />
+                ))}
+              </div>
+            ))}
+          </div>
+        )}
+        {discards.length > 0 && (
+          <div className="compact-discards" style={{ display: "flex", gap: 0, overflowX: "auto", overflowY: "hidden", minWidth: 0 }}>
+            {discards.map((d) => (
+              <TileView key={d.id} tile={d} faceUp gold={gold} small
+                style={{ width: "var(--fp-opponent-tile-w)", height: "var(--fp-opponent-tile-h)", fontSize: 6 }}
+                className={lastDiscardedTileId === d.id ? "discard-arrive last-discard" : undefined}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    );
+  }
 
   // Compact single-row layout for opponents on mobile landscape
   if (compact) {
@@ -219,7 +273,11 @@ export function PlayerArea({
       </div>
 
       {/* Hand */}
-      <div style={{ display: "flex", flexWrap: "wrap", gap: 1, marginBottom: 4, alignItems: "flex-end", paddingTop: isMe ? "var(--hand-padding-top)" : 0, overflow: "visible", position: "relative" }}>
+      <div style={{
+        display: "flex", flexWrap: "wrap", gap: firstPerson ? "var(--fp-hand-gap)" : 1, marginBottom: 4, alignItems: "flex-end",
+        paddingTop: isMe ? "var(--hand-padding-top)" : 0, overflow: "visible", position: "relative",
+        ...(firstPerson ? { "--tile-w": "var(--fp-tile-w)", "--tile-h": "var(--fp-tile-h)" } as React.CSSProperties : {}),
+      }}>
         {isMe && hand ? (
           hand.map((t, idx) => {
             const isSelected = selectedTileId === t.id;
@@ -365,8 +423,8 @@ export function PlayerArea({
         </div>
       )}
 
-      {/* Discards - horizontal scroll on compact landscape, grid otherwise */}
-      {discards.length > 0 && (isMe && isCompactLandscape ? (
+      {/* Discards - horizontal scroll on compact landscape / first-person, grid otherwise */}
+      {discards.length > 0 && (isMe && (isCompactLandscape || firstPerson) ? (
         <div className="compact-discards" style={{
           display: "flex",
           gap: 1,

--- a/apps/web/src/components/Tile.tsx
+++ b/apps/web/src/components/Tile.tsx
@@ -18,6 +18,7 @@ interface TileProps {
   onTouchEnd?: () => void;
   onMouseEnter?: (e: React.MouseEvent) => void;
   onMouseLeave?: () => void;
+  style?: React.CSSProperties;
 }
 
 const SUIT_CHARS: Record<string, string> = { wan: "万", bing: "饼", tiao: "条" };
@@ -46,10 +47,10 @@ function getTileDisplay(tile: Tile): { value: string; suit: string; color: strin
   }
 }
 
-export function TileView({ tile, faceUp = true, selected, claimable, onClick, onDoubleClick, gold, small, className, onTouchStart, onTouchEnd, onMouseEnter, onMouseLeave }: TileProps) {
-  const w = small ? "var(--tile-w-sm)" : "var(--tile-w)";
-  const h = small ? "var(--tile-h-sm)" : "var(--tile-h)";
-  const fontSize = small ? "var(--tile-font-sm)" : "var(--tile-font)";
+export function TileView({ tile, faceUp = true, selected, claimable, onClick, onDoubleClick, gold, small, className, onTouchStart, onTouchEnd, onMouseEnter, onMouseLeave, style: styleProp }: TileProps) {
+  const w = styleProp?.width as string ?? (small ? "var(--tile-w-sm)" : "var(--tile-w)");
+  const h = styleProp?.height as string ?? (small ? "var(--tile-h-sm)" : "var(--tile-h)");
+  const fontSize = styleProp?.fontSize as string ?? (small ? "var(--tile-font-sm)" : "var(--tile-font)");
   const suitSize = small ? "var(--tile-suit-font-sm)" : "var(--tile-suit-font)";
   const isGold = gold && isSuitedTile(tile.tile) && isGoldTile(tile, gold);
 

--- a/apps/web/src/hooks/useIsMobile.ts
+++ b/apps/web/src/hooks/useIsMobile.ts
@@ -19,3 +19,16 @@ export function useIsCompactLandscape(): boolean {
 
   return isCompact;
 }
+
+export function useIsFirstPersonMobile(): boolean {
+  const [isFP, setIsFP] = useState(
+    () => window.innerHeight <= BREAKPOINTS.COMPACT_HEIGHT && window.innerWidth <= 900
+  );
+  useEffect(() => {
+    const onResize = () =>
+      setIsFP(window.innerHeight <= BREAKPOINTS.COMPACT_HEIGHT && window.innerWidth <= 900);
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, []);
+  return isFP;
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -212,6 +212,11 @@ body {
     --compact-padding: 2px 8px;
     --compact-label-font: 12px;
     --compact-info-font: 11px;
+    --fp-tile-w: 38px;
+    --fp-tile-h: 56px;
+    --fp-opponent-tile-w: 18px;
+    --fp-opponent-tile-h: 26px;
+    --fp-hand-gap: 2px;
   }
 }
 
@@ -238,6 +243,11 @@ body {
     --compact-padding: 2px 4px;
     --compact-label-font: 10px;
     --compact-info-font: 9px;
+    --fp-tile-w: 32px;
+    --fp-tile-h: 46px;
+    --fp-opponent-tile-w: 16px;
+    --fp-opponent-tile-h: 22px;
+    --fp-hand-gap: 1px;
   }
   .game-table {
     grid-template-columns: 50px 1fr 50px;


### PR DESCRIPTION
Current compact layout gives equal weight to all players. Mobile needs first-person perspective like 雀魂.

A) useIsFirstPersonMobile hook (innerHeight<=500 && innerWidth<=900)
B) New grid: columns 44px/1fr/44px, rows 24px/1fr/minmax(55%,65%)
C) CSS vars: --fp-tile-w:38px, --fp-tile-h:56px, --fp-opponent-tile:18x26px
D) Bottom hand uses larger tiles, discards scrollable row above hand

Desktop unchanged.
Files: useIsMobile.ts, GameTable.tsx, index.css, PlayerArea.tsx

Closes #293