### PR TITLE
iPhone SE and 16 landscape stress test with fp-side-col fixes

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -289,6 +289,8 @@ body {
     --fp-hand-gap: 1px;
     --grid-side-col: 50px;
     --wall-progress-w: 60px;
+    --fp-side-col: 36px;
+    --fp-top-row: 20px;
   }
 }
 


### PR DESCRIPTION
First-person layout not validated at real sizes. --fp-side-col 44px never overridden at 390px. Tile touch targets may be below 44px.

Fix: reduce --fp-side-col to 36-38px at 390px. Verify --fp-top-row. Confirm tile touch targets. Test 667x375 and 844x390.

Files: index.css, useIsMobile.ts, GameTable.tsx, PlayerArea.tsx

Closes #323