### PR TITLE
TileCounter touch target fix and swipe-to-discard hint

### DIFF
--- a/apps/web/src/animations.css
+++ b/apps/web/src/animations.css
@@ -432,6 +432,19 @@
   animation: meldEntrance 0.3s ease-out;
 }
 
+/* Swipe-to-discard discovery hint */
+@keyframes swipeHintFade {
+  0% { opacity: 0; transform: translateX(-50%) translateY(4px); }
+  15% { opacity: 1; transform: translateX(-50%) translateY(0); }
+  75% { opacity: 1; transform: translateX(-50%) translateY(0); }
+  100% { opacity: 0; transform: translateX(-50%) translateY(-4px); }
+}
+
+.swipe-hint {
+  animation: swipeHintFade 3s ease-in-out forwards;
+  pointer-events: none;
+}
+
 /* Respect reduced-motion preferences */
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after {

--- a/apps/web/src/components/PlayerArea.tsx
+++ b/apps/web/src/components/PlayerArea.tsx
@@ -71,11 +71,29 @@ export function PlayerArea({
     }
   };
 
+  // Swipe-to-discard discovery hint
+  const [showSwipeHint, setShowSwipeHint] = useState(false);
+  const swipeHintDismissed = useRef(false);
+
+  useEffect(() => {
+    if (isMe && canDiscard && isCurrentTurn && !swipeHintDismissed.current && !localStorage.getItem("swipeHintShown")) {
+      setShowSwipeHint(true);
+      const timer = setTimeout(() => setShowSwipeHint(false), 3000);
+      return () => clearTimeout(timer);
+    }
+  }, [isMe, canDiscard, isCurrentTurn]);
+
   // Swipe-to-discard gesture
   const swipe = useSwipeGesture({
     onSwipeUp: (tileId: number) => {
       const tile = hand?.find((t) => t.id === tileId);
       if (!tile) return;
+      // Dismiss swipe hint permanently on first successful swipe
+      if (!swipeHintDismissed.current) {
+        swipeHintDismissed.current = true;
+        setShowSwipeHint(false);
+        localStorage.setItem("swipeHintShown", "1");
+      }
       const tileIsGold = !!(gold && tile.tile.kind === "suited" && tile.tile.suit === gold.wildTile.suit && tile.tile.value === gold.wildTile.value);
       if (tileIsGold) {
         // Gold tile safety: select tile to show warning bubble instead of auto-discarding
@@ -316,6 +334,15 @@ export function PlayerArea({
                   position: "absolute", top: -14, left: "50%", transform: "translateX(-50%)",
                   fontSize: "var(--font-xs)", color: "#4fc3f7", whiteSpace: "nowrap",
                 }}>新牌</div>
+              )}
+              {idx === 0 && showSwipeHint && (
+                <div className="swipe-hint" style={{
+                  position: "absolute", bottom: "100%", left: "50%",
+                  transform: "translateX(-50%)", marginBottom: 6,
+                  fontSize: "var(--font-xs)", color: "var(--color-gold-bright)",
+                  whiteSpace: "nowrap", zIndex: 10,
+                  textShadow: "0 1px 4px rgba(0,0,0,0.8)",
+                }}>↑ 上滑出牌</div>
               )}
               {/* Discard / Kong bubble */}
               {showBubble && (

--- a/apps/web/src/components/TileCounter.tsx
+++ b/apps/web/src/components/TileCounter.tsx
@@ -146,7 +146,7 @@ export function TileCounter({ gameState }: TileCounterProps) {
           border: `1px solid ${expanded ? "rgba(255,215,0,0.4)" : "rgba(184,134,11,0.3)"}`,
           color: "var(--color-text-warm)",
           borderRadius: 20,
-          minHeight: 36,
+          minHeight: 44,
           cursor: "pointer",
           whiteSpace: "nowrap",
         }}


### PR DESCRIPTION
Two mobile UX improvements:

1. TileCounter.tsx line 149: minHeight: 36 is below 44px minimum. Bump to 44px.
2. PlayerArea.tsx: Swipe-to-discard gesture is undiscoverable. Add subtle one-time visual hint (small arrow or swipe up text) on first discard opportunity. Use localStorage to track if hint shown. Fade after first successful swipe.

Files: TileCounter.tsx, PlayerArea.tsx

Closes #435