### PR TITLE
Portrait mode graceful fallback layout or improved overlay

### DIFF
--- a/apps/web/src/animations.css
+++ b/apps/web/src/animations.css
@@ -18,6 +18,7 @@
  *   overlayScaleOut         → inline style        (ClaimOverlay: exit modal + chi picker)
  *   tileDeparting           → .tile-departing      (PlayerArea: discarded tile exit)
  *   discardFlyToPool        → inline style         (GameTable: discard fly overlay)
+ *   phoneRotate             → .phone-rotate-icon  (Game: portrait overlay)
  *   pageFadeIn              → .page-transition    (index: page entrance)
  *   spin                    → .spinner            (index: loading spinner)
  */
@@ -38,9 +39,14 @@
 }
 
 /* Portrait rotate phone animation */
-@keyframes rotatePhone {
+@keyframes phoneRotate {
   0%, 100% { transform: rotate(0deg); }
-  50% { transform: rotate(90deg); }
+  40%, 60% { transform: rotate(90deg); }
+}
+
+.phone-rotate-icon {
+  animation: phoneRotate 2.5s ease-in-out infinite;
+  display: inline-block;
 }
 
 /* Tile draw-in animation (new draw slides into hand) */

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -38,11 +38,39 @@ body {
   position: fixed;
   inset: 0;
   z-index: 9999;
-  background: var(--color-bg-dark);
+  background: radial-gradient(ellipse at center, var(--color-bg-medium) 0%, var(--color-bg-dark) 70%);
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 20px;
+  gap: 1.5rem;
+  padding: 2rem;
+  text-align: center;
+}
+
+.portrait-rotate-overlay .portrait-title {
+  font-size: clamp(1.5rem, 5vw, 2rem);
+  color: var(--color-gold-bright);
+  font-weight: 700;
+  letter-spacing: 0.05em;
+}
+
+.portrait-rotate-overlay .portrait-phone-icon {
+  font-size: clamp(3rem, 10vw, 4.5rem);
+  line-height: 1;
+}
+
+.portrait-rotate-overlay .portrait-msg {
+  font-size: clamp(0.875rem, 3vw, 1.125rem);
+  color: var(--color-text-primary);
+  max-width: 20rem;
+  line-height: 1.5;
+}
+
+.portrait-rotate-overlay .portrait-hint {
+  font-size: clamp(0.75rem, 2.5vw, 0.875rem);
+  color: var(--color-text-secondary);
+  max-width: 18rem;
+  line-height: 1.4;
 }
 
 #root {

--- a/apps/web/src/pages/Game.tsx
+++ b/apps/web/src/pages/Game.tsx
@@ -383,9 +383,15 @@ export function Game({ initialGameState, onLeave }: GameProps) {
     <div className="game-wrapper">
       {isPortrait && (
         <div className="portrait-rotate-overlay">
-          <div style={{ fontSize: 48, animation: 'rotatePhone 2s ease-in-out infinite' }}>📱</div>
-          <div style={{ fontSize: 18, color: '#eee' }}>请旋转手机</div>
-          <div style={{ fontSize: 14, color: 'var(--color-text-secondary)' }}>Please rotate your phone</div>
+          <div className="portrait-title">福州麻将</div>
+          <div className="portrait-phone-icon phone-rotate-icon">📱</div>
+          <div className="portrait-msg">
+            请将手机横屏以获得最佳体验
+          </div>
+          <div className="portrait-hint">
+            Please rotate your device to landscape mode.
+            The game table requires a wider screen to display properly.
+          </div>
         </div>
       )}
       {showFlash && (


### PR DESCRIPTION
Currently shows rotate-your-phone overlay (z-index 9999) but no actual portrait layout. Users with rotation lock see nothing useful.

Option A: Simple functional portrait layout (stacked: opponents top, hand bottom, smaller tiles)
Option B: At minimum, improve rotate overlay with game name, visual phone rotation animation, not just text

Check apps/web/src/pages/Game.tsx ~line 80 for portrait detection logic.

Client-only: Game.tsx, index.css, possibly new PortraitLayout component

Closes #391