### PR TITLE
Add discard travel and claim highlight animations

### DIFF
--- a/apps/web/src/animations.css
+++ b/apps/web/src/animations.css
@@ -16,6 +16,7 @@
  *   overlayFadeOut          → inline style        (ClaimOverlay: exit backdrop)
  *   overlayScaleOut         → inline style        (ClaimOverlay: exit modal + chi picker)
  *   tileDeparting           → .tile-departing      (PlayerArea: discarded tile exit)
+ *   discardFlyToPool        → inline style         (GameTable: discard fly overlay)
  *   pageFadeIn              → .page-transition    (index: page entrance)
  *   spin                    → .spinner            (index: loading spinner)
  */
@@ -294,6 +295,12 @@
 @keyframes centerActionOut {
   0% { opacity: 1; transform: translate(-50%, -50%) scale(1); }
   100% { opacity: 0; transform: translate(-50%, -50%) scale(0.5) translateY(20px); }
+}
+
+/* Hand-to-pool discard fly animation */
+@keyframes discardFlyToPool {
+  0% { transform: translate(0, 0) scale(1); opacity: 1; }
+  100% { transform: translate(0, -80px) scale(0.7); opacity: 0; }
 }
 
 /* Wall-to-hand draw fly animations */

--- a/apps/web/src/components/GameTable.tsx
+++ b/apps/web/src/components/GameTable.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect, useRef } from "react";
 import type { ClientGameState, TileInstance } from "@fuzhou-mahjong/shared";
 import { PlayerArea } from "./PlayerArea";
 import { GameInfo } from "./GameInfo";
@@ -37,6 +38,17 @@ interface GameTableProps {
 export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTileId, claimableTileIds, canDiscard, onDiscard, canHu, onHu, canDraw, onDraw, kongTileIds, onAnGang, onBuGang, onBackgroundClick, disconnectedPlayers, drawAnimation, departingTileId }: GameTableProps) {
   const isCompact = useIsCompactLandscape();
   const isFirstPersonMobile = useIsFirstPersonMobile();
+
+  // Discard fly overlay — triggered when a tile departs the hand
+  const [discardFlyKey, setDiscardFlyKey] = useState<number | null>(null);
+  const discardFlyKeyRef = useRef(0);
+  useEffect(() => {
+    if (departingTileId != null) {
+      const key = ++discardFlyKeyRef.current;
+      setDiscardFlyKey(key);
+      setTimeout(() => setDiscardFlyKey((cur) => (cur === key ? null : cur)), 500);
+    }
+  }, [departingTileId]);
   const { myHand, myFlowers, myMelds, myDiscards, myName, otherPlayers, currentTurn, myIndex, gold, dealerIndex, lianZhuangCount, wallRemaining, myHasDiscardedGold, cumulativeScores, roundsPlayed } = state;
   const lastDiscardTileId = state.lastDiscard?.tile.id ?? null;
   const lastDiscardPlayerIndex = state.lastDiscard?.playerIndex ?? -1;
@@ -173,6 +185,35 @@ export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTile
           cumulativeScore={roundsPlayed > 0 ? cumulativeScores[myIndex] : undefined}
         />
       </div>
+
+      {/* Discard fly overlay — tile travels from hand toward discard pool */}
+      {discardFlyKey != null && (
+        <div
+          key={discardFlyKey}
+          style={{
+            position: "absolute",
+            bottom: "15%",
+            left: "50%",
+            marginLeft: -6,
+            pointerEvents: "none",
+            zIndex: 20,
+            animation: "discardFlyToPool 0.3s ease-in forwards",
+          }}
+        >
+          <img
+            src={TILE_BACK_URL}
+            alt=""
+            style={{
+              width: "var(--wall-tw)",
+              height: "var(--wall-th)",
+              display: "block",
+              borderRadius: 2,
+              boxShadow: "0 1px 4px rgba(0,0,0,0.4)",
+            }}
+            draggable={false}
+          />
+        </div>
+      )}
 
       {/* Draw fly animation overlay */}
       {drawAnimation && (

--- a/apps/web/src/components/PlayerArea.tsx
+++ b/apps/web/src/components/PlayerArea.tsx
@@ -301,7 +301,7 @@ export function PlayerArea({
                 position: "relative",
                 transform: tileSwipeOffset < 0 ? `translateY(${tileSwipeOffset}px)` : undefined,
                 opacity: isSwiping ? 1 - Math.min(0.5, Math.abs(tileSwipeOffset) / 100) : 1,
-                transition: isSwiping ? "none" : "transform 0.2s ease, opacity 0.2s ease",
+                transition: isSwiping ? "none" : "transform 0.2s ease, opacity 0.2s ease, margin 0.15s ease",
                 boxShadow: swipeReady ? "0 0 12px rgba(0,184,148,0.6)" : undefined,
               }}
             >


### PR DESCRIPTION
Remaining animation gaps after #112/#125/#143/#146:

1. Discard travel: tile should visually fly from hand to discard pool (currently fades in place then appears in pool). Add overlay tile that travels from hand position to discard area.
2. Claim highlight: when a discard is claimed, briefly highlight it in the discard pool before it moves to the claimers meld area.
3. Hand gap close: when a tile leaves hand, remaining tiles should slide together smoothly (CSS gap transition).

All GPU-composited (transform/opacity only). Under 300ms.
Files: PlayerArea.tsx, GameTable.tsx, animations.css

Closes #296