### PR TITLE
Raise compact breakpoint to 550px and widen first-person gate

### DIFF
--- a/apps/web/src/hooks/useIsMobile.ts
+++ b/apps/web/src/hooks/useIsMobile.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 
 export const BREAKPOINTS = {
-  COMPACT_HEIGHT: 500,
+  COMPACT_HEIGHT: 550,
   SMALL_PHONE_HEIGHT: 390,
   TABLET_WIDTH: 768,
   PHONE_WIDTH: 480,
@@ -22,11 +22,11 @@ export function useIsCompactLandscape(): boolean {
 
 export function useIsFirstPersonMobile(): boolean {
   const [isFP, setIsFP] = useState(
-    () => window.innerHeight <= BREAKPOINTS.COMPACT_HEIGHT && window.innerWidth <= 900
+    () => window.innerHeight <= BREAKPOINTS.COMPACT_HEIGHT && window.innerWidth <= 1024
   );
   useEffect(() => {
     const onResize = () =>
-      setIsFP(window.innerHeight <= BREAKPOINTS.COMPACT_HEIGHT && window.innerWidth <= 900);
+      setIsFP(window.innerHeight <= BREAKPOINTS.COMPACT_HEIGHT && window.innerWidth <= 1024);
     window.addEventListener("resize", onResize);
     return () => window.removeEventListener("resize", onResize);
   }, []);

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -223,7 +223,7 @@ body {
 }
 
 /* BREAKPOINTS.COMPACT_HEIGHT */
-@media (orientation: landscape) and (max-height: 500px) {
+@media (orientation: landscape) and (max-height: 550px) {
   :root {
     --tile-w: 36px;
     --tile-h: 54px;
@@ -257,6 +257,22 @@ body {
     --seat-card-min-height: 48px;
     --table-center-padding: 10px 8px;
     --table-center-min-height: 70px;
+  }
+}
+
+/* Intermediate compact tier: 501–550px height */
+@media (orientation: landscape) and (max-height: 550px) and (min-height: 501px) {
+  :root {
+    --tile-w: 30px;
+    --tile-h: 44px;
+    --tile-font: 10px;
+    --tile-suit-font: 7px;
+    --wall-tw: 8px;
+    --wall-th: 11px;
+    --fp-tile-w: 32px;
+    --fp-tile-h: 48px;
+    --fp-opponent-tile-w: 18px;
+    --fp-opponent-tile-h: 26px;
   }
 }
 
@@ -296,7 +312,7 @@ body {
 }
 
 /* Landscape compact layout for lobby/room — BREAKPOINTS.COMPACT_HEIGHT */
-@media (orientation: landscape) and (max-height: 500px) {
+@media (orientation: landscape) and (max-height: 550px) {
   .lobby-page, .room-page {
     padding: 12px 20px;
   }


### PR DESCRIPTION
Compact threshold 500px too low — devices at 501-550px overflow. First-person gate 900px too narrow.

1. Raise compact to 550px in CSS + React hooks
2. Add semi-compact tier 500-550px
3. Widen first-person to 1024px

Files: useIsMobile.ts, index.css

Closes #370