### PR TITLE
Mobile touch and overflow polish fixes

### DIFF
--- a/apps/web/src/components/ClaimOverlay.tsx
+++ b/apps/web/src/components/ClaimOverlay.tsx
@@ -187,6 +187,8 @@ export function ClaimOverlay({ actions, gameState, onAction }: ClaimOverlayProps
               scrollSnapType: "x mandatory",
               WebkitOverflowScrolling: "touch",
               justifyContent: actions.chiOptions.length <= 2 ? "center" : undefined,
+              maxHeight: "60dvh",
+              overflowY: "auto",
             }}>
               {actions.chiOptions.map((combo, i) => (
                 <button

--- a/apps/web/src/components/PlayerArea.tsx
+++ b/apps/web/src/components/PlayerArea.tsx
@@ -281,6 +281,7 @@ export function PlayerArea({
         display: "flex", flexWrap: "nowrap", gap: firstPerson ? "var(--fp-hand-gap)" : 1, marginBottom: 4, alignItems: "flex-end",
         justifyContent: isMe ? "center" : undefined,
         paddingTop: isMe ? "var(--hand-padding-top)" : 0, overflow: "hidden", position: "relative",
+        touchAction: "manipulation",
         ...(firstPerson ? { "--tile-w": "var(--fp-tile-w)", "--tile-h": "var(--fp-tile-h)" } as React.CSSProperties : {}),
       }}>
         {isMe && hand ? (

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -348,7 +348,7 @@ body {
     --fp-hand-gap: 1px;
     --grid-side-col: clamp(40px, 13vh, 60px);
     --wall-progress-w: clamp(50px, 16vh, 80px);
-    --fp-side-col: clamp(30px, 9.5vh, 44px);
+    --fp-side-col: clamp(40px, 9.5vh, 44px);
     --fp-top-row: clamp(16px, 5.3vh, 24px);
     --font-badge: max(10px, 2.6vh);
     --font-uc-label: max(10px, 2.6vh);


### PR DESCRIPTION
Fix touch target regression and overflow issues on mobile.

1. index.css:351 — --fp-side-col: clamp(30px, 9.5vh, 44px) allows 30px minimum, violating 44px touch target rule. Change min to 40px.
2. ClaimOverlay.tsx:182 — chi picker has no maxHeight, can overflow viewport on 340px screens with many chi options. Add maxHeight constraint.
3. PlayerArea.tsx:64 — add touch-action: manipulation to tile interactions to prevent iOS double-tap-to-zoom conflict with our 300ms double-tap window.

Client-only, 3 files: index.css, ClaimOverlay.tsx, PlayerArea.tsx

Closes #405