### PR TITLE
Migrate hardcoded inline fontSize values to CSS custom properties

### DIFF
--- a/apps/web/src/components/CenterAction.tsx
+++ b/apps/web/src/components/CenterAction.tsx
@@ -77,7 +77,7 @@ export function CenterAction({ display, gold }: { display: ActionDisplay | null;
         ))}
       </div>
       <div style={{
-        fontSize: 20,
+        fontSize: "var(--font-xl)",
         fontWeight: "bold",
         color: display.color,
         textShadow: `0 0 20px ${display.color}, 0 2px 4px rgba(0,0,0,0.5)`,

--- a/apps/web/src/components/ConnectionStatus.tsx
+++ b/apps/web/src/components/ConnectionStatus.tsx
@@ -38,11 +38,11 @@ export function ConnectionStatus({ connectionState, reconnectAttempt, timeoutMs,
     }}>
       <div className="spinner" style={{ width: 40, height: 40, borderWidth: 4 }} />
 
-      <div style={{ fontSize: 20, color: "var(--color-text-warm)", fontWeight: "bold" }}>
+      <div style={{ fontSize: "var(--font-xl)", color: "var(--color-text-warm)", fontWeight: "bold" }}>
         {connectionState === "reconnecting" ? "重新连接中... / Reconnecting..." : "连接已断开 / Disconnected"}
       </div>
 
-      <div style={{ fontSize: 16, color: "var(--color-text-secondary)" }}>
+      <div style={{ fontSize: "var(--font-lg)", color: "var(--color-text-secondary)" }}>
         {remaining > 0
           ? `${remaining}s 内重连可恢复游戏 / ${remaining}s to reconnect`
           : "超时 / Timed out"
@@ -50,7 +50,7 @@ export function ConnectionStatus({ connectionState, reconnectAttempt, timeoutMs,
       </div>
 
       {reconnectAttempt > 0 && (
-        <div style={{ fontSize: 13, color: "#6a9a6a" }}>
+        <div style={{ fontSize: "var(--font-md)", color: "#6a9a6a" }}>
           重试 #{reconnectAttempt}
         </div>
       )}

--- a/apps/web/src/components/GameInfo.tsx
+++ b/apps/web/src/components/GameInfo.tsx
@@ -64,7 +64,7 @@ export function GameInfo({ gold, wallRemaining, dealerIndex, lianZhuangCount, my
       borderRadius: 8,
     }}>
       <div style={{ marginBottom: 8 }}>
-        <span style={{ color: "var(--color-text-secondary)", fontSize: 12 }}>金牌: </span>
+        <span style={{ color: "var(--color-text-secondary)", fontSize: "var(--font-sm)" }}>金牌: </span>
         {gold && <TileView tile={gold.indicatorTile} faceUp gold={null} small className={`gold-indicator-glow${goldFlip ? " gold-flip-reveal" : ""}`} />}
       </div>
 
@@ -76,18 +76,18 @@ export function GameInfo({ gold, wallRemaining, dealerIndex, lianZhuangCount, my
           borderRadius: 6,
           border: "1px solid rgba(255,165,0,0.4)",
         }}>
-          <div style={{ fontSize: 11, color: "var(--color-accent-orange)", marginBottom: 4 }}>
+          <div style={{ fontSize: "var(--font-sm)", color: "var(--color-accent-orange)", marginBottom: 4 }}>
             {posLabel(lastDiscard.playerIndex)} 打出:
           </div>
           <TileView tile={lastDiscard.tile} faceUp gold={gold} />
         </div>
       )}
 
-      <div style={{ fontSize: 12, color: "var(--color-text-secondary)" }}>
+      <div style={{ fontSize: "var(--font-sm)", color: "var(--color-text-secondary)" }}>
         庄:{posLabel(dealerIndex)} | 连庄:{lianZhuangCount}
       </div>
       {wallRemaining !== undefined && (
-        <div style={{ fontSize: 12, color: "var(--color-text-secondary)" }}>
+        <div style={{ fontSize: "var(--font-sm)", color: "var(--color-text-secondary)" }}>
           余{wallRemaining}
         </div>
       )}
@@ -95,7 +95,7 @@ export function GameInfo({ gold, wallRemaining, dealerIndex, lianZhuangCount, my
         <div
           className="wall-low-pulse"
           style={{
-            fontSize: 11,
+            fontSize: "var(--font-sm)",
             color: "var(--color-error)",
             padding: "2px 6px",
             borderRadius: 4,
@@ -115,7 +115,7 @@ function MuteButton() {
     <button
       onClick={() => { setMuted(!muted); setMutedState(!muted); }}
       style={{
-        marginTop: 6, padding: "2px 8px", fontSize: 12,
+        marginTop: 6, padding: "2px 8px", fontSize: "var(--font-sm)",
         background: "transparent", border: "1px solid var(--color-text-secondary)",
         color: "var(--color-text-secondary)", borderRadius: 4, minHeight: 44,
         cursor: "pointer",

--- a/apps/web/src/components/PlayerArea.tsx
+++ b/apps/web/src/components/PlayerArea.tsx
@@ -178,10 +178,10 @@ export function PlayerArea({
         <span style={{ fontSize: "var(--compact-label-font, 12px)", fontWeight: "bold", color: "var(--color-text-warm)", whiteSpace: "nowrap", flexShrink: 0 }}>
           {label}
         </span>
-        {isDealer && <span style={{ fontSize: 9, background: "var(--color-dealer-bg)", color: "var(--color-gold-bright)", padding: "0 4px", borderRadius: 3, fontWeight: "bold", flexShrink: 0 }}>庄</span>}
-        {isDisconnected && <span style={{ fontSize: 9, background: "var(--color-disconnect)", color: "#fff", padding: "0 4px", borderRadius: 3, fontWeight: "bold", flexShrink: 0 }}>断线</span>}
-        {hasDiscardedGold && <span style={{ fontSize: 9, background: "var(--color-action-hu)", color: "#fff", padding: "0 4px", borderRadius: 3, fontWeight: "bold", flexShrink: 0 }}>弃金</span>}
-        {isCurrentTurn && <span className="your-turn-prompt" style={{ fontSize: 9, background: "rgba(255,215,0,0.2)", color: "var(--color-gold-bright)", padding: "0 4px", borderRadius: 3, border: "1px solid var(--color-gold-bright)", flexShrink: 0 }}>出牌</span>}
+        {isDealer && <span style={{ fontSize: "var(--font-xs)", background: "var(--color-dealer-bg)", color: "var(--color-gold-bright)", padding: "0 4px", borderRadius: 3, fontWeight: "bold", flexShrink: 0 }}>庄</span>}
+        {isDisconnected && <span style={{ fontSize: "var(--font-xs)", background: "var(--color-disconnect)", color: "#fff", padding: "0 4px", borderRadius: 3, fontWeight: "bold", flexShrink: 0 }}>断线</span>}
+        {hasDiscardedGold && <span style={{ fontSize: "var(--font-xs)", background: "var(--color-action-hu)", color: "#fff", padding: "0 4px", borderRadius: 3, fontWeight: "bold", flexShrink: 0 }}>弃金</span>}
+        {isCurrentTurn && <span className="your-turn-prompt" style={{ fontSize: "var(--font-xs)", background: "rgba(255,215,0,0.2)", color: "var(--color-gold-bright)", padding: "0 4px", borderRadius: 3, border: "1px solid var(--color-gold-bright)", flexShrink: 0 }}>出牌</span>}
 
         {/* Hand count */}
         <span style={{ fontSize: "var(--compact-info-font, 11px)", color: "var(--color-text-secondary)", flexShrink: 0 }}>{handCount ?? 0}张</span>
@@ -258,16 +258,16 @@ export function PlayerArea({
         <span style={{ fontSize: "var(--label-font)", fontWeight: "bold", color: "var(--color-text-warm)" }}>
           {label}
         </span>
-        {isDealer && <span style={{ fontSize: 10, background: "var(--color-dealer-bg)", color: "var(--color-gold-bright)", padding: "1px 5px", borderRadius: 3, fontWeight: "bold" }}>庄</span>}
-        {isDisconnected && <span style={{ fontSize: 10, background: "var(--color-disconnect)", color: "#fff", padding: "1px 5px", borderRadius: 3, fontWeight: "bold", animation: "disconnectPulse 2s ease-in-out infinite" }}>断线</span>}
-        {hasDiscardedGold && <span style={{ fontSize: 10, background: "var(--color-action-hu)", color: "#fff", padding: "1px 5px", borderRadius: 3, fontWeight: "bold" }}>弃金</span>}
-        {isCurrentTurn && <span className="your-turn-prompt" style={{ fontSize: 10, background: "rgba(255,215,0,0.2)", color: "var(--color-gold-bright)", padding: "1px 5px", borderRadius: 3, border: "1px solid var(--color-gold-bright)" }}>出牌</span>}
-        <span style={{ fontSize: 11, color: "var(--color-text-secondary)", marginLeft: "auto" }}>
+        {isDealer && <span style={{ fontSize: "var(--font-xs)", background: "var(--color-dealer-bg)", color: "var(--color-gold-bright)", padding: "1px 5px", borderRadius: 3, fontWeight: "bold" }}>庄</span>}
+        {isDisconnected && <span style={{ fontSize: "var(--font-xs)", background: "var(--color-disconnect)", color: "#fff", padding: "1px 5px", borderRadius: 3, fontWeight: "bold", animation: "disconnectPulse 2s ease-in-out infinite" }}>断线</span>}
+        {hasDiscardedGold && <span style={{ fontSize: "var(--font-xs)", background: "var(--color-action-hu)", color: "#fff", padding: "1px 5px", borderRadius: 3, fontWeight: "bold" }}>弃金</span>}
+        {isCurrentTurn && <span className="your-turn-prompt" style={{ fontSize: "var(--font-xs)", background: "rgba(255,215,0,0.2)", color: "var(--color-gold-bright)", padding: "1px 5px", borderRadius: 3, border: "1px solid var(--color-gold-bright)" }}>出牌</span>}
+        <span style={{ fontSize: "var(--font-sm)", color: "var(--color-text-secondary)", marginLeft: "auto" }}>
           🌸{flowers.length}
         </span>
         {cumulativeScore != null && (
           <span className="cumulative-score-badge" style={{
-            fontSize: 11, fontWeight: "bold",
+            fontSize: "var(--font-sm)", fontWeight: "bold",
             color: cumulativeScore > 0 ? "var(--color-gold-bright)" : cumulativeScore < 0 ? "var(--color-error)" : "var(--color-text-secondary)",
             padding: "1px 6px", borderRadius: 3, background: "rgba(0,0,0,0.3)",
           }}>
@@ -314,7 +314,7 @@ export function PlayerArea({
               {lastDrawnTileId === t.id && !isCompactLandscape && (
                 <div style={{
                   position: "absolute", top: -14, left: "50%", transform: "translateX(-50%)",
-                  fontSize: 10, color: "#4fc3f7", whiteSpace: "nowrap",
+                  fontSize: "var(--font-xs)", color: "#4fc3f7", whiteSpace: "nowrap",
                 }}>新牌</div>
               )}
               {/* Discard / Kong bubble */}
@@ -401,7 +401,7 @@ export function PlayerArea({
 
       {/* Tenpai indicator */}
       {isMe && tenpaiTiles && tenpaiTiles.length > 0 && (
-        <div style={{ fontSize: 12, color: "var(--color-success)", marginBottom: 4 }}>
+        <div style={{ fontSize: "var(--font-sm)", color: "var(--color-success)", marginBottom: 4 }}>
           🀄 听牌！等: {tenpaiTiles.map(t => `${t.value}${{wan:"万",bing:"饼",tiao:"条"}[t.suit]}`).join(" ")}
         </div>
       )}

--- a/apps/web/src/components/TileCounter.tsx
+++ b/apps/web/src/components/TileCounter.tsx
@@ -68,7 +68,7 @@ function TileCell({ label, remaining, total, color }: {
       textDecoration: allGone ? "line-through" : "none",
     }}>
       <span style={{
-        fontSize: 14,
+        fontSize: "var(--font-md)",
         fontWeight: "bold",
         color: allGone ? "var(--color-text-secondary)" : color,
         opacity: allGone ? 0.5 : 1,
@@ -107,7 +107,7 @@ export function TileCounter({ gameState }: TileCounterProps) {
         }}>
           {SUITS.map(suit => (
             <div key={suit} style={{ marginBottom: 6 }}>
-              <div style={{ color: SUIT_COLORS[suit], fontWeight: "bold", fontSize: 10, marginBottom: 2 }}>
+              <div style={{ color: SUIT_COLORS[suit], fontWeight: "bold", fontSize: "var(--font-xs)", marginBottom: 2 }}>
                 {SUIT_LABELS[suit]}
               </div>
               <div style={{ display: "flex", gap: 2, flexWrap: "wrap" }}>
@@ -127,7 +127,7 @@ export function TileCounter({ gameState }: TileCounterProps) {
               </div>
             </div>
           ))}
-          <div style={{ fontSize: 9, color: "var(--color-text-muted)", opacity: 0.3, marginTop: 4, textAlign: "center" }}>
+          <div style={{ fontSize: "var(--font-xs)", color: "var(--color-text-muted)", opacity: 0.3, marginTop: 4, textAlign: "center" }}>
             ● 剩余 &nbsp; ○ 已见
           </div>
         </div>
@@ -139,7 +139,7 @@ export function TileCounter({ gameState }: TileCounterProps) {
           alignItems: "center",
           gap: 6,
           padding: "6px 12px",
-          fontSize: 13,
+          fontSize: "var(--font-md)",
           background: expanded ? "rgba(255,215,0,0.15)" : "rgba(0,0,0,0.7)",
           backdropFilter: "blur(8px)",
           WebkitBackdropFilter: "blur(8px)",
@@ -151,7 +151,7 @@ export function TileCounter({ gameState }: TileCounterProps) {
           whiteSpace: "nowrap",
         }}
       >
-        <span style={{ fontSize: 11 }}>{expanded ? "▼" : "▶"}</span>
+        <span style={{ fontSize: "var(--font-sm)" }}>{expanded ? "▼" : "▶"}</span>
         <span>牌 {totalRemaining}</span>
       </button>
     </div>

--- a/apps/web/src/components/TileTooltip.tsx
+++ b/apps/web/src/components/TileTooltip.tsx
@@ -76,9 +76,9 @@ export function useLongPress(gold: GoldState | null) {
         boxShadow: "0 4px 20px rgba(0,0,0,0.5)",
         pointerEvents: "none",
       }}>
-        <div style={{ fontSize: 28, marginBottom: 4 }}>{name}</div>
-        {isGold && <div style={{ fontSize: 12, color: "var(--color-gold-bright)" }}>金牌 (百搭)</div>}
-        {!isSuitedTile(tile.tile) && <div style={{ fontSize: 12, color: "#aab4a0" }}>花牌</div>}
+        <div style={{ fontSize: "var(--font-2xl)", marginBottom: 4 }}>{name}</div>
+        {isGold && <div style={{ fontSize: "var(--font-sm)", color: "var(--color-gold-bright)" }}>金牌 (百搭)</div>}
+        {!isSuitedTile(tile.tile) && <div style={{ fontSize: "var(--font-sm)", color: "#aab4a0" }}>花牌</div>}
       </div>
     );
   };

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -197,6 +197,14 @@ body {
   --font-uc-badge: 12px;
   --font-uc-tile: 11px;
   --font-dot: 9px;
+
+  /* Typography scale — used by components for inline fontSize */
+  --font-xs: 9px;
+  --font-sm: 11px;
+  --font-md: 13px;
+  --font-lg: 16px;
+  --font-xl: 20px;
+  --font-2xl: 28px;
   --font-overflow: 10px;
 }
 
@@ -301,6 +309,13 @@ body {
     --font-uc-tile: max(9px, 1.4vh);
     --font-dot: max(9px, 1.3vh);
     --font-overflow: max(9px, 1.4vh);
+
+    --font-xs: max(9px, 1.3vh);
+    --font-sm: max(11px, 1.8vh);
+    --font-md: max(13px, 2.2vh);
+    --font-lg: max(16px, 2.8vh);
+    --font-xl: max(20px, 3.6vh);
+    --font-2xl: max(28px, 5vh);
   }
 }
 
@@ -359,6 +374,13 @@ body {
     --font-uc-tile: max(9px, 2.3vh);
     --font-dot: max(9px, 2.3vh);
     --font-overflow: max(9px, 2.3vh);
+
+    --font-xs: max(9px, 2.3vh);
+    --font-sm: max(11px, 2.8vh);
+    --font-md: max(13px, 3.3vh);
+    --font-lg: max(16px, 4.1vh);
+    --font-xl: max(20px, 5.1vh);
+    --font-2xl: max(28px, 7.2vh);
   }
 }
 


### PR DESCRIPTION
Multiple components have hardcoded fontSize in inline styles that do not scale on mobile.

Files: TileCounter.tsx (lines 71,110,130,142,154), GameInfo.tsx (lines 67,79,86,90,98,118), PlayerArea.tsx (lines 181-184,261-265,270), ConnectionStatus.tsx (lines 41,45,53), CenterAction.tsx (line 80), TileTooltip.tsx (lines 79-81)

Extract into CSS custom properties (--font-xs, --font-sm, --font-md etc) in index.css with media-query overrides for compact/ultra-compact. Pure CSS/styling change, no logic.

Client-only: index.css + 6 component files

Closes #427