### PR TITLE
Z-index audit and safe-area fixes for mobile overlays

### DIFF
--- a/apps/web/src/components/ClaimOverlay.tsx
+++ b/apps/web/src/components/ClaimOverlay.tsx
@@ -77,7 +77,7 @@ export function ClaimOverlay({ actions, gameState, onAction }: ClaimOverlayProps
         background: "var(--overlay-bg)",
         border: "2px solid var(--color-accent-orange)",
         borderRadius: 12,
-        padding: "var(--overlay-padding-y) var(--overlay-padding-x)",
+        padding: "calc(var(--overlay-padding-y) + env(safe-area-inset-top, 0px)) calc(var(--overlay-padding-x) + env(safe-area-inset-right, 0px)) calc(var(--overlay-padding-y) + env(safe-area-inset-bottom, 0px)) calc(var(--overlay-padding-x) + env(safe-area-inset-left, 0px))",
         display: "flex",
         flexDirection: "column",
         alignItems: "center",

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -850,7 +850,7 @@ button.lobby-create-btn:hover:not(:disabled) {
 
 /* Toast notifications */
 .game-toast-container { position: fixed; top: 16px; left: 50%; transform: translateX(-50%); z-index: 9000; display: flex; flex-direction: column; gap: 8px; align-items: center; pointer-events: none; }
-.game-toast-container.compact { top: auto; bottom: calc(60px + env(safe-area-inset-bottom, 0px)); }
+.game-toast-container.compact { top: auto; bottom: calc(70px + env(safe-area-inset-bottom, 0px)); }
 .game-toast { background: var(--toast-bg); color: var(--color-text-warm); padding: 8px 20px; border-radius: 8px; font-size: var(--label-font); font-weight: bold; border: 1px solid var(--color-gold-border); animation: pageFadeIn 0.3s ease-out; white-space: nowrap; }
 
 /* ── Game-over overlay ── */

--- a/apps/web/src/pages/Game.tsx
+++ b/apps/web/src/pages/Game.tsx
@@ -454,7 +454,7 @@ export function Game({ initialGameState, onLeave }: GameProps) {
         position: 'fixed',
         top: 'calc(8px + env(safe-area-inset-top, 0px))',
         right: 'calc(8px + env(safe-area-inset-right, 0px))',
-        zIndex: 20,
+        zIndex: 30,
       }}>
         <button
           onClick={() => setSettingsOpen((v) => !v)}


### PR DESCRIPTION
Z-index conflicts: settings button z-20 same as fly animations. ClaimOverlay no safe-area padding. Toast overlaps hand.

1. Settings button z-index 20->30
2. ClaimOverlay add safe-area padding
3. Compact toast positioning adjust

Files: Game.tsx, ClaimOverlay.tsx, index.css

Closes #375