### PR TITLE
Fix ClaimOverlay and discard bubble viewport overflow on small phones

### DIFF
--- a/apps/web/src/components/ClaimOverlay.tsx
+++ b/apps/web/src/components/ClaimOverlay.tsx
@@ -76,7 +76,7 @@ export function ClaimOverlay({ actions, gameState, onAction }: ClaimOverlayProps
         alignItems: "center",
         gap: isCompact ? 6 : 12,
         maxWidth: "90vw",
-        maxHeight: "90dvh",
+        maxHeight: isCompact ? "80dvh" : "90dvh",
         overflowY: "auto",
         animation: exiting ? "overlayScaleOut 0.18s ease-in forwards" : "overlayScaleIn 0.2s ease-out",
       }}>

--- a/apps/web/src/components/PlayerArea.tsx
+++ b/apps/web/src/components/PlayerArea.tsx
@@ -319,13 +319,14 @@ export function PlayerArea({
               {showBubble && (
                 <div className="discard-bubble" style={{
                   position: "absolute",
-                  bottom: "100%",
+                  ...(isCompactLandscape
+                    ? { top: "100%", marginTop: 4 }
+                    : { bottom: "100%", marginBottom: 4 }),
                   left: "50%",
                   transform: "translateX(-50%)",
                   display: "flex",
                   flexDirection: "column",
                   gap: 4,
-                  marginBottom: 4,
                   zIndex: 20,
                   animation: "bubbleFadeIn 0.15s ease-out",
                 }}>


### PR DESCRIPTION
ClaimOverlay 90dvh covers too much on 375px. Discard bubble can clip above viewport.

Files: ClaimOverlay.tsx, PlayerArea.tsx

Closes #337