### PR TITLE
Verify claim animations work on compact and first-person modes

### DIFF
--- a/apps/web/src/animations.css
+++ b/apps/web/src/animations.css
@@ -356,7 +356,12 @@
   100% { transform: translate(120px, 0) scale(0.8); opacity: 0; filter: drop-shadow(0 0 4px rgba(255,215,0,0.4)); }
 }
 
-/* Pool-to-player claim fly animations (chi/peng/gang) */
+/* Pool-to-player claim fly animations (chi/peng/gang)
+ * Audit (ticket #190, 2026-03-30): verified at compact (≤500px height) and
+ * first-person (≤500px height + ≤900px width) breakpoints.
+ * Overlay is position:absolute inside .game-table which has overflow:visible,
+ * so the 60px translations are never clipped.  meld-new (.meldEntrance) is
+ * applied in all three PlayerArea layout paths (ultraCompact / compact / normal). */
 @keyframes claimFlyBottom {
   0% { transform: translate(0, -60px) scale(0.8); opacity: 1; }
   100% { transform: translate(0, 0) scale(1); opacity: 0; }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -324,6 +324,9 @@ body {
   background: radial-gradient(ellipse at center, var(--color-bg-card) 0%, var(--color-bg-medium) 60%, #082818 100%);
   flex: 1;
   min-height: 0;
+  /* overflow:visible is load-bearing — claim-fly, draw-fly, and discard-fly
+     overlays are position:absolute children that animate beyond grid bounds.
+     Changing this to hidden/auto would clip those animations.  (audit #190) */
   overflow: visible;
   border: 3px solid rgba(139, 90, 43, 0.5);
   box-shadow: inset 0 0 30px rgba(0,0,0,0.3), 0 4px 20px rgba(0,0,0,0.4);


### PR DESCRIPTION
Audit: claimFly overlay + meldEntrance animation on compact (500px) and first-person (<=500px+<=900px) breakpoints. Check not clipped by overflow. Fix if broken.

Files: GameTable.tsx (claim overlay), PlayerArea.tsx (meld-new class), animations.css

Closes #357