### PR TITLE
Score and result screen mobile landscape optimization

### DIFF
--- a/apps/web/src/components/SessionSummary.tsx
+++ b/apps/web/src/components/SessionSummary.tsx
@@ -37,17 +37,17 @@ function RoundHistorySection({ roundHistory, playerNames, isCompact }: {
   const contentMaxHeight = isCompact ? (expanded ? 240 : 0) : 160;
 
   return (
-    <div style={{ marginBottom: 16 }}>
+    <div style={{ marginBottom: "clamp(8px, 2.5vh, 16px)" }}>
       <div
         style={{
-          fontSize: 13, color: "var(--color-text-secondary)", marginBottom: 6,
+          fontSize: "clamp(11px, 3vh, 13px)", color: "var(--color-text-secondary)", marginBottom: "clamp(3px, 1vh, 6px)",
           ...(showToggle ? { cursor: "pointer", userSelect: "none" as const } : {}),
         }}
         onClick={showToggle ? () => setExpanded(e => !e) : undefined}
       >
         每局记录 / Round History
         {showToggle && (
-          <span style={{ marginLeft: 6, fontSize: 11 }}>
+          <span style={{ marginLeft: 6, fontSize: "clamp(9px, 2.5vh, 11px)" }}>
             {expanded ? "▲ 收起" : "▼ 展开"}
           </span>
         )}
@@ -56,14 +56,14 @@ function RoundHistorySection({ roundHistory, playerNames, isCompact }: {
         <div style={{ maxHeight: contentMaxHeight, overflowY: "auto" }}>
           {/* Player name header */}
           <div style={{
-            fontSize: 11, padding: "4px 10px", marginBottom: 2,
+            fontSize: "clamp(9px, 2.5vh, 11px)", padding: "clamp(2px, 0.8vh, 4px) clamp(6px, 1.8vh, 10px)", marginBottom: 2,
             display: "flex", justifyContent: "space-between", alignItems: "center",
             color: "var(--color-text-secondary)", opacity: 0.7,
           }}>
             <span />
             <span>
               {playerNames.map((name, i) => (
-                <span key={i} style={{ marginLeft: 8, minWidth: 28, display: "inline-block", textAlign: "right" }}>
+                <span key={i} style={{ marginLeft: "clamp(4px, 1.2vh, 8px)", minWidth: "clamp(20px, 6vh, 28px)", display: "inline-block", textAlign: "right" }}>
                   {name.length > 4 ? name.slice(0, 3) + "…" : name}
                 </span>
               ))}
@@ -71,7 +71,7 @@ function RoundHistorySection({ roundHistory, playerNames, isCompact }: {
           </div>
           {roundHistory.map((round, ri) => (
             <div key={ri} style={{
-              fontSize: 12, padding: "6px 10px", marginBottom: 2,
+              fontSize: "clamp(10px, 2.8vh, 12px)", padding: "clamp(3px, 1vh, 6px) clamp(6px, 1.8vh, 10px)", marginBottom: 2,
               background: "rgba(255,255,255,0.03)", borderRadius: 4,
               display: "flex", justifyContent: "space-between", alignItems: "center",
             }}>
@@ -81,7 +81,7 @@ function RoundHistorySection({ roundHistory, playerNames, isCompact }: {
               <span style={{ color: "var(--color-text-primary)" }}>
                 {round.scores.map((s, i) => (
                   <span key={i} style={{
-                    marginLeft: 8, minWidth: 28, display: "inline-block", textAlign: "right",
+                    marginLeft: "clamp(4px, 1.2vh, 8px)", minWidth: "clamp(20px, 6vh, 28px)", display: "inline-block", textAlign: "right",
                     color: s > 0 ? "var(--color-success)" : s < 0 ? "var(--color-error)" : "var(--color-text-secondary)",
                     opacity: s === 0 ? 0.6 : 1,
                   }}>
@@ -133,36 +133,36 @@ export function SessionSummary({ data, onClose }: SessionSummaryProps) {
         background: "linear-gradient(135deg, var(--color-bg-dark) 0%, var(--color-bg-medium) 100%)",
         border: "1px solid rgba(255,215,0,0.3)",
         borderRadius: 12,
-        padding: isCompact ? "16px 20px" : "24px 28px",
+        padding: isCompact ? "clamp(8px, 2.5vh, 16px) clamp(12px, 3vh, 20px)" : "24px 28px",
         maxWidth: 440,
         width: "90vw",
         maxHeight: "90dvh",
         overflowY: "auto",
         color: "var(--color-text-primary)",
       }}>
-        <h2 style={{ textAlign: "center", fontSize: isCompact ? 18 : 22, marginBottom: 4, color: "var(--color-gold-bright)" }}>
+        <h2 style={{ textAlign: "center", fontSize: isCompact ? "clamp(14px, 4.5vh, 18px)" : 22, marginBottom: "clamp(2px, 0.8vh, 4px)", color: "var(--color-gold-bright)" }}>
           本场总结 / Session Summary
         </h2>
-        <div style={{ textAlign: "center", fontSize: 13, color: "var(--color-text-secondary)", marginBottom: 16 }}>
+        <div style={{ textAlign: "center", fontSize: "clamp(11px, 3vh, 13px)", color: "var(--color-text-secondary)", marginBottom: "clamp(8px, 2.5vh, 16px)" }}>
           共 {roundsPlayed} 局
         </div>
 
         {/* Final Rankings */}
-        <div style={{ marginBottom: 16 }}>
-          <div style={{ fontSize: 13, color: "var(--color-text-secondary)", marginBottom: 6 }}>最终排名 / Final Rankings</div>
+        <div style={{ marginBottom: "clamp(8px, 2.5vh, 16px)" }}>
+          <div style={{ fontSize: "clamp(11px, 3vh, 13px)", color: "var(--color-text-secondary)", marginBottom: "clamp(3px, 1vh, 6px)" }}>最终排名 / Final Rankings</div>
           {rankings.map((p, rank) => (
             <div key={p.i} className="session-rank-row" style={{
               display: "flex", justifyContent: "space-between", alignItems: "center",
-              padding: "8px 14px", marginBottom: 4, borderRadius: 6,
+              padding: "clamp(4px, 1.5vh, 8px) clamp(8px, 2.5vh, 14px)", marginBottom: "clamp(2px, 0.6vh, 4px)", borderRadius: 6,
               background: rank === 0 ? "rgba(255,215,0,0.12)" : "rgba(255,255,255,0.04)",
               border: rank === 0 ? "1px solid rgba(255,215,0,0.4)" : "1px solid transparent",
             }}>
-              <span style={{ fontSize: rank === 0 ? 16 : 14 }}>
+              <span style={{ fontSize: rank === 0 ? "clamp(13px, 3.8vh, 16px)" : "clamp(11px, 3.2vh, 14px)" }}>
                 {rank === 0 ? "👑 " : `${rank + 1}. `}
                 {p.name}
               </span>
               <span style={{
-                fontWeight: "bold", fontSize: rank === 0 ? 18 : 14,
+                fontWeight: "bold", fontSize: rank === 0 ? "clamp(14px, 4vh, 18px)" : "clamp(11px, 3.2vh, 14px)",
                 color: p.score > 0 ? "var(--color-gold-bright)" : p.score < 0 ? "var(--color-error)" : "var(--color-text-secondary)",
               }}>
                 {p.score > 0 ? "+" : ""}{p.score}
@@ -174,17 +174,17 @@ export function SessionSummary({ data, onClose }: SessionSummaryProps) {
         {/* MVP Stats */}
         {roundHistory.length > 0 && (
           <div style={{
-            marginBottom: 16, padding: 10,
+            marginBottom: "clamp(8px, 2.5vh, 16px)", padding: "clamp(6px, 1.8vh, 10px)",
             background: "rgba(255,255,255,0.04)", borderRadius: 6,
           }}>
-            <div style={{ fontSize: 13, color: "var(--color-text-secondary)", marginBottom: 6 }}>数据亮点 / Highlights</div>
+            <div style={{ fontSize: "clamp(11px, 3vh, 13px)", color: "var(--color-text-secondary)", marginBottom: "clamp(3px, 1vh, 6px)" }}>数据亮点 / Highlights</div>
             {mostWins > 0 && (
-              <div style={{ fontSize: 13, color: "var(--color-text-warm)", marginBottom: 4 }}>
+              <div style={{ fontSize: "clamp(11px, 3vh, 13px)", color: "var(--color-text-warm)", marginBottom: "clamp(2px, 0.6vh, 4px)" }}>
                 🏆 最多胜场: {playerNames[mostWinsIdx]} ({mostWins}胡)
               </div>
             )}
             {highestRoundScore > 0 && (
-              <div style={{ fontSize: 13, color: "var(--color-text-warm)" }}>
+              <div style={{ fontSize: "clamp(11px, 3vh, 13px)", color: "var(--color-text-warm)" }}>
                 🎯 单局最高: {playerNames[highestRoundPlayer]} (+{highestRoundScore})
               </div>
             )}
@@ -204,10 +204,11 @@ export function SessionSummary({ data, onClose }: SessionSummaryProps) {
           onClick={onClose}
           style={{
             position: "sticky", bottom: 0,
-            width: "100%", padding: "12px 0", fontSize: 16,
+            width: "100%", padding: "clamp(8px, 2.5vh, 12px) 0", fontSize: "clamp(13px, 3.5vh, 16px)",
             background: "var(--color-bg-button)", color: "var(--color-text-primary)",
             border: "1px solid rgba(255,215,0,0.3)",
             borderRadius: 6, cursor: "pointer",
+            minHeight: "max(36px, 9vh)",
           }}
         >
           返回大厅 / Back to Lobby

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1038,3 +1038,16 @@ button.lobby-create-btn:hover:not(:disabled) {
   gap: 10px;
   align-items: center;
 }
+
+/* Compact score rows for landscape mobile */
+@media (orientation: landscape) and (max-height: 550px) {
+  .score-row {
+    padding: clamp(3px, 1vh, 6px) clamp(8px, 2.5vh, 16px);
+    font-size: clamp(11px, 3vh, 14px);
+    margin-bottom: max(1px, 0.3vh);
+  }
+  .score-breakdown {
+    margin-bottom: clamp(4px, 1.2vh, 8px);
+    padding: clamp(6px, 1.8vh, 10px);
+  }
+}

--- a/apps/web/src/pages/Game.tsx
+++ b/apps/web/src/pages/Game.tsx
@@ -535,39 +535,39 @@ export function Game({ initialGameState, onLeave }: GameProps) {
             background: "var(--overlay-bg)",
             border: "2px solid var(--color-gold-border-hover)",
             borderRadius: "var(--radius-lg)",
-            padding: "16px 20px",
+            padding: "clamp(8px, 2.5vh, 16px) clamp(12px, 3vh, 20px)",
             maxWidth: 360, width: "90vw",
             maxHeight: "90dvh", overflowY: "auto",
             textAlign: "center",
             animation: "overlayScaleIn 0.3s ease-out",
           }}>
-            <h2 style={{ fontSize: 24, marginBottom: 8 }}>
+            <h2 style={{ fontSize: "clamp(16px, 5vh, 24px)", marginBottom: "clamp(4px, 1.2vh, 8px)" }}>
               {go.winnerId !== null
                 ? `🎉 ${(go.playerNames ?? [])[go.winnerId] || "玩家"} 胡了!`
                 : "流局 / Draw"}
             </h2>
-            <p style={{ fontSize: 16, color: "var(--color-text-gold)", marginBottom: 12 }}>
+            <p style={{ fontSize: "clamp(12px, 3.5vh, 16px)", color: "var(--color-text-gold)", marginBottom: "clamp(6px, 2vh, 12px)" }}>
               {winTypeNames[go.winType] || go.winType}
             </p>
 
             {/* Score breakdown */}
             {go.breakdown && go.winnerId !== null && (
               <div className="score-breakdown">
-                <div style={{ fontSize: 12, color: "var(--color-text-secondary)", marginBottom: 4 }}>得分明细</div>
-                <div style={{ display: "flex", flexWrap: "wrap", gap: "4px 12px", justifyContent: "center", fontSize: 13, color: "var(--color-text-primary)" }}>
+                <div style={{ fontSize: "clamp(10px, 2.8vh, 12px)", color: "var(--color-text-secondary)", marginBottom: "clamp(2px, 0.8vh, 4px)" }}>得分明细</div>
+                <div style={{ display: "flex", flexWrap: "wrap", gap: "clamp(2px, 0.8vh, 4px) clamp(6px, 2vh, 12px)", justifyContent: "center", fontSize: "clamp(11px, 3vh, 13px)", color: "var(--color-text-primary)" }}>
                   <span>花分: {go.breakdown.flowerScore}</span>
                   <span>金: {go.breakdown.goldScore}</span>
                   <span>连庄: {go.breakdown.lianZhuangCount}</span>
                   <span>特殊: {go.breakdown.specialMultiplier}x</span>
                 </div>
-                <div style={{ fontSize: 14, color: "var(--color-text-gold)", marginTop: 4 }}>
+                <div style={{ fontSize: "clamp(12px, 3.2vh, 14px)", color: "var(--color-text-gold)", marginTop: "clamp(2px, 0.8vh, 4px)" }}>
                   总分: {go.breakdown.totalScore}
                 </div>
               </div>
             )}
 
             {/* Round scores */}
-            <div style={{ marginBottom: 12 }}>
+            <div style={{ marginBottom: "clamp(6px, 2vh, 12px)" }}>
               {go.scores
                 .map((score, i) => ({ name: (go.playerNames ?? [])[i] || `玩家${i}`, score, i }))
                 .sort((a, b) => b.score - a.score)
@@ -583,8 +583,8 @@ export function Game({ initialGameState, onLeave }: GameProps) {
             </div>
 
             {/* Actions */}
-            <div style={{ display: "flex", gap: 12, justifyContent: "center", flexWrap: "wrap" }}>
-              <Button variant="gold" size="lg" onClick={handleNextRound} style={{ minHeight: 48 }}>
+            <div style={{ display: "flex", gap: "clamp(6px, 2vh, 12px)", justifyContent: "center", flexWrap: "wrap" }}>
+              <Button variant="gold" size="lg" onClick={handleNextRound} style={{ minHeight: "clamp(36px, 10vh, 48px)" }}>
                 下一局 / Next Round
               </Button>
               {onLeave && (
@@ -601,7 +601,7 @@ export function Game({ initialGameState, onLeave }: GameProps) {
                     socket.emit("leaveRoom");
                     onLeave();
                   }
-                }} style={{ minHeight: 48 }}>
+                }} style={{ minHeight: "clamp(36px, 10vh, 48px)" }}>
                   离开 / Leave
                 </Button>
               )}


### PR DESCRIPTION
End-of-round and end-of-game screens likely not optimized for landscape mobile. Audit and fix:

1. Game-over modal (Game.tsx) — verify it fits within 390px height without scrolling, text readable, buttons tappable
2. SessionSummary modal — round history table may overflow on small screens, needs compact layout
3. Score display — ensure cumulative scores are visible and readable at compact sizes
4. Use relative units throughout, respect safe-area insets

Client-only: Game.tsx, SessionSummary.tsx, index.css

Closes #403