### PR TITLE
Lobby and Room landscape mobile 2-column layout

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -386,9 +386,32 @@ body {
     padding: 6px 12px;
   }
   .lobby-page hr, .room-page hr { margin: 8px 0; }
-  /* Reduce vertical spacing between lobby sections */
-  .lobby-content { gap: 12px !important; }
-  .room-page h2 { margin-bottom: 10px !important; }
+  /* Lobby 2-column layout for landscape mobile */
+  .lobby-content {
+    display: grid !important;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem !important;
+    max-width: 100%;
+  }
+  .lobby-header {
+    grid-column: 1 / -1;
+  }
+  .lobby-left { gap: 12px; }
+  .lobby-right { gap: 12px; overflow-y: auto; max-height: 70vh; }
+
+  /* Room page compact: reduce spacing to fit above fold */
+  .room-page h2 { margin-bottom: 6px !important; }
+  .room-actions { gap: 8px; }
+  .room-start-row { gap: 8px; }
+  /* Side-by-side bot controls + action buttons */
+  .room-controls-row {
+    margin-top: 12px;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+  }
 
   /* Tighter seat layout for landscape mobile */
   .seat-layout {
@@ -540,6 +563,14 @@ hr {
   gap: 20px;
 }
 
+/* Lobby left/right wrappers — stack by default */
+.lobby-left,
+.lobby-right {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
 /* Room content column */
 .room-content {
   max-width: 480px;
@@ -655,9 +686,16 @@ hr {
   margin-bottom: 20px;
 }
 
+/* Room controls wrapper — stacks vertically by default */
+.room-controls-row {
+  margin-top: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
 /* Room action button rows */
 .room-actions {
-  margin-top: 24px;
   display: flex;
   gap: 10px;
   flex-wrap: wrap;
@@ -665,7 +703,6 @@ hr {
 }
 
 .room-start-row {
-  margin-top: 10px;
   display: flex;
   gap: 10px;
 }

--- a/apps/web/src/pages/Lobby.tsx
+++ b/apps/web/src/pages/Lobby.tsx
@@ -64,118 +64,120 @@ export function Lobby({ onJoined }: LobbyProps) {
         <h2>Fuzhou Mahjong</h2>
       </div>
 
-      <div>
-        <input
-          type="text"
-          placeholder="你的名字 / Your name"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          style={{ width: "100%", padding: "var(--btn-padding)", fontSize: "var(--lobby-subtitle-font)", boxSizing: "border-box" }}
-        />
-      </div>
+      <div className="lobby-left">
+        <div>
+          <input
+            type="text"
+            placeholder="你的名字 / Your name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            style={{ width: "100%", padding: "var(--btn-padding)", fontSize: "var(--lobby-subtitle-font)", boxSizing: "border-box" }}
+          />
+        </div>
 
-      <div className="lobby-section">
+        <div className="lobby-section">
+          <Button
+            variant="gold"
+            size="lg"
+            onClick={handleQuickStart}
+            disabled={quickStarting}
+            className="lobby-create-btn lobby-quick-start"
+            style={{ width: "100%" }}
+          >
+            {quickStarting ? "启动中... / Starting..." : "⚡ 快速开始 / Quick Start"}
+          </Button>
+          <p className="lobby-hint">
+            一键开局，自动匹配 3 个机器人
+          </p>
+        </div>
+
+        <div className="lobby-section">
+          <Button
+            variant="gold"
+            size="lg"
+            onClick={handleCreate}
+            disabled={!name.trim()}
+            className="lobby-create-btn"
+            style={{ width: "100%" }}
+          >
+            创建房间 / Create Room
+          </Button>
+          <p className="lobby-hint">
+            创建房间后可邀请朋友或添加机器人
+          </p>
+        </div>
+
+        <hr />
+
+        <h3 className="lobby-section-heading">手动加入 / Join by Code</h3>
+        <div className="lobby-join-row">
+          <input
+            type="text"
+            placeholder="房间号 / Room Code"
+            value={roomCode}
+            onChange={(e) => setRoomCode(e.target.value.toUpperCase())}
+            maxLength={4}
+            style={{ flex: 1, padding: "var(--btn-padding)", fontSize: "var(--lobby-subtitle-font)", textTransform: "uppercase", letterSpacing: 4, textAlign: "center" }}
+          />
+          <Button
+            onClick={() => handleJoin(roomCode.trim())}
+            disabled={!name.trim() || !roomCode.trim()}
+          >
+            加入 / Join
+          </Button>
+        </div>
+
+        {error && <p className="error-msg">{error}</p>}
+
+        <hr />
         <Button
-          variant="gold"
-          size="lg"
-          onClick={handleQuickStart}
-          disabled={quickStarting}
-          className="lobby-create-btn lobby-quick-start"
-          style={{ width: "100%" }}
+          variant="secondary"
+          onClick={() => setShowTutorial(true)}
+          style={{ width: "100%", background: "transparent", border: "1px solid var(--color-gold-border-hover)" }}
         >
-          {quickStarting ? "启动中... / Starting..." : "⚡ 快速开始 / Quick Start"}
+          游戏规则 / How to Play
         </Button>
-        <p className="lobby-hint">
-          一键开局，自动匹配 3 个机器人
-        </p>
       </div>
 
-      <div className="lobby-section">
-        <Button
-          variant="gold"
-          size="lg"
-          onClick={handleCreate}
-          disabled={!name.trim()}
-          className="lobby-create-btn"
-          style={{ width: "100%" }}
-        >
-          创建房间 / Create Room
-        </Button>
-        <p className="lobby-hint">
-          创建房间后可邀请朋友或添加机器人
-        </p>
-      </div>
-
-      <hr />
-
-      <h3 className="lobby-section-heading">可用房间 / Available Rooms</h3>
-      {rooms.length === 0 ? (
-        <p className="lobby-empty-msg">暂无房间 / No rooms available</p>
-      ) : (
-        <div className="room-card-list">
-          {rooms.map((room) => (
-            <div key={room.roomId} className="room-card">
-              <div className="room-card-row">
-                <span style={{ fontFamily: "monospace", fontSize: 22, fontWeight: "bold", color: "var(--color-text-primary)", letterSpacing: 4 }}>
-                  {room.roomId}
-                </span>
-                <span className={room.playerCount >= room.maxPlayers ? "room-badge-full" : "room-badge-waiting"}>
-                  {room.playerCount >= room.maxPlayers ? "已满 / Full" : "等待中 / Waiting"}
-                </span>
-              </div>
-              <div className="room-card-row">
-                <div>
-                  <div className="player-dots">
-                    {Array.from({ length: room.maxPlayers }).map((_, i) => (
-                      <span key={i} className={`player-dot${i < room.playerCount ? " player-dot-filled" : ""}`} />
-                    ))}
-                  </div>
-                  <span style={{ color: "var(--color-text-secondary)", fontSize: "var(--label-font)" }}>
-                    {room.players.join(", ")}
+      <div className="lobby-right">
+        <h3 className="lobby-section-heading">可用房间 / Available Rooms</h3>
+        {rooms.length === 0 ? (
+          <p className="lobby-empty-msg">暂无房间 / No rooms available</p>
+        ) : (
+          <div className="room-card-list">
+            {rooms.map((room) => (
+              <div key={room.roomId} className="room-card">
+                <div className="room-card-row">
+                  <span style={{ fontFamily: "monospace", fontSize: 22, fontWeight: "bold", color: "var(--color-text-primary)", letterSpacing: 4 }}>
+                    {room.roomId}
+                  </span>
+                  <span className={room.playerCount >= room.maxPlayers ? "room-badge-full" : "room-badge-waiting"}>
+                    {room.playerCount >= room.maxPlayers ? "已满 / Full" : "等待中 / Waiting"}
                   </span>
                 </div>
-                <Button
-                  onClick={() => handleJoin(room.roomId)}
-                  disabled={!name.trim() || room.playerCount >= room.maxPlayers}
-                >
-                  加入 / Join
-                </Button>
+                <div className="room-card-row">
+                  <div>
+                    <div className="player-dots">
+                      {Array.from({ length: room.maxPlayers }).map((_, i) => (
+                        <span key={i} className={`player-dot${i < room.playerCount ? " player-dot-filled" : ""}`} />
+                      ))}
+                    </div>
+                    <span style={{ color: "var(--color-text-secondary)", fontSize: "var(--label-font)" }}>
+                      {room.players.join(", ")}
+                    </span>
+                  </div>
+                  <Button
+                    onClick={() => handleJoin(room.roomId)}
+                    disabled={!name.trim() || room.playerCount >= room.maxPlayers}
+                  >
+                    加入 / Join
+                  </Button>
+                </div>
               </div>
-            </div>
-          ))}
-        </div>
-      )}
-
-      <hr />
-
-      <h3 className="lobby-section-heading">手动加入 / Join by Code</h3>
-      <div className="lobby-join-row">
-        <input
-          type="text"
-          placeholder="房间号 / Room Code"
-          value={roomCode}
-          onChange={(e) => setRoomCode(e.target.value.toUpperCase())}
-          maxLength={4}
-          style={{ flex: 1, padding: "var(--btn-padding)", fontSize: "var(--lobby-subtitle-font)", textTransform: "uppercase", letterSpacing: 4, textAlign: "center" }}
-        />
-        <Button
-          onClick={() => handleJoin(roomCode.trim())}
-          disabled={!name.trim() || !roomCode.trim()}
-        >
-          加入 / Join
-        </Button>
+            ))}
+          </div>
+        )}
       </div>
-
-      {error && <p className="error-msg">{error}</p>}
-
-      <hr />
-      <Button
-        variant="secondary"
-        onClick={() => setShowTutorial(true)}
-        style={{ width: "100%", background: "transparent", border: "1px solid var(--color-gold-border-hover)" }}
-      >
-        游戏规则 / How to Play
-      </Button>
 
       <TutorialModal open={showTutorial} onClose={() => setShowTutorial(false)} />
     </div>

--- a/apps/web/src/pages/Room.tsx
+++ b/apps/web/src/pages/Room.tsx
@@ -88,40 +88,42 @@ export function Room({ initialRoomState, sessionScores }: RoomProps) {
         </div>
       </div>
 
-      {/* Action buttons */}
-      <div className="room-actions">
-        <Button
-          onClick={() => socket.emit("addBot")}
-          disabled={room.players.length >= 4}
-          style={{ flex: 1, minWidth: 120 }}
-        >
-          +机器人 / +Bot
-        </Button>
-        <Button
-          variant="secondary"
-          onClick={() => socket.emit("removeBot")}
-          disabled={!room.players.some((p) => p.isBot)}
-        >
-          -机器人
-        </Button>
-      </div>
-      <div className="room-start-row">
-        <Button
-          variant="gold"
-          size="lg"
-          onClick={handleStart}
-          disabled={room.players.length < 4}
-          className="lobby-create-btn"
-          style={{ flex: 1 }}
-        >
-          开始游戏 / Start
-        </Button>
-        <Button
-          variant="danger"
-          onClick={() => setShowLeaveConfirm(true)}
-        >
-          离开 / Leave
-        </Button>
+      {/* Action buttons — all in one row on landscape compact */}
+      <div className="room-controls-row">
+        <div className="room-actions">
+          <Button
+            onClick={() => socket.emit("addBot")}
+            disabled={room.players.length >= 4}
+            style={{ flex: 1, minWidth: 120 }}
+          >
+            +机器人 / +Bot
+          </Button>
+          <Button
+            variant="secondary"
+            onClick={() => socket.emit("removeBot")}
+            disabled={!room.players.some((p) => p.isBot)}
+          >
+            -机器人
+          </Button>
+        </div>
+        <div className="room-start-row">
+          <Button
+            variant="gold"
+            size="lg"
+            onClick={handleStart}
+            disabled={room.players.length < 4}
+            className="lobby-create-btn"
+            style={{ flex: 1 }}
+          >
+            开始游戏 / Start
+          </Button>
+          <Button
+            variant="danger"
+            onClick={() => setShowLeaveConfirm(true)}
+          >
+            离开 / Leave
+          </Button>
+        </div>
       </div>
       {showLeaveConfirm && (
         <div className="confirm-modal-backdrop">


### PR DESCRIPTION
Lobby and Room pages waste wide aspect ratio on landscape phones by stacking everything vertically, forcing scrolling.

1. Lobby: On landscape mobile, use 2-column layout — left column for name input + Quick Start + Create/Join actions, right column for room list
2. Room: Ensure seat grid + action buttons (Start/Leave) + bot controls all fit above fold on short landscape viewports (375px height)
3. Respect safe-area inset padding from commit c6328bd
4. Reference: 雀魂 mobile lobby uses compact landscape-first layout with side-by-side panels

Client-only: Lobby.tsx, Room.tsx, index.css

Closes #399