### PR TITLE
Tooltip safe-area clipping and remaining hardcoded px values

### DIFF
--- a/apps/web/src/animations.css
+++ b/apps/web/src/animations.css
@@ -313,7 +313,7 @@
 /* Hand-to-pool discard fly animation */
 @keyframes discardFlyToPool {
   0% { transform: translate(0, 0) scale(1); opacity: 1; }
-  100% { transform: translate(0, -80px) scale(0.7); opacity: 0; }
+  100% { transform: translate(0, max(-80px, -10vh)) scale(0.7); opacity: 0; }
 }
 
 /* Wall-to-hand draw fly animations */

--- a/apps/web/src/components/TileTooltip.tsx
+++ b/apps/web/src/components/TileTooltip.tsx
@@ -65,8 +65,8 @@ export function useLongPress(gold: GoldState | null) {
     return (
       <div style={{
         position: "fixed",
-        left: Math.max(8, Math.min(tooltip.x - 40, window.innerWidth - 120 - 8)),
-        top: Math.max(tooltip.y - 100, 10),
+        left: `clamp(max(8px, env(safe-area-inset-left, 0px)), ${tooltip.x - 40}px, calc(100vw - 128px - env(safe-area-inset-right, 0px)))`,
+        top: `max(${Math.max(tooltip.y - 100, 0)}px, env(safe-area-inset-top, 10px))`,
         background: "var(--color-bg-dark)",
         border: isGold ? "2px solid var(--color-gold-bright)" : "1px solid var(--color-text-secondary)",
         borderRadius: 8,


### PR DESCRIPTION
Post-#203 mobile polish sweep.

1. TileTooltip.tsx — add safe-area inset awareness for notched phones (top/left positioning should account for env(safe-area-inset-top) etc.)
2. Audit animations.css for any remaining hardcoded px values that #203 missed (e.g. discardFlyToPool uses -80px)
3. Verify rendering at 375x667 (iPhone SE) and 390x844 (iPhone 14) viewport sizes

Files: TileTooltip.tsx, animations.css, ClaimOverlay.tsx

Closes #382