### PR TITLE
Add claim fly animation for chi peng gang tile movement

### DIFF
--- a/apps/web/src/animations.css
+++ b/apps/web/src/animations.css
@@ -343,6 +343,24 @@
   100% { transform: translate(120px, 0) scale(0.8); opacity: 0; filter: brightness(1); }
 }
 
+/* Pool-to-player claim fly animations (chi/peng/gang) */
+@keyframes claimFlyBottom {
+  0% { transform: translate(0, -60px) scale(0.8); opacity: 1; }
+  100% { transform: translate(0, 0) scale(1); opacity: 0; }
+}
+@keyframes claimFlyTop {
+  0% { transform: translate(0, 60px) scale(0.8); opacity: 1; }
+  100% { transform: translate(0, 0) scale(1); opacity: 0; }
+}
+@keyframes claimFlyLeft {
+  0% { transform: translate(60px, 0) scale(0.8); opacity: 1; }
+  100% { transform: translate(0, 0) scale(1); opacity: 0; }
+}
+@keyframes claimFlyRight {
+  0% { transform: translate(-60px, 0) scale(0.8); opacity: 1; }
+  100% { transform: translate(0, 0) scale(1); opacity: 0; }
+}
+
 /* Score flash animation */
 @keyframes scoreFlash {
   0% { opacity: 0; transform: translateY(4px) scale(0.9); }

--- a/apps/web/src/components/GameTable.tsx
+++ b/apps/web/src/components/GameTable.tsx
@@ -32,10 +32,11 @@ interface GameTableProps {
   onBackgroundClick?: () => void;
   disconnectedPlayers?: Set<number>;
   drawAnimation?: DrawAnimationState | null;
+  claimAnimation?: { seat: DrawAnimationSeat; key: number } | null;
   departingTileId?: number | null;
 }
 
-export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTileId, claimableTileIds, canDiscard, onDiscard, canHu, onHu, canDraw, onDraw, kongTileIds, onAnGang, onBuGang, onBackgroundClick, disconnectedPlayers, drawAnimation, departingTileId }: GameTableProps) {
+export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTileId, claimableTileIds, canDiscard, onDiscard, canHu, onHu, canDraw, onDraw, kongTileIds, onAnGang, onBuGang, onBackgroundClick, disconnectedPlayers, drawAnimation, claimAnimation, departingTileId }: GameTableProps) {
   const isCompact = useIsCompactLandscape();
   const isFirstPersonMobile = useIsFirstPersonMobile();
 
@@ -241,6 +242,36 @@ export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTile
               boxShadow: drawAnimation.isSupplement
                 ? "0 0 8px rgba(255,215,0,0.6)"
                 : "0 1px 4px rgba(0,0,0,0.4)",
+            }}
+            draggable={false}
+          />
+        </div>
+      )}
+
+      {/* Claim fly animation overlay — tile travels from pool toward claiming player */}
+      {claimAnimation && (
+        <div
+          key={claimAnimation.key}
+          style={{
+            position: "absolute",
+            top: "50%",
+            left: "50%",
+            marginTop: -8,
+            marginLeft: -6,
+            pointerEvents: "none",
+            zIndex: 20,
+            animation: `claimFly${claimAnimation.seat.charAt(0).toUpperCase() + claimAnimation.seat.slice(1)} 0.3s ease-out forwards`,
+          }}
+        >
+          <img
+            src={TILE_BACK_URL}
+            alt=""
+            style={{
+              width: "var(--wall-tw)",
+              height: "var(--wall-th)",
+              display: "block",
+              borderRadius: 2,
+              boxShadow: "0 1px 4px rgba(0,0,0,0.4)",
             }}
             draggable={false}
           />

--- a/apps/web/src/pages/Game.tsx
+++ b/apps/web/src/pages/Game.tsx
@@ -71,6 +71,8 @@ export function Game({ initialGameState, onLeave }: GameProps) {
   const [tutorialCondensed, setTutorialCondensed] = useState(false);
   const [drawAnimation, setDrawAnimation] = useState<DrawAnimationState | null>(null);
   const drawAnimKeyRef = useRef(0);
+  const [claimAnimation, setClaimAnimation] = useState<{ seat: DrawAnimationSeat; key: number } | null>(null);
+  const claimAnimKeyRef = useRef(0);
   const [showLeaveConfirm, setShowLeaveConfirm] = useState(false);
   const [departingTileId, setDepartingTileId] = useState<number | null>(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
@@ -181,12 +183,17 @@ export function Game({ initialGameState, onLeave }: GameProps) {
         const newMelds = state.myMelds.length + state.otherPlayers.reduce((s, p) => s + p.melds.length, 0);
         if (newMelds > prevMelds) {
           // Find which player got a new meld
+          const seatMap: DrawAnimationSeat[] = ["bottom", "right", "top", "left"];
           if (state.myMelds.length > prev.myMelds.length) {
             const meld = state.myMelds[state.myMelds.length - 1];
             showClaim(meld.tiles, meld.type, state.myName || "我");
             if (meld.type === "chi") sounds.chi();
             else if (meld.type === "peng") sounds.peng();
             else sounds.gang();
+            // Claim fly toward bottom (self)
+            const ck = ++claimAnimKeyRef.current;
+            setClaimAnimation({ seat: "bottom", key: ck });
+            setTimeout(() => setClaimAnimation((cur) => cur?.key === ck ? null : cur), 300);
           } else {
             for (let i = 0; i < state.otherPlayers.length; i++) {
               if (state.otherPlayers[i].melds.length > (prev.otherPlayers[i]?.melds.length || 0)) {
@@ -195,6 +202,11 @@ export function Game({ initialGameState, onLeave }: GameProps) {
                 if (meld.type === "chi") sounds.chi();
                 else if (meld.type === "peng") sounds.peng();
                 else sounds.gang();
+                // Claim fly toward the claiming player's seat
+                const seat = seatMap[i + 1]; // otherPlayers[0]=right, [1]=top, [2]=left
+                const ck = ++claimAnimKeyRef.current;
+                setClaimAnimation({ seat, key: ck });
+                setTimeout(() => setClaimAnimation((cur) => cur?.key === ck ? null : cur), 300);
                 break;
               }
             }
@@ -642,6 +654,7 @@ export function Game({ initialGameState, onLeave }: GameProps) {
         onBackgroundClick={() => setSelectedTileId(null)}
         disconnectedPlayers={disconnectedPlayers}
         drawAnimation={drawAnimation}
+        claimAnimation={claimAnimation}
         departingTileId={departingTileId}
       />
       {isClaimWindow && actions && (


### PR DESCRIPTION
When a tile is claimed, it should fly from discard area to the claimers meld area. Currently meld just appears via .meld-new scale. Add directional claimFly animation (Bottom/Top/Left/Right variants like drawFly). 200-300ms.

Files: animations.css (new keyframes), GameTable.tsx (overlay), Game.tsx (detect claim event)

Closes #319