### PR TITLE
Extract Lobby ternary inline styles to CSS classes

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -518,11 +518,43 @@ hr {
   margin-top: 10px;
 }
 
+/* Room status badge — full / waiting variants */
+.room-badge-full {
+  background: rgba(255,82,82,0.2);
+  color: var(--color-error);
+  border: 1px solid rgba(255,82,82,0.3);
+  padding: 2px 10px;
+  border-radius: 12px;
+  font-size: 12px;
+}
+
+.room-badge-waiting {
+  background: rgba(46,125,80,0.3);
+  color: var(--color-text-secondary);
+  border: 1px solid rgba(46,125,80,0.5);
+  padding: 2px 10px;
+  border-radius: 12px;
+  font-size: 12px;
+}
+
 /* Player dot indicators */
 .player-dots {
   display: flex;
   gap: 6px;
   margin-bottom: 4px;
+}
+
+.player-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: var(--radius-sm);
+  background: rgba(184, 134, 11, 0.15);
+  border: 1px solid rgba(184, 134, 11, 0.3);
+  display: inline-block;
+}
+
+.player-dot-filled {
+  background: var(--color-bg-button-hover);
 }
 
 /* Room heading */
@@ -595,6 +627,13 @@ hr {
 .room-card:hover {
   border-color: var(--color-gold-border-hover);
   box-shadow: 0 4px 16px rgba(0,0,0,0.4), inset 0 1px 0 rgba(255,255,255,0.05);
+}
+
+/* Quick Start gradient button */
+.lobby-quick-start {
+  background: linear-gradient(135deg, var(--color-bg-button) 0%, var(--color-bg-button-hover) 100%);
+  border: 2px solid var(--color-gold-border-hover);
+  box-shadow: 0 0 12px rgba(212, 160, 23, 0.3);
 }
 
 button.lobby-create-btn:hover:not(:disabled) {

--- a/apps/web/src/pages/Lobby.tsx
+++ b/apps/web/src/pages/Lobby.tsx
@@ -80,8 +80,8 @@ export function Lobby({ onJoined }: LobbyProps) {
           size="lg"
           onClick={handleQuickStart}
           disabled={quickStarting}
-          className="lobby-create-btn"
-          style={{ width: "100%", background: "linear-gradient(135deg, var(--color-bg-button) 0%, var(--color-bg-button-hover) 100%)", border: "2px solid var(--color-gold-border-hover)", boxShadow: "0 0 12px rgba(212, 160, 23, 0.3)" }}
+          className="lobby-create-btn lobby-quick-start"
+          style={{ width: "100%" }}
         >
           {quickStarting ? "启动中... / Starting..." : "⚡ 快速开始 / Quick Start"}
         </Button>
@@ -119,7 +119,7 @@ export function Lobby({ onJoined }: LobbyProps) {
                 <span style={{ fontFamily: "monospace", fontSize: 22, fontWeight: "bold", color: "var(--color-text-primary)", letterSpacing: 4 }}>
                   {room.roomId}
                 </span>
-                <span className="room-status-badge" style={{ background: room.playerCount >= room.maxPlayers ? "rgba(255,82,82,0.2)" : "rgba(46,125,80,0.3)", color: room.playerCount >= room.maxPlayers ? "var(--color-error)" : "var(--color-text-secondary)", border: `1px solid ${room.playerCount >= room.maxPlayers ? "rgba(255,82,82,0.3)" : "rgba(46,125,80,0.5)"}`, padding: "2px 10px", borderRadius: 12, fontSize: 12 }}>
+                <span className={room.playerCount >= room.maxPlayers ? "room-badge-full" : "room-badge-waiting"}>
                   {room.playerCount >= room.maxPlayers ? "已满 / Full" : "等待中 / Waiting"}
                 </span>
               </div>
@@ -127,7 +127,7 @@ export function Lobby({ onJoined }: LobbyProps) {
                 <div>
                   <div className="player-dots">
                     {Array.from({ length: room.maxPlayers }).map((_, i) => (
-                      <span key={i} style={{ width: 10, height: 10, borderRadius: "var(--radius-sm)", background: i < room.playerCount ? "var(--color-bg-button-hover)" : "rgba(184, 134, 11, 0.15)", border: "1px solid rgba(184, 134, 11, 0.3)", display: "inline-block" }} />
+                      <span key={i} className={`player-dot${i < room.playerCount ? " player-dot-filled" : ""}`} />
                     ))}
                   </div>
                   <span style={{ color: "var(--color-text-secondary)", fontSize: "var(--label-font)" }}>


### PR DESCRIPTION
Lobby still has ternary inline styles for room badges, player dots, Quick Start gradient. Extract to CSS classes.

- Room status badge ternary -> .room-badge-full / .room-badge-waiting
- Player dots -> .player-dot / .player-dot-filled
- Quick Start gradient/shadow -> .lobby-quick-start (already has .lobby-create-btn but gradient is inline)
- How to Play button -> use existing Button component fully

Files: Lobby.tsx, index.css

Closes #356