### PR TITLE
Scale animation distances and gesture thresholds for compact mobile

### DIFF
--- a/apps/web/src/animations.css
+++ b/apps/web/src/animations.css
@@ -319,41 +319,41 @@
 /* Wall-to-hand draw fly animations */
 @keyframes drawFlyBottom {
   0% { transform: translate(0, 0) scale(1); opacity: 1; }
-  100% { transform: translate(0, 120px) scale(1.2); opacity: 0; }
+  100% { transform: translate(0, min(120px, 15vh)) scale(1.2); opacity: 0; }
 }
 @keyframes drawFlyTop {
   0% { transform: translate(0, 0) scale(1); opacity: 1; }
-  100% { transform: translate(0, -120px) scale(0.8); opacity: 0; }
+  100% { transform: translate(0, max(-120px, -15vh)) scale(0.8); opacity: 0; }
 }
 @keyframes drawFlyLeft {
   0% { transform: translate(0, 0) scale(1); opacity: 1; }
-  100% { transform: translate(-120px, 0) scale(0.8); opacity: 0; }
+  100% { transform: translate(max(-120px, -15vw), 0) scale(0.8); opacity: 0; }
 }
 @keyframes drawFlyRight {
   0% { transform: translate(0, 0) scale(1); opacity: 1; }
-  100% { transform: translate(120px, 0) scale(0.8); opacity: 0; }
+  100% { transform: translate(min(120px, 15vw), 0) scale(0.8); opacity: 0; }
 }
 
 /* Supplement draw variant — slightly different path with glow */
 @keyframes supplementFlyBottom {
   0% { transform: translate(0, 0) scale(1); opacity: 1; filter: drop-shadow(0 0 4px rgba(255,215,0,0.4)); }
   50% { filter: drop-shadow(0 0 10px rgba(255,215,0,0.8)); }
-  100% { transform: translate(0, 120px) scale(1.2); opacity: 0; filter: drop-shadow(0 0 4px rgba(255,215,0,0.4)); }
+  100% { transform: translate(0, min(120px, 15vh)) scale(1.2); opacity: 0; filter: drop-shadow(0 0 4px rgba(255,215,0,0.4)); }
 }
 @keyframes supplementFlyTop {
   0% { transform: translate(0, 0) scale(1); opacity: 1; filter: drop-shadow(0 0 4px rgba(255,215,0,0.4)); }
   50% { filter: drop-shadow(0 0 10px rgba(255,215,0,0.8)); }
-  100% { transform: translate(0, -120px) scale(0.8); opacity: 0; filter: drop-shadow(0 0 4px rgba(255,215,0,0.4)); }
+  100% { transform: translate(0, max(-120px, -15vh)) scale(0.8); opacity: 0; filter: drop-shadow(0 0 4px rgba(255,215,0,0.4)); }
 }
 @keyframes supplementFlyLeft {
   0% { transform: translate(0, 0) scale(1); opacity: 1; filter: drop-shadow(0 0 4px rgba(255,215,0,0.4)); }
   50% { filter: drop-shadow(0 0 10px rgba(255,215,0,0.8)); }
-  100% { transform: translate(-120px, 0) scale(0.8); opacity: 0; filter: drop-shadow(0 0 4px rgba(255,215,0,0.4)); }
+  100% { transform: translate(max(-120px, -15vw), 0) scale(0.8); opacity: 0; filter: drop-shadow(0 0 4px rgba(255,215,0,0.4)); }
 }
 @keyframes supplementFlyRight {
   0% { transform: translate(0, 0) scale(1); opacity: 1; filter: drop-shadow(0 0 4px rgba(255,215,0,0.4)); }
   50% { filter: drop-shadow(0 0 10px rgba(255,215,0,0.8)); }
-  100% { transform: translate(120px, 0) scale(0.8); opacity: 0; filter: drop-shadow(0 0 4px rgba(255,215,0,0.4)); }
+  100% { transform: translate(min(120px, 15vw), 0) scale(0.8); opacity: 0; filter: drop-shadow(0 0 4px rgba(255,215,0,0.4)); }
 }
 
 /* Pool-to-player claim fly animations (chi/peng/gang)
@@ -363,19 +363,19 @@
  * so the 60px translations are never clipped.  meld-new (.meldEntrance) is
  * applied in all three PlayerArea layout paths (ultraCompact / compact / normal). */
 @keyframes claimFlyBottom {
-  0% { transform: translate(0, -60px) scale(0.8); opacity: 1; }
+  0% { transform: translate(0, max(-60px, -7.5vh)) scale(0.8); opacity: 1; }
   100% { transform: translate(0, 0) scale(1); opacity: 0; }
 }
 @keyframes claimFlyTop {
-  0% { transform: translate(0, 60px) scale(0.8); opacity: 1; }
+  0% { transform: translate(0, min(60px, 7.5vh)) scale(0.8); opacity: 1; }
   100% { transform: translate(0, 0) scale(1); opacity: 0; }
 }
 @keyframes claimFlyLeft {
-  0% { transform: translate(60px, 0) scale(0.8); opacity: 1; }
+  0% { transform: translate(min(60px, 7.5vw), 0) scale(0.8); opacity: 1; }
   100% { transform: translate(0, 0) scale(1); opacity: 0; }
 }
 @keyframes claimFlyRight {
-  0% { transform: translate(-60px, 0) scale(0.8); opacity: 1; }
+  0% { transform: translate(max(-60px, -7.5vw), 0) scale(0.8); opacity: 1; }
   100% { transform: translate(0, 0) scale(1); opacity: 0; }
 }
 

