### PR TITLE
Dead socket guard in broadcastState and emitOrBotAction

### DIFF
--- a/apps/server/src/gameEngine.ts
+++ b/apps/server/src/gameEngine.ts
@@ -29,7 +29,7 @@ import type {
   WinContext,
   BotContext,
 } from "@fuzhou-mahjong/shared";
-import { ServerGameState, getGame } from "./gameState.js";
+import { ServerGameState, getGame, setOnGameDeleted } from "./gameState.js";
 import { findRoom, findRoomBySocket } from "./room.js";
 
 type GameServer = Server<ClientEvents, ServerEvents>;
@@ -135,12 +135,26 @@ function getBotVersion(roomId: string): number {
   return botActionVersion.get(roomId) ?? 0;
 }
 
-/** Pick first non-gold tile to discard as emergency fallback. */
+// Clean up per-room state when a game is deleted
+setOnGameDeleted((roomId) => {
+  botActionVersion.delete(roomId);
+  const window = activeWindows.get(roomId);
+  if (window) {
+    window.cancel();
+    activeWindows.delete(roomId);
+  }
+});
+
+/** Pick first non-gold tile to discard as emergency fallback. Returns Pass if hand is empty. */
 function emergencyDiscard(
   hand: TileInstance[],
   playerIndex: number,
   gold: import("@fuzhou-mahjong/shared").GoldState | null,
 ): GameAction {
+  if (hand.length === 0) {
+    console.warn(`[GameEngine] emergencyDiscard: player ${playerIndex} has empty hand, passing`);
+    return { type: ActionType.Pass, playerIndex };
+  }
   const tile = hand.find(t => !gold || !isGoldTile(t, gold)) ?? hand[0];
   return { type: ActionType.Discard, playerIndex, tile };
 }
@@ -212,7 +226,12 @@ export function handlePlayerAction(
     case ActionType.Draw:
       handleDraw(io, game, playerIndex);
       break;
+    case ActionType.Pass:
+      // Pass during own turn: advance to next player's draw
+      advanceToNextPlayer(io, game, playerIndex);
+      break;
     default:
+      console.warn(`[GameEngine] Unhandled action type in handlePlayerAction: ${action.type}`);
       break;
   }
 }
@@ -889,7 +908,11 @@ function endGameDraw(io: GameServer, game: ServerGameState): void {
 function broadcastState(io: GameServer, game: ServerGameState): void {
   for (let i = 0; i < 4; i++) {
     if (!game.isBot(i)) {
-      io.to(game.getSocketId(i)).emit("gameStateUpdate", game.getClientGameState(i));
+      const socketId = game.getSocketId(i);
+      const socket = io.sockets.sockets.get(socketId);
+      if (socket) {
+        socket.emit("gameStateUpdate", game.getClientGameState(i));
+      }
     }
   }
 }
@@ -972,6 +995,17 @@ export function emitOrBotAction(
       }
     }, 300 + Math.random() * 500);
   } else {
-    io.to(game.getSocketId(playerIndex)).emit("actionRequired", actions);
+    const socketId = game.getSocketId(playerIndex);
+    const socket = io.sockets.sockets.get(socketId);
+    if (socket) {
+      socket.emit("actionRequired", actions);
+    } else {
+      // Disconnected human player — auto-pass to prevent game freeze
+      console.warn(`[GameEngine] Player ${playerIndex} has no valid socket, auto-passing`);
+      setTimeout(() => {
+        if (game.state.phase !== GamePhase.Playing) return;
+        handlePlayerAction(io, game.roomId, { type: ActionType.Pass, playerIndex }, playerIndex);
+      }, 100);
+    }
   }
 }

--- a/apps/server/src/gameState.ts
+++ b/apps/server/src/gameState.ts
@@ -206,4 +206,11 @@ export function getGame(roomId: string): ServerGameState | undefined {
 
 export function deleteGame(roomId: string): void {
   games.delete(roomId);
+  onGameDeleted?.(roomId);
+}
+
+/** Hook called when a game is deleted, used by gameEngine to clean up per-room state. */
+let onGameDeleted: ((roomId: string) => void) | null = null;
+export function setOnGameDeleted(cb: (roomId: string) => void): void {
+  onGameDeleted = cb;
 }

--- a/apps/server/src/handlers/roomHandlers.ts
+++ b/apps/server/src/handlers/roomHandlers.ts
@@ -259,6 +259,13 @@ export function registerRoomHandlers(io: GameServer, socket: GameSocket): void {
       if (!player) return;
 
       const playerIndex = room.getPlayerIndexByPlayerId(player.playerId);
+
+      // Sync the game's socketIds so broadcastState/emitOrBotAction see this player as disconnected
+      const game = getGame(room.id);
+      if (game && playerIndex >= 0) {
+        game.updateSocketId(playerIndex, `disconnected-${player.playerId}`);
+      }
+
       io.to(room.id).emit("playerDisconnected", { playerIndex, playerName: player.name, timeoutMs: RECONNECT_TIMEOUT_MS });
       io.to(room.id).emit("roomUpdated", room.getState());
       console.log(`Player ${player.name} disconnected from game in room ${room.id}`);


### PR DESCRIPTION
Bot deadlock — multiple silent failure paths cause game freezes.

## Critical fixes:
1. **botActionVersion map never cleaned up** — entries persist after deleteGame(), leaking memory and causing stale version checks
2. **Pass action falls through switch** in handlePlayerAction — when bot safety fallback fires Pass outside ActionWindow, it hits default case and silently does nothing, hanging the game
3. **emergencyDiscard can return undefined** if hand is empty — causes another silent failure path

## Also includes original scope:
4. Check socket validity before emitting in broadcastState
5. Auto-pass disconnected players in emitOrBotAction
6. Sync game socketIds when player disconnects

Files: gameEngine.ts, roomHandlers.ts (server only)

Closes #378