### PR TITLE
Bot decideBotAction silent-pass audit and logging

### DIFF
--- a/packages/shared/src/game/bot.ts
+++ b/packages/shared/src/game/bot.ts
@@ -577,5 +577,8 @@ export function decideBotAction(
   }
 
   // Default: pass
+  console.warn(
+    `[Bot:decision] Player ${playerIndex} defaulting to Pass — available: canHu=${actions.canHu}, canPeng=${actions.canPeng}, canMingGang=${actions.canMingGang}, chiOptions=${actions.chiOptions.length}, canDiscard=${actions.canDiscard}, canDraw=${actions.canDraw}`,
+  );
   return { type: ActionType.Pass, playerIndex };
 }


### PR DESCRIPTION
In packages/shared/src/game/bot.ts ~line 579-581, default fallback is silent Pass with zero logging. Bot may miss valid Hu/Gang.

1. Add structured logging matching [Bot:...] pattern when decideBotAction falls through to default pass — log available actions, phase, playerIndex
2. Audit decision tree for edge cases where valid actions (Hu/Gang) could be missed due to early returns or ordering

Shared package only: bot.ts

Closes #428