### PR TITLE
Bot fallback double-failure causes permanent game hang

### DIFF
--- a/apps/server/src/gameEngine.ts
+++ b/apps/server/src/gameEngine.ts
@@ -990,7 +990,15 @@ export function emitOrBotAction(
             handlePlayerAction(io, game.roomId, emergencyDiscard(player.hand, playerIndex, game.state.gold), playerIndex);
           }
         } catch (fallbackErr) {
-          console.error(`Bot ${playerIndex} fallback also failed:`, fallbackErr);
+          console.error(`[GameEngine] Bot ${playerIndex} fallback also failed:`, fallbackErr);
+          // Last resort: force Pass to prevent permanent hang
+          try {
+            handlePlayerAction(io, game.roomId, { type: ActionType.Pass, playerIndex }, playerIndex);
+          } catch (lastResortErr) {
+            console.error(`[GameEngine] Bot ${playerIndex} last-resort Pass also failed:`, lastResortErr);
+            // Force advance turn as absolute last resort
+            advanceToNextPlayer(io, game, playerIndex);
+          }
         }
       }
     }, 300 + Math.random() * 500);
@@ -1002,8 +1010,20 @@ export function emitOrBotAction(
     } else {
       // Disconnected human player — auto-pass to prevent game freeze
       console.warn(`[GameEngine] Player ${playerIndex} has no valid socket, auto-passing`);
+      const savedTurn = game.state.currentTurn;
       setTimeout(() => {
         if (game.state.phase !== GamePhase.Playing) return;
+        // Skip if turn has advanced since timeout was set (stale)
+        if (game.state.currentTurn !== savedTurn) {
+          console.warn(`[GameEngine] Player ${playerIndex} auto-pass skipped: turn has advanced`);
+          return;
+        }
+        // Skip if no action window is expecting this player
+        const window = activeWindows.get(game.roomId);
+        if (!window) {
+          console.warn(`[GameEngine] Player ${playerIndex} auto-pass skipped: no active window`);
+          return;
+        }
         handlePlayerAction(io, game.roomId, { type: ActionType.Pass, playerIndex }, playerIndex);
       }, 100);
     }


### PR DESCRIPTION
Bot action catch block (~line 990 in gameEngine.ts) does console.error and nothing else when both decideBotAction() AND the fallback throw. Game hangs permanently.

1. In the bot action inner catch block, add last-resort recovery: emit Pass unconditionally or force-advance turn. Log the full error chain.
2. Validate disconnected-player auto-pass (lines ~1002-1010) checks activeWindows.get(game.roomId) still expects this player before sending pass. Stale pass could go to wrong window.

Server-only, 1 file: gameEngine.ts

Closes #386