### PR TITLE
refactor: tokenize game-over overlay inline styles (#187)

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -98,6 +98,13 @@ body {
   --color-tile-back-border: #1a3c2a;
   --color-tile-back-border-right: #1e4530;
 
+  /* Spacing */
+  --spacing-xs: 4px;
+  --spacing-sm: 8px;
+  --spacing-md: 12px;
+  --spacing-lg: 16px;
+  --spacing-xl: 20px;
+
   /* Consistent border-radius */
   --radius-sm: 4px;
   --radius-md: 8px;
@@ -828,3 +835,89 @@ button.lobby-create-btn:hover:not(:disabled) {
 .game-toast-container { position: fixed; top: 16px; left: 50%; transform: translateX(-50%); z-index: 9000; display: flex; flex-direction: column; gap: 8px; align-items: center; pointer-events: none; }
 .game-toast-container.compact { top: auto; bottom: calc(60px + env(safe-area-inset-bottom, 0px)); }
 .game-toast { background: var(--toast-bg); color: var(--color-text-warm); padding: 8px 20px; border-radius: 8px; font-size: var(--label-font); font-weight: bold; border: 1px solid var(--color-gold-border); animation: pageFadeIn 0.3s ease-out; white-space: nowrap; }
+
+/* ── Game-over overlay ── */
+.game-over-wrapper {
+  text-align: center;
+  padding: clamp(var(--spacing-md), 3vh, 40px);
+  max-height: 100dvh;
+  overflow-y: auto;
+}
+
+.game-over-layout {
+  display: block;
+}
+.game-over-layout.compact {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--spacing-md);
+}
+
+.score-breakdown {
+  margin-bottom: var(--spacing-md);
+  padding: 10px;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: var(--radius-md);
+  display: inline-block;
+}
+
+.score-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 6px var(--spacing-lg);
+  margin-bottom: var(--spacing-xs);
+  border-radius: var(--radius-sm);
+  border: 1px solid transparent;
+}
+.score-row.positive {
+  background: rgba(76, 175, 80, 0.15);
+}
+.score-row.negative {
+  background: rgba(244, 67, 54, 0.1);
+}
+.score-row.top-positive {
+  background: rgba(76, 175, 80, 0.15);
+  border-color: var(--color-success);
+}
+.score-row.cumulative-top {
+  background: rgba(255, 215, 0, 0.12);
+  border-color: rgba(255, 215, 0, 0.4);
+}
+
+.all-hands-section {
+  margin-bottom: var(--spacing-xl);
+  text-align: left;
+}
+
+.all-hands-toggle {
+  display: block;
+  width: 100%;
+  padding: var(--spacing-sm) 0;
+  margin-bottom: var(--spacing-sm);
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: var(--radius-md);
+  color: var(--color-text-secondary);
+  font-size: 13px;
+  cursor: pointer;
+  text-align: center;
+}
+
+.hand-reveal-row {
+  margin-bottom: var(--spacing-sm);
+  padding: var(--spacing-sm) var(--spacing-md);
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+.hand-reveal-row.winner {
+  background: rgba(255, 215, 0, 0.1);
+  border-color: rgba(255, 215, 0, 0.4);
+}
+
+.game-over-actions {
+  display: inline-flex;
+  gap: 10px;
+  align-items: center;
+}

--- a/apps/web/src/pages/Game.tsx
+++ b/apps/web/src/pages/Game.tsx
@@ -415,8 +415,8 @@ export function Game({ initialGameState, onLeave }: GameProps) {
             ))}
           </div>
         )}
-      <div className={isWin ? "hu-celebration" : ""} style={{ textAlign: "center", padding: "clamp(12px, 3vh, 40px)", maxHeight: "100dvh", overflowY: "auto" }}>
-        <div style={{ display: isCompact ? "grid" : "block", gridTemplateColumns: isCompact ? "1fr 1fr" : undefined, gap: 12 }}>
+      <div className={`game-over-wrapper${isWin ? " hu-celebration" : ""}`}>
+        <div className={`game-over-layout${isCompact ? " compact" : ""}`}>
           <div>
         <h2 style={{ fontSize: isCompact ? 20 : 28, marginBottom: isCompact ? 8 : 16 }}>
           {isWin ? `🎉 ${getPlayerName(gameOver.winnerId!)} 胡了!` : "流局 / Draw"}
