### PR TITLE
Modal max-widths game-over layout and z-index cleanup

### DIFF
--- a/apps/web/src/components/SessionSummary.tsx
+++ b/apps/web/src/components/SessionSummary.tsx
@@ -134,7 +134,7 @@ export function SessionSummary({ data, onClose }: SessionSummaryProps) {
         border: "1px solid rgba(255,215,0,0.3)",
         borderRadius: 12,
         padding: isCompact ? "clamp(8px, 2.5vh, 16px) clamp(12px, 3vh, 20px)" : "24px 28px",
-        maxWidth: 440,
+        maxWidth: "min(440px, 90vw)",
         width: "90vw",
         maxHeight: "90dvh",
         overflowY: "auto",

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -780,7 +780,7 @@ button.lobby-create-btn:hover:not(:disabled) {
   grid-template-columns: 1fr 1.6fr 1fr;
   grid-template-rows: auto 1fr auto;
   gap: var(--seat-gap);
-  max-width: 400px;
+  max-width: min(400px, 90vw);
   margin: 0 auto;
 }
 
@@ -945,7 +945,7 @@ button.lobby-create-btn:hover:not(:disabled) {
 
 /* Shared confirmation modal */
 .confirm-modal-backdrop { position: fixed; inset: 0; background: rgba(0,0,0,0.6); display: flex; align-items: center; justify-content: center; z-index: 50; }
-.confirm-modal { background: var(--overlay-bg); border: 2px solid var(--color-gold-border-hover); border-radius: var(--radius-lg); padding: 24px; max-width: 360px; text-align: center; max-height: calc(100dvh - 40px); overflow-y: auto; }
+.confirm-modal { background: var(--overlay-bg); border: 2px solid var(--color-gold-border-hover); border-radius: var(--radius-lg); padding: 24px; max-width: min(360px, 90vw); text-align: center; max-height: calc(100dvh - 40px); overflow-y: auto; }
 .confirm-modal-title { font-size: 18px; margin-bottom: 8px; }
 .confirm-modal-subtitle { font-size: 13px; color: var(--color-text-secondary); margin-bottom: 0; }
 .confirm-modal-actions { display: flex; gap: 12px; justify-content: center; margin-top: 16px; }

--- a/apps/web/src/pages/Game.tsx
+++ b/apps/web/src/pages/Game.tsx
@@ -475,7 +475,7 @@ export function Game({ initialGameState, onLeave }: GameProps) {
         >⚙</button>
         {settingsOpen && (
           <div style={{
-            position: 'absolute', top: 48, right: 0,
+            position: 'absolute', top: 48, right: 0, zIndex: 45,
             background: 'var(--overlay-bg)', border: '1px solid var(--color-gold-border-hover)',
             borderRadius: 'var(--radius-md)', padding: 4, minWidth: 160,
             display: 'flex', flexDirection: 'column', gap: 2,
@@ -536,8 +536,8 @@ export function Game({ initialGameState, onLeave }: GameProps) {
             border: "2px solid var(--color-gold-border-hover)",
             borderRadius: "var(--radius-lg)",
             padding: "clamp(8px, 2.5vh, 16px) clamp(12px, 3vh, 20px)",
-            maxWidth: 360, width: "90vw",
-            maxHeight: "90dvh", overflowY: "auto",
+            maxWidth: "min(360px, 90vw)", width: "90vw",
+            maxHeight: "max(70dvh, 300px)", overflowY: "auto",
             textAlign: "center",
             animation: "overlayScaleIn 0.3s ease-out",
           }}>


### PR DESCRIPTION
Frontend CSS/layout fixes:

1. Hardcoded modal max-widths — confirm-modal (index.css:948) uses max-width: 360px, SessionSummary (SessionSummary.tsx:137) uses maxWidth: 440. Both should use min(Xpx, 90vw) pattern.
2. Game-over modal missing landscape rules (Game.tsx:528-609) — No orientation:landscape media query. On 667x375 the 90dvh maxHeight leaves no room. Add landscape-specific max-height like max(70dvh, 300px).
3. Settings dropdown missing z-index (Game.tsx:478) — No explicit z-index, renders behind ClaimOverlay (z:40). Add zIndex: 45.
4. seat-layout hardcoded 400px (index.css:783) — Change to max-width: min(400px, 90vw).

Client-only: index.css, Game.tsx, SessionSummary.tsx

Closes #413