### PR TITLE
Meld assembly positional animation for hand tiles joining meld

### DIFF
--- a/apps/web/src/animations.css
+++ b/apps/web/src/animations.css
@@ -392,8 +392,9 @@
 
 /* Meld entrance animation */
 @keyframes meldEntrance {
-  from { opacity: 0; transform: scale(0.8); }
-  to { opacity: 1; transform: scale(1); }
+  from { opacity: 0; transform: scale(0.8) translateX(-12px); }
+  50% { opacity: 1; transform: scale(1.05) translateX(2px); }
+  to { opacity: 1; transform: scale(1) translateX(0); }
 }
 
 .meld-new {


### PR DESCRIPTION
After claim fly lands, hand tiles forming the meld just pop in. Add 200-300ms slide-into-position for tiles joining a new meld. Independent from claim fly overlay.

Files: animations.css (enhance meldEntrance), PlayerArea.tsx (all 3 layout tiers)

Closes #324