### PR TITLE
Settings dropdown safe-area fix and GameTable grid overflow

### DIFF
--- a/apps/web/src/components/GameTable.tsx
+++ b/apps/web/src/components/GameTable.tsx
@@ -72,7 +72,7 @@ export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTile
         ? `". top ." "left center right" ". bottom ."`
         : `". top ." "left center right" "bottom bottom bottom"`,
       gridTemplateColumns: isFirstPersonMobile ? "var(--fp-side-col) 1fr var(--fp-side-col)" : isCompact ? "var(--grid-side-col) 1fr var(--grid-side-col)" : "1fr 2fr 1fr",
-      gridTemplateRows: isFirstPersonMobile ? "var(--fp-top-row) 1fr minmax(55%, 65%)" : isCompact ? "var(--grid-top-row) var(--grid-center-row) 1fr" : "auto 1fr auto",
+      gridTemplateRows: isFirstPersonMobile ? "var(--fp-top-row) 1fr minmax(min(55%, 200px), 65%)" : isCompact ? "var(--grid-top-row) var(--grid-center-row) 1fr" : "auto 1fr auto",
       flex: 1,
       minHeight: 0,
       gap: "var(--game-gap)",

--- a/apps/web/src/pages/Game.tsx
+++ b/apps/web/src/pages/Game.tsx
@@ -477,7 +477,7 @@ export function Game({ initialGameState, onLeave }: GameProps) {
         >⚙</button>
         {settingsOpen && (
           <div style={{
-            position: 'absolute', top: 48, right: 0, zIndex: 45,
+            position: 'absolute', top: 'calc(48px + env(safe-area-inset-top, 0px))', right: 0, zIndex: 45,
             background: 'var(--overlay-bg)', border: '1px solid var(--color-gold-border-hover)',
             borderRadius: 'var(--radius-md)', padding: 4, minWidth: 160,
             display: 'flex', flexDirection: 'column', gap: 2,


### PR DESCRIPTION
Two quick UI fixes:

1. Game.tsx ~line 480: settings dropdown top: 48 hardcoded. Should be calc(48px + env(safe-area-inset-top, 0px)).
2. GameTable.tsx lines 69-75: minmax(55%, 65%) bottom row can overflow when viewport height < 390px. Needs clamp or fallback.

Client-only: Game.tsx, GameTable.tsx

Closes #423