### PR TITLE
Responsive ClaimOverlay for compact and first-person mobile

### DIFF
--- a/apps/web/src/components/CenterAction.tsx
+++ b/apps/web/src/components/CenterAction.tsx
@@ -68,7 +68,7 @@ export function CenterAction({ display, gold }: { display: ActionDisplay | null;
         filter: "drop-shadow(0 4px 12px rgba(0,0,0,0.5))",
       }}>
         {display.tiles.map((t) => (
-          <div key={t.id} style={{ transform: "scale(1.8)" }}>
+          <div key={t.id} style={{ transform: `scale(${window.innerHeight <= 500 ? 1.2 : 1.8})` }}>
             <TileView tile={t} faceUp gold={gold} />
           </div>
         ))}

--- a/apps/web/src/components/ClaimOverlay.tsx
+++ b/apps/web/src/components/ClaimOverlay.tsx
@@ -23,6 +23,7 @@ const BTN = {
 };
 
 export function ClaimOverlay({ actions, gameState, onAction }: ClaimOverlayProps) {
+  const isCompact = window.innerHeight <= 500;
   const [showChiPicker, setShowChiPicker] = useState(false);
   const [exiting, setExiting] = useState(false);
   const [exitingChi, setExitingChi] = useState(false);
@@ -72,14 +73,14 @@ export function ClaimOverlay({ actions, gameState, onAction }: ClaimOverlayProps
         display: "flex",
         flexDirection: "column",
         alignItems: "center",
-        gap: 12,
+        gap: isCompact ? 6 : 12,
         maxWidth: "90vw",
         maxHeight: "90dvh",
         overflowY: "auto",
         animation: exiting ? "overlayScaleOut 0.18s ease-in forwards" : "overlayScaleIn 0.2s ease-out",
       }}>
         <div style={{ color: "var(--color-accent-orange)", fontWeight: "bold", fontSize: "var(--btn-font)", marginBottom: 4 }}>
-          可以操作！请选择
+          {isCompact ? "选择" : "可以操作！请选择"}
         </div>
 
         <div style={{ display: "flex", flexWrap: "wrap", justifyContent: "center", gap: 10 }}>
@@ -144,7 +145,7 @@ export function ClaimOverlay({ actions, gameState, onAction }: ClaimOverlayProps
         {actions.canPass && (
           <div style={{ borderTop: "1px solid rgba(255,255,255,0.1)", paddingTop: 8, width: "100%" , textAlign: "center" }}>
             <button
-              style={{ ...BTN.base, ...BTN.pass }}
+              style={{ ...BTN.base, ...BTN.pass, ...(isCompact ? { padding: "6px 12px" } : {}) }}
               onClick={() => handleAction({ type: ActionType.Pass, playerIndex: myIndex })}
             >
               过
@@ -181,8 +182,8 @@ export function ClaimOverlay({ actions, gameState, onAction }: ClaimOverlayProps
                     display: "flex",
                     gap: 4,
                     alignItems: "center",
-                    padding: "10px 16px",
-                    minHeight: 56,
+                    padding: isCompact ? "6px 10px" : "10px 16px",
+                    minHeight: isCompact ? 44 : 56,
                     scrollSnapAlign: "start",
                     flexShrink: 0,
                     borderRadius: 10,
@@ -215,7 +216,7 @@ export function ClaimOverlay({ actions, gameState, onAction }: ClaimOverlayProps
                 style={{
                   ...BTN.base,
                   ...BTN.pass,
-                  minHeight: 56,
+                  minHeight: isCompact ? 44 : 56,
                   scrollSnapAlign: "start",
                   flexShrink: 0,
                 }}


### PR DESCRIPTION
ClaimOverlay is the most critical interaction moment. On iPhone SE 375px height it eats most of the screen.

1. Detect isCompact inside ClaimOverlay
2. Compact: reduce padding, gap, font sizes. Max ~180px height
3. Chi-picker tiles verify small sizing
4. Header: shorten to 选择 in compact
5. All buttons >= 44px touch target
6. CenterAction scale(1.8) -> scale(1.2) on compact

Files: ClaimOverlay.tsx, CenterAction.tsx

Closes #301