### PR TITLE
Tokenize Lobby and Room page inline styles with CSS variables

### DIFF
--- a/apps/web/src/pages/Lobby.tsx
+++ b/apps/web/src/pages/Lobby.tsx
@@ -60,8 +60,8 @@ export function Lobby({ onJoined }: LobbyProps) {
     <div className="lobby-page" style={{ display: "flex", justifyContent: "center", padding: "max(16px, 3vh) max(12px, 3vw)" }}>
     <div className="lobby-content" style={{ maxWidth: 560, width: "100%", display: "flex", flexDirection: "column", gap: 20 }}>
       <div style={{ textAlign: "center", marginBottom: 8 }}>
-        <h1 style={{ fontSize: 36, color: "var(--color-text-primary)", marginBottom: 4 }}>福州麻将</h1>
-        <h2 style={{ fontSize: 16, color: "var(--color-text-secondary)", fontWeight: 400 }}>Fuzhou Mahjong</h2>
+        <h1 style={{ color: "var(--color-text-primary)", marginBottom: 4 }}>福州麻将</h1>
+        <h2 style={{ color: "var(--color-text-secondary)", fontWeight: 400 }}>Fuzhou Mahjong</h2>
       </div>
 
       <div>
@@ -70,7 +70,7 @@ export function Lobby({ onJoined }: LobbyProps) {
           placeholder="你的名字 / Your name"
           value={name}
           onChange={(e) => setName(e.target.value)}
-          style={{ width: "100%", padding: "10px 12px", fontSize: 16, boxSizing: "border-box" }}
+          style={{ width: "100%", padding: "var(--btn-padding)", fontSize: "var(--lobby-subtitle-font)", boxSizing: "border-box" }}
         />
       </div>
 
@@ -81,11 +81,11 @@ export function Lobby({ onJoined }: LobbyProps) {
           onClick={handleQuickStart}
           disabled={quickStarting}
           className="lobby-create-btn"
-          style={{ width: "100%", background: "linear-gradient(135deg, var(--color-bg-button) 0%, var(--color-bg-button-hover) 100%)", border: "2px solid rgba(212, 160, 23, 0.8)", boxShadow: "0 0 12px rgba(212, 160, 23, 0.3)" }}
+          style={{ width: "100%", background: "linear-gradient(135deg, var(--color-bg-button) 0%, var(--color-bg-button-hover) 100%)", border: "2px solid var(--color-gold-border-hover)", boxShadow: "0 0 12px rgba(212, 160, 23, 0.3)" }}
         >
           {quickStarting ? "启动中... / Starting..." : "⚡ 快速开始 / Quick Start"}
         </Button>
-        <p style={{ color: "var(--color-text-secondary)", fontSize: 13, textAlign: "center" }}>
+        <p style={{ color: "var(--color-text-secondary)", fontSize: "var(--label-font)", textAlign: "center" }}>
           一键开局，自动匹配 3 个机器人
         </p>
       </div>
@@ -101,7 +101,7 @@ export function Lobby({ onJoined }: LobbyProps) {
         >
           创建房间 / Create Room
         </Button>
-        <p style={{ color: "var(--color-text-secondary)", fontSize: 13, textAlign: "center" }}>
+        <p style={{ color: "var(--color-text-secondary)", fontSize: "var(--label-font)", textAlign: "center" }}>
           创建房间后可邀请朋友或添加机器人
         </p>
       </div>
@@ -127,10 +127,10 @@ export function Lobby({ onJoined }: LobbyProps) {
                 <div>
                   <div style={{ display: "flex", gap: 6, marginBottom: 4 }}>
                     {Array.from({ length: room.maxPlayers }).map((_, i) => (
-                      <span key={i} style={{ width: 10, height: 10, borderRadius: "50%", background: i < room.playerCount ? "var(--color-bg-button-hover)" : "rgba(184, 134, 11, 0.15)", border: "1px solid rgba(184, 134, 11, 0.3)", display: "inline-block" }} />
+                      <span key={i} style={{ width: 10, height: 10, borderRadius: "var(--radius-sm)", background: i < room.playerCount ? "var(--color-bg-button-hover)" : "rgba(184, 134, 11, 0.15)", border: "1px solid rgba(184, 134, 11, 0.3)", display: "inline-block" }} />
                     ))}
                   </div>
-                  <span style={{ color: "var(--color-text-secondary)", fontSize: 13 }}>
+                  <span style={{ color: "var(--color-text-secondary)", fontSize: "var(--label-font)" }}>
                     {room.players.join(", ")}
                   </span>
                 </div>
@@ -156,7 +156,7 @@ export function Lobby({ onJoined }: LobbyProps) {
           value={roomCode}
           onChange={(e) => setRoomCode(e.target.value.toUpperCase())}
           maxLength={4}
-          style={{ flex: 1, padding: "10px 12px", fontSize: 16, textTransform: "uppercase", letterSpacing: 4, textAlign: "center" }}
+          style={{ flex: 1, padding: "var(--btn-padding)", fontSize: "var(--lobby-subtitle-font)", textTransform: "uppercase", letterSpacing: 4, textAlign: "center" }}
         />
         <Button
           onClick={() => handleJoin(roomCode.trim())}

--- a/apps/web/src/pages/Room.tsx
+++ b/apps/web/src/pages/Room.tsx
@@ -50,7 +50,7 @@ export function Room({ initialRoomState, sessionScores }: RoomProps) {
   return (
     <div className="room-page" style={{ display: "flex", justifyContent: "center", padding: "max(16px, 3vh) max(12px, 3vw)" }}>
     <div style={{ maxWidth: 480, width: "100%" }}>
-      <h2 style={{ textAlign: "center", color: "var(--color-text-secondary)", fontSize: 15, fontWeight: 400, marginBottom: 20 }}>房间 / Room</h2>
+      <h2 style={{ textAlign: "center", color: "var(--color-text-secondary)", fontSize: "var(--label-font)", fontWeight: 400, marginBottom: 20 }}>房间 / Room</h2>
 
       {/* Mahjong table seat layout */}
       <div className="seat-layout">
@@ -64,15 +64,15 @@ export function Room({ initialRoomState, sessionScores }: RoomProps) {
         </div>
         {/* Center: room ID */}
         <div className="table-center" style={{ gridArea: "center" }}>
-          <div style={{ fontSize: 11, color: "var(--color-text-secondary)", marginBottom: 4 }}>ROOM</div>
-          <div style={{ fontSize: 28, fontWeight: "bold", fontFamily: "monospace", letterSpacing: 6, color: "var(--color-text-gold)" }}>
+          <div style={{ fontSize: "var(--compact-info-font)", color: "var(--color-text-secondary)", marginBottom: 4 }}>ROOM</div>
+          <div style={{ fontSize: "var(--lobby-title-font)", fontWeight: "bold", fontFamily: "monospace", letterSpacing: 6, color: "var(--color-text-gold)" }}>
             {room.roomId}
           </div>
-          <div style={{ fontSize: 12, color: "var(--color-text-secondary)", marginTop: 6 }}>
+          <div style={{ fontSize: "var(--compact-info-font)", color: "var(--color-text-secondary)", marginTop: 6 }}>
             {room.players.length}/4 玩家
           </div>
           {sessionScores && sessionScores.roundsPlayed > 0 && (
-            <div style={{ fontSize: 11, color: "var(--color-text-gold)", marginTop: 4 }}>
+            <div style={{ fontSize: "var(--compact-info-font)", color: "var(--color-text-gold)", marginTop: 4 }}>
               已完成 {sessionScores.roundsPlayed} 局
             </div>
           )}
@@ -125,7 +125,7 @@ export function Room({ initialRoomState, sessionScores }: RoomProps) {
       {showLeaveConfirm && (
         <div className="confirm-modal-backdrop">
           <div className="confirm-modal">
-            <p style={{ fontSize: 18, marginBottom: 16 }}>确定要离开房间吗？</p>
+            <p style={{ fontSize: "var(--lobby-subtitle-font)", marginBottom: 16 }}>确定要离开房间吗？</p>
             <div style={{ display: 'flex', gap: 12, justifyContent: 'center' }}>
               <Button variant='secondary' onClick={() => setShowLeaveConfirm(false)}>取消</Button>
               <Button variant='danger' onClick={handleLeave}>离开</Button>
@@ -144,16 +144,16 @@ function SeatCard({ seat, score }: { seat: { index: number; player: { name: stri
 
   return (
     <div className={`seat-card ${isEmpty ? "seat-empty" : "seat-filled"}`}>
-      <div style={{ fontSize: 11, color: "var(--color-text-gold)", marginBottom: 4, letterSpacing: 1 }}>{wind}</div>
+      <div style={{ fontSize: "var(--compact-info-font)", color: "var(--color-text-gold)", marginBottom: 4, letterSpacing: 1 }}>{wind}</div>
       {player ? (
         <>
-          <div style={{ fontSize: 15, fontWeight: 600, color: "var(--color-text-primary)" }}>
+          <div style={{ fontSize: "var(--label-font)", fontWeight: 600, color: "var(--color-text-primary)" }}>
             {player.name}
           </div>
-          {player.isBot && <div style={{ fontSize: 11, color: "var(--color-text-secondary)", marginTop: 2 }}>🤖 Bot</div>}
+          {player.isBot && <div style={{ fontSize: "var(--compact-info-font)", color: "var(--color-text-secondary)", marginTop: 2 }}>🤖 Bot</div>}
           {score != null && (
             <div style={{
-              fontSize: 12, fontWeight: "bold", marginTop: 2,
+              fontSize: "var(--compact-info-font)", fontWeight: "bold", marginTop: 2,
               color: score > 0 ? "var(--color-text-gold)" : score < 0 ? "var(--color-error)" : "var(--color-text-secondary)",
             }}>
               {score > 0 ? "+" : ""}{score}
@@ -161,7 +161,7 @@ function SeatCard({ seat, score }: { seat: { index: number; player: { name: stri
           )}
         </>
       ) : (
-        <div style={{ fontSize: 13, opacity: 0.5, color: "var(--color-text-secondary)" }}>空位 / Empty</div>
+        <div style={{ fontSize: "var(--label-font)", opacity: 0.5, color: "var(--color-text-secondary)" }}>空位 / Empty</div>
       )}
     </div>
   );


### PR DESCRIPTION
Lobby and Room have dozens of hardcoded inline values while CSS variables exist unused.

Lobby.tsx: fontSize 36/16 -> var(--lobby-title/subtitle-font), input padding -> var(--btn-padding), badge colors -> var(--color-error-bg) etc, label fonts -> var(--label-font)
Room.tsx: SeatCard -> var(--seat-card-padding/--seat-gap), font sizes -> var(--label-font/--lobby-title-font), room ID color -> var(--color-text-gold)

Use existing CSS vars. Tokenization only, no layout redesign.
Files: Lobby.tsx, Room.tsx

Closes #313