### PR TITLE
Improve small phone opponent readability with larger tiles and fonts

### DIFF
--- a/apps/web/src/components/PlayerArea.tsx
+++ b/apps/web/src/components/PlayerArea.tsx
@@ -117,14 +117,14 @@ export function PlayerArea({
           opacity: isDisconnected ? 0.5 : 1,
           overflow: "hidden",
           minHeight: 0,
-          fontSize: 8,
+          fontSize: 10,
         }}
       >
         <div style={{ display: "flex", alignItems: "center", gap: 2 }}>
-          <span style={{ fontSize: 9, fontWeight: "bold", color: "var(--color-text-warm)", whiteSpace: "nowrap" }}>{label}</span>
+          <span style={{ fontSize: 10, fontWeight: "bold", color: "var(--color-text-warm)", whiteSpace: "nowrap" }}>{label}</span>
           {isDealer && <span style={{ fontSize: 7, background: "var(--color-dealer-bg)", color: "var(--color-gold-bright)", padding: "0 2px", borderRadius: 2, fontWeight: "bold" }}>庄</span>}
           {isCurrentTurn && <span style={{ fontSize: 7, background: "rgba(255,215,0,0.2)", color: "var(--color-gold-bright)", padding: "0 2px", borderRadius: 2 }}>出牌</span>}
-          <span style={{ fontSize: 8, color: "var(--color-text-secondary)", marginLeft: "auto" }}>{handCount ?? 0}张 🌸{flowers.length}</span>
+          <span style={{ fontSize: 10, color: "var(--color-text-secondary)", marginLeft: "auto" }}>{handCount ?? 0}张 🌸{flowers.length}</span>
         </div>
         {melds.length > 0 && (
           <div style={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
@@ -141,13 +141,14 @@ export function PlayerArea({
           </div>
         )}
         {discards.length > 0 && (
-          <div className="compact-discards" style={{ display: "flex", gap: 0, overflowX: "auto", overflowY: "hidden", minWidth: 0 }}>
-            {discards.map((d) => (
+          <div className="compact-discards" style={{ display: "flex", gap: 0, overflowX: "auto", overflowY: "hidden", minWidth: 0, alignItems: "center" }}>
+            {discards.slice(-6).map((d) => (
               <TileView key={d.id} tile={d} faceUp gold={gold} small
                 style={{ width: "var(--fp-opponent-tile-w)", height: "var(--fp-opponent-tile-h)", fontSize: 6 }}
                 className={lastDiscardedTileId === d.id ? "discard-arrive last-discard" : undefined}
               />
             ))}
+            {discards.length > 6 && <span style={{ fontSize: 8, color: "var(--color-text-muted)" }}>+{discards.length - 6}</span>}
           </div>
         )}
       </div>

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -246,8 +246,8 @@ body {
     --compact-info-font: 11px;
     --fp-tile-w: 38px;
     --fp-tile-h: 56px;
-    --fp-opponent-tile-w: 18px;
-    --fp-opponent-tile-h: 26px;
+    --fp-opponent-tile-w: 20px;
+    --fp-opponent-tile-h: 28px;
     --fp-hand-gap: 2px;
     --lobby-title-font: 24px;
     --lobby-subtitle-font: 13px;
@@ -284,8 +284,8 @@ body {
     --compact-info-font: 9px;
     --fp-tile-w: 32px;
     --fp-tile-h: 46px;
-    --fp-opponent-tile-w: 16px;
-    --fp-opponent-tile-h: 22px;
+    --fp-opponent-tile-w: 20px;
+    --fp-opponent-tile-h: 28px;
     --fp-hand-gap: 1px;
     --grid-side-col: 50px;
     --wall-progress-w: 60px;


### PR DESCRIPTION
On iPhone SE 667x375, opponent tiles are 18x26px with 8-9px fonts — nearly unreadable.

Fix: increase --fp-opponent-tile to 20x28, bump opponent font to 10px min, limit visible discards to recent 4-6 with count badge.
Verify layout still fits without scroll.

Files: PlayerArea.tsx, index.css, GameTable.tsx

Closes #331