--- a/apps/web/src/components/ClaimOverlay.tsx
+++ b/apps/web/src/components/ClaimOverlay.tsx
@@ -32,6 +32,7 @@ const BTN = {
 
 export function ClaimOverlay({ actions, gameState, onAction }: ClaimOverlayProps) {
   const isCompact = window.innerHeight <= BREAKPOINTS.COMPACT_HEIGHT;
+  const isUltraCompact = window.innerHeight <= 390;
   const [showChiPicker, setShowChiPicker] = useState(false);
   const [exiting, setExiting] = useState(false);
   const [exitingChi, setExitingChi] = useState(false);
@@ -81,9 +82,9 @@ export function ClaimOverlay({ actions, gameState, onAction }: ClaimOverlayProps
         display: "flex",
         flexDirection: "column",
         alignItems: "center",
-        gap: isCompact ? 6 : 12,
+        gap: isUltraCompact ? 4 : isCompact ? 6 : 12,
         maxWidth: "90vw",
-        maxHeight: isCompact ? "80dvh" : "90dvh",
+        maxHeight: isUltraCompact ? "70dvh" : isCompact ? "80dvh" : "90dvh",
         overflowY: "auto",
         animation: exiting ? "overlayScaleOut 0.18s ease-in forwards" : "overlayScaleIn 0.2s ease-out",
       }}>

--- a/apps/web/src/components/TileTooltip.tsx
+++ b/apps/web/src/components/TileTooltip.tsx
@@ -65,7 +65,7 @@ export function useLongPress(gold: GoldState | null) {
     return (
       <div style={{
         position: "fixed",
-        left: Math.min(tooltip.x - 40, window.innerWidth - 120),
+        left: Math.max(8, Math.min(tooltip.x - 40, window.innerWidth - 120 - 8)),
         top: Math.max(tooltip.y - 100, 10),
         background: "var(--color-bg-dark)",
         border: isGold ? "2px solid var(--color-gold-bright)" : "1px solid var(--color-text-secondary)",

--- a/apps/web/src/hooks/useSwipeGesture.ts
+++ b/apps/web/src/hooks/useSwipeGesture.ts
@@ -13,7 +13,7 @@ interface SwipeConfig {
  */
 export function useSwipeGesture({
   onSwipeUp,
-  threshold = 40,
+  threshold = Math.min(40, window.innerHeight * 0.08),
   enabled = true,
 }: SwipeConfig) {
   const [swipingTileId, setSwipingTileId] = useState<number | null>(null);


### PR DESCRIPTION
Hardcoded px values break on small phones.

1. Draw fly 120px -> min(120px,15vh)
2. Swipe threshold 40px -> responsive
3. Tooltip positioning viewport clamping
4. ClaimOverlay ultra-compact tier for 390px

Files: animations.css, useSwipeGesture.ts, TileTooltip.tsx, ClaimOverlay.tsx

Closes #379