### PR TITLE
Replace stale window innerHeight reads with reactive hooks

### DIFF
--- a/apps/web/src/components/CenterAction.tsx
+++ b/apps/web/src/components/CenterAction.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import type { TileInstance, GoldState } from "@fuzhou-mahjong/shared";
 import { TileView } from "./Tile";
 import { BREAKPOINTS } from "../hooks/useIsMobile";
+import { useWindowSize } from "../hooks/useWindowSize";
 
 interface CenterActionProps {
   gold: GoldState | null;
@@ -45,6 +46,7 @@ export function useCenterAction() {
 }
 
 export function CenterAction({ display, gold }: { display: ActionDisplay | null; gold: GoldState | null }) {
+  const { height } = useWindowSize();
   if (!display) return null;
 
   return (
@@ -69,7 +71,7 @@ export function CenterAction({ display, gold }: { display: ActionDisplay | null;
         filter: "drop-shadow(0 4px 12px rgba(0,0,0,0.5))",
       }}>
         {display.tiles.map((t) => (
-          <div key={t.id} style={{ transform: `scale(${window.innerHeight <= BREAKPOINTS.COMPACT_HEIGHT ? 1.2 : 1.8})` }}>
+          <div key={t.id} style={{ transform: `scale(${height <= BREAKPOINTS.COMPACT_HEIGHT ? 1.2 : 1.8})` }}>
             <TileView tile={t} faceUp gold={gold} />
           </div>
         ))}

--- a/apps/web/src/components/ClaimOverlay.tsx
+++ b/apps/web/src/components/ClaimOverlay.tsx
@@ -3,6 +3,7 @@ import { ActionType } from "@fuzhou-mahjong/shared";
 import type { AvailableActions, ClientGameState, GameAction, TileInstance } from "@fuzhou-mahjong/shared";
 import { TileView } from "./Tile";
 import { BREAKPOINTS } from "../hooks/useIsMobile";
+import { useWindowSize } from "../hooks/useWindowSize";
 
 interface ClaimOverlayProps {
   actions: AvailableActions;
@@ -31,8 +32,9 @@ const BTN = {
 };
 
 export function ClaimOverlay({ actions, gameState, onAction }: ClaimOverlayProps) {
-  const isCompact = window.innerHeight <= BREAKPOINTS.COMPACT_HEIGHT;
-  const isUltraCompact = window.innerHeight <= 390;
+  const { height } = useWindowSize();
+  const isCompact = height <= BREAKPOINTS.COMPACT_HEIGHT;
+  const isUltraCompact = height <= 390;
   const [showChiPicker, setShowChiPicker] = useState(false);
   const [exiting, setExiting] = useState(false);
   const [exitingChi, setExitingChi] = useState(false);

--- a/apps/web/src/components/SessionSummary.tsx
+++ b/apps/web/src/components/SessionSummary.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import type { GameOverResult } from "@fuzhou-mahjong/shared";
 import { BREAKPOINTS } from "../hooks/useIsMobile";
+import { useWindowSize } from "../hooks/useWindowSize";
 
 interface RoundRecord {
   scores: number[];
@@ -99,7 +100,8 @@ function RoundHistorySection({ roundHistory, playerNames, isCompact }: {
 
 export function SessionSummary({ data, onClose }: SessionSummaryProps) {
   const { playerNames, cumulativeScores, roundsPlayed, roundHistory } = data;
-  const isCompact = window.innerHeight <= BREAKPOINTS.COMPACT_HEIGHT;
+  const { height } = useWindowSize();
+  const isCompact = height <= BREAKPOINTS.COMPACT_HEIGHT;
 
   // Rankings sorted by cumulative score
   const rankings = cumulativeScores

--- a/apps/web/src/components/TutorialModal.tsx
+++ b/apps/web/src/components/TutorialModal.tsx
@@ -3,6 +3,7 @@ import { TileView } from "./Tile";
 import type { TileInstance } from "@fuzhou-mahjong/shared";
 import { Suit } from "@fuzhou-mahjong/shared";
 import { BREAKPOINTS } from "../hooks/useIsMobile";
+import { useWindowSize } from "../hooks/useWindowSize";
 
 /* Helper to create demo TileInstance objects for display */
 function demoTile(id: number, tile: TileInstance["tile"]): TileInstance {
@@ -217,10 +218,11 @@ export function TutorialModal({ open, onClose, condensed }: TutorialModalProps) 
     ? CONDENSED_INDICES.map((i) => ALL_SLIDES[i])
     : ALL_SLIDES;
   const [currentSlide, setCurrentSlide] = useState(0);
+  const { height } = useWindowSize();
 
   if (!open) return null;
 
-  const isCompact = window.innerHeight <= BREAKPOINTS.COMPACT_HEIGHT;
+  const isCompact = height <= BREAKPOINTS.COMPACT_HEIGHT;
   const slide = slides[currentSlide];
   const isFirst = currentSlide === 0;
   const isLast = currentSlide === slides.length - 1;

--- a/apps/web/src/hooks/useSwipeGesture.ts
+++ b/apps/web/src/hooks/useSwipeGesture.ts
@@ -13,7 +13,7 @@ interface SwipeConfig {
  */
 export function useSwipeGesture({
   onSwipeUp,
-  threshold = Math.min(40, window.innerHeight * 0.08),
+  threshold: thresholdProp,
   enabled = true,
 }: SwipeConfig) {
   const [swipingTileId, setSwipingTileId] = useState<number | null>(null);
@@ -66,13 +66,14 @@ export function useSwipeGesture({
 
   const onTouchEnd = useCallback(() => {
     const ref = touchRef.current;
+    const threshold = thresholdProp ?? Math.min(40, window.innerHeight * 0.08);
     if (ref && ref.locked && swipeOffset < -threshold) {
       onSwipeUp(ref.tileId);
     }
     touchRef.current = null;
     setSwipingTileId(null);
     setSwipeOffset(0);
-  }, [swipeOffset, threshold, onSwipeUp]);
+  }, [swipeOffset, thresholdProp, onSwipeUp]);
 
   return { onTouchStart, onTouchMove, onTouchEnd, swipingTileId, swipeOffset };
 }

--- a/apps/web/src/hooks/useWindowSize.ts
+++ b/apps/web/src/hooks/useWindowSize.ts
@@ -1,0 +1,30 @@
+import { useState, useEffect } from "react";
+
+interface WindowSize {
+  width: number;
+  height: number;
+}
+
+export function useWindowSize(): WindowSize {
+  const [size, setSize] = useState<WindowSize>(() => ({
+    width: window.innerWidth,
+    height: window.innerHeight,
+  }));
+
+  useEffect(() => {
+    let timeout: ReturnType<typeof setTimeout>;
+    const onResize = () => {
+      clearTimeout(timeout);
+      timeout = setTimeout(() => {
+        setSize({ width: window.innerWidth, height: window.innerHeight });
+      }, 100);
+    };
+    window.addEventListener("resize", onResize);
+    return () => {
+      clearTimeout(timeout);
+      window.removeEventListener("resize", onResize);
+    };
+  }, []);
+
+  return size;
+}

--- a/apps/web/src/pages/Game.tsx
+++ b/apps/web/src/pages/Game.tsx
@@ -7,6 +7,7 @@ import { sounds, setMuted, isMuted } from "../sounds";
 import { TileCounter } from "../components/TileCounter";
 import { TutorialModal } from "../components/TutorialModal";
 import { BREAKPOINTS } from "../hooks/useIsMobile";
+import { useWindowSize } from "../hooks/useWindowSize";
 import { TileView } from "../components/Tile";
 import { SessionSummary, type SessionData } from "../components/SessionSummary";
 import { Button } from "../components/Button";
@@ -350,7 +351,8 @@ export function Game({ initialGameState, onLeave }: GameProps) {
     ? (actions.canHu || actions.canPeng || actions.canMingGang || actions.chiOptions.length > 0) && !actions.canDiscard
     : false;
 
-  const isCompactMain = window.innerHeight <= BREAKPOINTS.COMPACT_HEIGHT;
+  const { height: windowHeight } = useWindowSize();
+  const isCompactMain = windowHeight <= BREAKPOINTS.COMPACT_HEIGHT;
 
   const handleAction = (action: GameAction) => {
     socket.emit("playerAction", action);


### PR DESCRIPTION
5 components read window.innerHeight at render time but do not re-read on resize/rotation. After device rotation, layout uses stale dimensions until next re-render.

Audit all components using window.innerHeight or window.innerWidth directly in render. Replace with a shared useWindowSize() hook that listens to resize events and returns current dimensions reactively.

Client-only: ClaimOverlay.tsx, TileTooltip.tsx, useSwipeGesture.ts, and any others found during audit

Closes #418