### PR TITLE
Mobile hand tile interaction audit and tap target fixes

### DIFF
--- a/apps/web/src/components/Tile.tsx
+++ b/apps/web/src/components/Tile.tsx
@@ -122,7 +122,7 @@ export function TileView({ tile, faceUp = true, selected, claimable, onClick, on
           ? "0 0 8px rgba(255,215,0,0.6), 0 3px 6px rgba(0,0,0,0.3), inset 0 1px 0 rgba(255,255,255,0.8)"
           : "0 3px 6px rgba(0,0,0,0.3), 0 1px 2px rgba(0,0,0,0.2), inset 0 1px 0 rgba(255,255,255,0.8)",
         transform: selected
-          ? "translateY(-10px) translateZ(20px) scale(1.12)"
+          ? "translateY(var(--tile-select-lift, -10px)) translateZ(20px) scale(1.12)"
           : "translateZ(0)",
         transformStyle: "preserve-3d" as any,
         transition: "all 0.2s cubic-bezier(0.4, 0, 0.2, 1)",

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -164,6 +164,7 @@ body {
   --hand-new-tile-margin: 16px;
   --hand-padding-top: 18px;
   --tile-margin: 1px;
+  --tile-select-lift: -10px;
 
   /* Grid layout sizing */
   --grid-side-col: 60px;
@@ -277,6 +278,7 @@ body {
     --hand-new-tile-margin: 6px;
     --hand-padding-top: 8px;
     --tile-margin: 2px;
+    --tile-select-lift: -8px;
     --compact-gap: 6px;
     --compact-padding: 2px 8px;
     --compact-label-font: 12px;
@@ -337,11 +339,12 @@ body {
     --hand-padding-top: max(2px, 0.5vh);
     --hand-new-tile-margin: max(4px, 1vh);
     --tile-margin: 2px;
+    --tile-select-lift: -6px;
     --compact-gap: max(2px, 0.5vh);
     --compact-padding: max(2px, 0.5vh) max(4px, 1vh);
     --compact-label-font: max(10px, 2.6vh);
     --compact-info-font: max(9px, 2.3vh);
-    --fp-tile-w: clamp(28px, 8.5vh, 38px);
+    --fp-tile-w: clamp(40px, 8.5vh, 44px);
     --fp-tile-h: clamp(40px, 12vh, 56px);
     --fp-opponent-tile-w: clamp(16px, 5.3vh, 24px);
     --fp-opponent-tile-h: clamp(22px, 7.2vh, 32px);


### PR DESCRIPTION
Verify actual gameplay feel on mobile, not just layout.

1. Are tiles big enough to tap without misclicks on 375px-wide screen? Min 40px tap targets (reference 雀魂 mobile)
2. Does discard gesture (tap to select + confirm, double-tap, swipe) work reliably at small sizes?
3. Is ClaimOverlay (chi/pong/gang/hu/pass) easy to hit with thumbs? Buttons need adequate spacing
4. Check tile selection feedback — is the selected state visually clear on small screens?
5. Fix the top issues found

Client-only: PlayerArea.tsx, ClaimOverlay.tsx, index.css

Closes #396