@@ -427,7 +427,7 @@ export function Game({ initialGameState, onLeave }: GameProps) {
 
         {/* Score breakdown */}
         {gameOver.breakdown && isWin && (
-          <div style={{ marginBottom: 12, padding: 10, background: "rgba(255,255,255,0.05)", borderRadius: 6, display: "inline-block" }}>
+          <div className="score-breakdown">
             <div style={{ fontSize: 12, color: "var(--color-text-secondary)", marginBottom: 4 }}>得分明细</div>
             <div style={{ display: "flex", flexWrap: "wrap", gap: "4px 12px", justifyContent: "center", fontSize: 13, color: "var(--color-text-primary)" }}>
               <span>花分: {gameOver.breakdown.flowerScore}</span>
@@ -449,11 +449,8 @@ export function Game({ initialGameState, onLeave }: GameProps) {
             .map((score, i) => ({ name: (gameOver.playerNames ?? [])[i] || getPlayerName(i), score, i }))
             .sort((a, b) => b.score - a.score)
             .map((p, rank) => (
-              <div key={p.i} style={{
-                display: "flex", justifyContent: "space-between", alignItems: "center",
-                padding: "6px 16px", marginBottom: 4, borderRadius: 4, fontSize: isCompact ? 12 : 14,
-                background: p.score > 0 ? "rgba(76,175,80,0.15)" : p.score < 0 ? "rgba(244,67,54,0.1)" : "transparent",
-                border: rank === 0 && p.score > 0 ? "1px solid var(--color-success)" : "1px solid transparent",
+              <div key={p.i} className={`score-row${rank === 0 && p.score > 0 ? " top-positive" : p.score > 0 ? " positive" : p.score < 0 ? " negative" : ""}`} style={{
+                fontSize: isCompact ? 12 : 14,
                 animation: `scoreReveal 0.3s ease-out ${rank * 0.1}s both`,
               }}>
                 <span>
@@ -477,11 +474,8 @@ export function Game({ initialGameState, onLeave }: GameProps) {
               .map((score, i) => ({ name: (gameOver.playerNames ?? [])[i] || getPlayerName(i), score, i }))
               .sort((a, b) => b.score - a.score)
               .map((p, rank) => (
-                <div key={p.i} style={{
-                  display: "flex", justifyContent: "space-between", alignItems: "center",
-                  padding: "6px 16px", marginBottom: 4, borderRadius: 4, fontSize: isCompact ? 12 : 14,
-                  background: rank === 0 ? "rgba(255,215,0,0.12)" : "transparent",
-                  border: rank === 0 ? "1px solid rgba(255,215,0,0.4)" : "1px solid transparent",
+                <div key={p.i} className={`score-row${rank === 0 ? " cumulative-top" : ""}`} style={{
+                  fontSize: isCompact ? 12 : 14,
                   animation: `scoreReveal 0.3s ease-out ${rank * 0.1}s both`,
                 }}>
                   <span>
@@ -499,15 +493,10 @@ export function Game({ initialGameState, onLeave }: GameProps) {
         </div>
         {/* All player hands */}
         {gameOver.allHands && gameOver.allHands.length > 0 && (
-          <div style={{ marginBottom: 20, textAlign: "left" }}>
+          <div className="all-hands-section">
             <button
               onClick={() => setShowAllHands(!showAllHands)}
-              style={{
-                display: "block", width: "100%", padding: "8px 0", marginBottom: 8,
-                background: "rgba(255,255,255,0.06)", border: "1px solid rgba(255,255,255,0.12)",
-                borderRadius: 6, color: "var(--color-text-secondary)", fontSize: 13,
-                cursor: "pointer", textAlign: "center",
-              }}
+              className="all-hands-toggle"
             >
               {showAllHands ? "收起手牌 ▲" : "查看所有手牌 ▼"}
             </button>
@@ -515,11 +504,7 @@ export function Game({ initialGameState, onLeave }: GameProps) {
               const isWinner = idx === gameOver.winnerId;
               const name = (gameOver.playerNames ?? [])[idx] || getPlayerName(idx);
               return (
-                <div key={idx} style={{
-                  marginBottom: 8, padding: "8px 12px", borderRadius: 6,
-                  background: isWinner ? "rgba(255,215,0,0.1)" : "rgba(255,255,255,0.03)",
-                  border: isWinner ? "1px solid rgba(255,215,0,0.4)" : "1px solid rgba(255,255,255,0.08)",
-                }}>
+                <div key={idx} className={`hand-reveal-row${isWinner ? " winner" : ""}`}>
                   <div style={{ fontSize: 13, fontWeight: isWinner ? "bold" : "normal", color: isWinner ? "var(--color-text-gold)" : "var(--color-text-primary)", marginBottom: 4 }}>
                     {isWinner ? "🏆 " : ""}{name}
                   </div>
@@ -557,27 +542,29 @@ export function Game({ initialGameState, onLeave }: GameProps) {
           </div>
         )}
 
-        <Button variant="gold" size="lg" onClick={handleNextRound} style={{ minHeight: 48 }}>
-          下一局 / Next Round
-        </Button>
-        {onLeave && (
-          <Button variant="secondary" onClick={() => {
-              const cum = gameOver.cumulative;
-              if (cum && cum.roundsPlayed > 0) {
-                setSessionSummary({
-                  playerNames: gameOver.playerNames ?? [],
-                  cumulativeScores: cum.scores,
-                  roundsPlayed: cum.roundsPlayed,
-                  roundHistory,
-                });
-              } else {
-                socket.emit("leaveRoom");
-                onLeave();
-              }
-            }} style={{ marginLeft: 10, minHeight: 48 }}>
-            离开 / Leave
+        <div className="game-over-actions">
+          <Button variant="gold" size="lg" onClick={handleNextRound} style={{ minHeight: 48 }}>
+            下一局 / Next Round
           </Button>
-        )}
+          {onLeave && (
+            <Button variant="secondary" onClick={() => {
+                const cum = gameOver.cumulative;
+                if (cum && cum.roundsPlayed > 0) {
+                  setSessionSummary({
+                    playerNames: gameOver.playerNames ?? [],
+                    cumulativeScores: cum.scores,
+                    roundsPlayed: cum.roundsPlayed,
+                    roundHistory,
+                  });
+                } else {
+                  socket.emit("leaveRoom");
+                  onLeave();
+                }
+              }} style={{ minHeight: 48 }}>
+              离开 / Leave
+            </Button>
+          )}
+        </div>
       </div>
       {sessionSummary && (
         <SessionSummary


### PR DESCRIPTION
## Summary
- Add spacing design tokens (`--spacing-xs` through `--spacing-xl`) to `:root`
- Extract ~45 lines of inline styles from Game.tsx game-over section into 9 CSS classes: `.game-over-wrapper`, `.game-over-layout`, `.score-breakdown`, `.score-row` (with `.positive`/`.negative`/`.top-positive`/`.cumulative-top` variants), `.all-hands-section`, `.all-hands-toggle`, `.hand-reveal-row`, `.game-over-actions`
- Replace hardcoded values with `var(--spacing-*)`, `var(--radius-*)`, `var(--color-*)` tokens

## Test plan
- [ ] Verify game-over overlay renders correctly after a win (hu)
- [ ] Verify draw (流局) overlay renders correctly
- [ ] Check score rows highlight positive/negative/top correctly
- [ ] Check cumulative standings gold highlight on rank 1
- [ ] Verify all-hands toggle expands/collapses
- [ ] Verify hand-reveal-row winner styling (gold border)
- [ ] Test compact layout (landscape mobile) uses grid 2-col layout
- [ ] Confirm Next Round / Leave buttons render side-by-side

🤖 Generated with [Claude Code](https://claude.com/claude-code)