### PR TITLE
Unify dealer bot action through emitOrBotAction pattern

### DIFF
--- a/apps/server/src/gameEngine.ts
+++ b/apps/server/src/gameEngine.ts
@@ -897,7 +897,7 @@ function broadcastState(io: GameServer, game: ServerGameState): void {
 /**
  * Emit actionRequired to a player, or auto-respond if bot.
  */
-function emitOrBotAction(
+export function emitOrBotAction(
   io: GameServer,
   game: ServerGameState,
   playerIndex: number,
@@ -907,10 +907,14 @@ function emitOrBotAction(
   const version = nextBotVersion(game.roomId);
 
   if (game.isBot(playerIndex)) {
+    let acted = false;
+
     const safetyTimer = setTimeout(() => {
+      if (acted) return;
       // 5-second safety timeout: if bot callback hasn't fired, force discard
       if (getBotVersion(game.roomId) !== version) return; // stale
       if (game.state.phase !== GamePhase.Playing) return;
+      acted = true;
       console.warn(`Bot ${playerIndex} safety timeout — forcing emergency discard`);
       try {
         const player = game.state.players[playerIndex];
@@ -921,15 +925,17 @@ function emitOrBotAction(
     }, 5_000);
 
     setTimeout(() => {
+      if (acted) return;
       // Stale check: if version has advanced, another action superseded this one
       if (getBotVersion(game.roomId) !== version) {
         clearTimeout(safetyTimer);
         return;
       }
       try {
+        acted = true;
+        clearTimeout(safetyTimer);
         // Check if game state is still valid for this bot action
         if (game.state.phase !== GamePhase.Playing) {
-          clearTimeout(safetyTimer);
           console.warn(`Bot ${playerIndex} action skipped: game phase is ${game.state.phase}, attempting Pass fallback`);
           try {
             handlePlayerAction(io, game.roomId, { type: ActionType.Pass, playerIndex }, playerIndex);
@@ -949,10 +955,8 @@ function emitOrBotAction(
             .map(p => p.discards),
         };
         const botAction = decideBotAction(player.hand, player.melds, actions, playerIndex, game.state.gold, lastDiscardTile, botContext);
-        clearTimeout(safetyTimer);
         handlePlayerAction(io, game.roomId, botAction, playerIndex);
       } catch (err) {
-        clearTimeout(safetyTimer);
         console.error(`Bot ${playerIndex} action error:`, err);
         // Fallback: try pass first, then discard if pass not allowed
         try {

--- a/apps/server/src/handlers/roomHandlers.ts
+++ b/apps/server/src/handlers/roomHandlers.ts
@@ -1,6 +1,5 @@
 import type { Server, Socket } from "socket.io";
 import type { ClientEvents, ServerEvents } from "@fuzhou-mahjong/shared";
-import { ActionType } from "@fuzhou-mahjong/shared";
 import {
   createRoom,
   findRoom,
@@ -12,8 +11,8 @@ import {
   unregisterPlayerRoom,
 } from "../room.js";
 import { createGame, getGame, deleteGame } from "../gameState.js";
-import { checkWin, MeldType, isGoldTile, GamePhase, decideBotAction } from "@fuzhou-mahjong/shared";
-import { handlePlayerAction } from "../gameEngine.js";
+import { checkWin, GamePhase } from "@fuzhou-mahjong/shared";
+import { handlePlayerAction, emitOrBotAction } from "../gameEngine.js";
 
 type GameSocket = Socket<ClientEvents, ServerEvents>;
 type GameServer = Server<ClientEvents, ServerEvents>;
@@ -299,25 +298,8 @@ export function registerRoomHandlers(io: GameServer, socket: GameSocket): void {
 function triggerDealerAction(io: GameServer, game: import("../gameState.js").ServerGameState, room: import("../room.js").Room): void {
   const dealerIdx = game.state.dealerIndex;
   if (game.isBot(dealerIdx)) {
-    setTimeout(() => {
-      try {
-        const actions = game.getInitialDealerActions();
-        const player = game.state.players[dealerIdx];
-        const botAction = decideBotAction(player.hand, player.melds, actions, dealerIdx, game.state.gold);
-        handlePlayerAction(io, game.roomId, botAction, dealerIdx);
-      } catch (err) {
-        console.error(`Dealer bot ${dealerIdx} action error:`, err);
-        // Fallback: discard first non-gold tile (dealer must discard, pass may not be valid)
-        try {
-          const player = game.state.players[dealerIdx];
-          const gold = game.state.gold;
-          const tile = player.hand.find(t => !gold || !isGoldTile(t, gold)) ?? player.hand[0];
-          handlePlayerAction(io, game.roomId, { type: ActionType.Discard, playerIndex: dealerIdx, tile }, dealerIdx);
-        } catch (e) {
-          console.error(`Dealer bot ${dealerIdx} discard fallback also failed:`, e);
-        }
-      }
-    }, 500);
+    const actions = game.getInitialDealerActions();
+    emitOrBotAction(io, game, dealerIdx, actions);
   } else if (room.players[dealerIdx].socketId) {
     io.to(room.players[dealerIdx].socketId!).emit("actionRequired", game.getInitialDealerActions());
   }


### PR DESCRIPTION
triggerDealerAction uses bare setTimeout without safety timer or version tracking. Route it through emitOrBotAction instead.

Also add acted flag to prevent double-action race in safety timer.

Files: gameEngine.ts, roomHandlers.ts (server only)

Closes #374