### PR TITLE
Add scroll fade indicators for horizontal opponent discards

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -775,6 +775,8 @@ button.lobby-create-btn:hover:not(:disabled) {
 .compact-discards {
   scrollbar-width: none; /* Firefox */
   -ms-overflow-style: none; /* IE/Edge */
+  mask-image: linear-gradient(to right, transparent 0%, black 8px, black calc(100% - 16px), transparent 100%);
+  -webkit-mask-image: linear-gradient(to right, transparent 0%, black 8px, black calc(100% - 16px), transparent 100%);
 }
 .compact-discards::-webkit-scrollbar {
   display: none; /* Chrome/Safari */


### PR DESCRIPTION
Compact opponent discards scroll horizontally with no visual cue. Add right-edge fade gradient and left when scrolled to indicate scrollability.

Pure CSS plus minor React for scroll state detection.
Files: PlayerArea.tsx, index.css

Closes #335