### PR TITLE
Conditionally render portrait-rotate-overlay instead of CSS hide

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -31,9 +31,9 @@ body {
   padding-bottom: env(safe-area-inset-bottom, 0px);
 }
 
-/* Portrait rotate overlay — shown on mobile in portrait orientation */
+/* Portrait rotate overlay — conditionally rendered via React state */
 .portrait-rotate-overlay {
-  display: none;
+  display: flex;
   position: fixed;
   inset: 0;
   z-index: 9999;
@@ -42,13 +42,6 @@ body {
   align-items: center;
   justify-content: center;
   gap: 20px;
-}
-
-/* BREAKPOINTS.TABLET_WIDTH */
-@media (orientation: portrait) and (max-width: 768px) {
-  .portrait-rotate-overlay {
-    display: flex;
-  }
 }
 
 #root {

--- a/apps/web/src/pages/Game.tsx
+++ b/apps/web/src/pages/Game.tsx
@@ -77,6 +77,14 @@ export function Game({ initialGameState, onLeave }: GameProps) {
   const [departingTileId, setDepartingTileId] = useState<number | null>(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [muted, setMutedState] = useState(isMuted);
+  const [isPortrait, setIsPortrait] = useState(() => window.matchMedia("(orientation: portrait)").matches && window.innerWidth <= 768);
+
+  useEffect(() => {
+    const mq = window.matchMedia("(orientation: portrait) and (max-width: 768px)");
+    const handler = (e: MediaQueryListEvent) => setIsPortrait(e.matches);
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, []);
   const settingsRef = useRef<HTMLDivElement>(null);
 
   // Close settings dropdown on click outside
@@ -381,10 +389,13 @@ export function Game({ initialGameState, onLeave }: GameProps) {
 
     return (
       <div>
-        <div className="portrait-rotate-overlay">
-          <div style={{ fontSize: 48, animation: 'rotatePhone 2s ease-in-out infinite' }}>📱</div>
-          <div style={{ fontSize: 18, color: '#eee' }}>请旋转手机</div>
-        </div>
+        {isPortrait && (
+          <div className="portrait-rotate-overlay">
+            <div style={{ fontSize: 48, animation: 'rotatePhone 2s ease-in-out infinite' }}>📱</div>
+            <div style={{ fontSize: 18, color: '#eee' }}>请旋转手机</div>
+            <div style={{ fontSize: 14, color: 'var(--color-text-secondary)' }}>Please rotate your phone</div>
+          </div>
+        )}
         {isWin && (
           <div className="confetti-container">
             {Array.from({ length: isCompact ? 10 : 30 }).map((_, i) => (
@@ -588,11 +599,13 @@ export function Game({ initialGameState, onLeave }: GameProps) {
 
   return (
     <div className="game-wrapper">
-      <div className="portrait-rotate-overlay">
-        <div style={{ fontSize: 48, animation: 'rotatePhone 2s ease-in-out infinite' }}>📱</div>
-        <div style={{ fontSize: 18, color: '#eee' }}>请旋转手机</div>
-        <div style={{ fontSize: 14, color: 'var(--color-text-secondary)' }}>Please rotate your phone</div>
-      </div>
+      {isPortrait && (
+        <div className="portrait-rotate-overlay">
+          <div style={{ fontSize: 48, animation: 'rotatePhone 2s ease-in-out infinite' }}>📱</div>
+          <div style={{ fontSize: 18, color: '#eee' }}>请旋转手机</div>
+          <div style={{ fontSize: 14, color: 'var(--color-text-secondary)' }}>Please rotate your phone</div>
+        </div>
+      )}
       {showFlash && (
         <>
           <div className="screen-flash" />


### PR DESCRIPTION
Portrait overlay always rendered in DOM, just CSS-hidden in landscape. Change to conditional render based on orientation state to avoid unnecessary DOM nodes and animation overhead.

Files: Game.tsx (portrait overlay sections)

Closes #336