### PR TITLE
Fix z-index hierarchy - tooltip blocks ClaimOverlay

### DIFF
--- a/apps/web/src/components/GameTable.tsx
+++ b/apps/web/src/components/GameTable.tsx
@@ -36,9 +36,10 @@ interface GameTableProps {
   claimAnimation?: { seat: DrawAnimationSeat; key: number } | null;
   departingTile?: TileInstance | null;
   revealedHands?: { hand: TileInstance[]; melds: import("@fuzhou-mahjong/shared").Meld[]; flowers: TileInstance[] }[] | null;
+  claimActive?: boolean;
 }
 
-export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTileId, claimableTileIds, canDiscard, onDiscard, canHu, onHu, canDraw, onDraw, kongTileIds, onAnGang, onBuGang, onBackgroundClick, disconnectedPlayers, drawAnimation, claimAnimation, departingTile, revealedHands }: GameTableProps) {
+export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTileId, claimableTileIds, canDiscard, onDiscard, canHu, onHu, canDraw, onDraw, kongTileIds, onAnGang, onBuGang, onBackgroundClick, disconnectedPlayers, drawAnimation, claimAnimation, departingTile, revealedHands, claimActive }: GameTableProps) {
   const isCompact = useIsCompactLandscape();
   const isFirstPersonMobile = useIsFirstPersonMobile();
 
@@ -213,6 +214,7 @@ export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTile
           tenpaiTiles={state.tenpaiTiles}
           firstPerson={isFirstPersonMobile}
           cumulativeScore={roundsPlayed > 0 ? cumulativeScores[myIndex] : undefined}
+          claimActive={claimActive}
         />
       </div>
 

--- a/apps/web/src/components/PlayerArea.tsx
+++ b/apps/web/src/components/PlayerArea.tsx
@@ -38,6 +38,7 @@ interface PlayerAreaProps {
   ultraCompact?: boolean;
   firstPerson?: boolean;
   cumulativeScore?: number;
+  claimActive?: boolean;
 }
 
 const BUBBLE_BTN = {
@@ -52,9 +53,14 @@ export function PlayerArea({
   isCurrentTurn, isDealer, gold, selectedTileId, onTileClick, label,
   claimableTileIds, onTileDoubleClick, lastDrawnTileId, lastDiscardedTileId, tenpaiTiles,
   canDiscard, onDiscard, canHu, onHu, kongTileIds, onAnGang, onBuGang, departingTileId, hasDiscardedGold,
-  isDisconnected, compact, ultraCompact, firstPerson, cumulativeScore,
+  isDisconnected, compact, ultraCompact, firstPerson, cumulativeScore, claimActive,
 }: PlayerAreaProps) {
-  const { onTouchStart: lpTouchStart, onTouchEnd: lpTouchEnd, onMouseEnter, onMouseLeave, Tooltip } = useLongPress(gold);
+  const { onTouchStart: lpTouchStart, onTouchEnd: lpTouchEnd, onMouseEnter, onMouseLeave, Tooltip, dismiss } = useLongPress(gold);
+
+  // Auto-dismiss tooltip when claim overlay appears
+  useEffect(() => {
+    if (claimActive) dismiss();
+  }, [claimActive, dismiss]);
   const isCompactLandscape = useIsCompactLandscape();
 
   // Double-tap detection for reliable mobile double-tap

--- a/apps/web/src/components/TileTooltip.tsx
+++ b/apps/web/src/components/TileTooltip.tsx
@@ -71,7 +71,7 @@ export function useLongPress(gold: GoldState | null) {
         border: isGold ? "2px solid var(--color-gold-bright)" : "1px solid var(--color-text-secondary)",
         borderRadius: 8,
         padding: 12,
-        zIndex: 200,
+        zIndex: 35,
         textAlign: "center",
         boxShadow: "0 4px 20px rgba(0,0,0,0.5)",
         pointerEvents: "none",
@@ -83,5 +83,10 @@ export function useLongPress(gold: GoldState | null) {
     );
   };
 
-  return { onTouchStart, onTouchEnd, onMouseEnter, onMouseLeave, Tooltip };
+  const dismiss = useCallback(() => {
+    if (timerRef.current) { clearTimeout(timerRef.current); timerRef.current = null; }
+    setTooltip((t) => t.visible ? { ...t, visible: false } : t);
+  }, []);
+
+  return { onTouchStart, onTouchEnd, onMouseEnter, onMouseLeave, Tooltip, dismiss };
 }

--- a/apps/web/src/pages/Game.tsx
+++ b/apps/web/src/pages/Game.tsx
@@ -449,6 +449,7 @@ export function Game({ initialGameState, onLeave }: GameProps) {
         claimAnimation={claimAnimation}
         departingTile={departingTile}
         revealedHands={gameOver?.allHands ?? null}
+        claimActive={isClaimWindow}
       />
       {isClaimWindow && actions && (
         <ClaimOverlay actions={actions} gameState={gameState} onAction={handleAction} />


### PR DESCRIPTION
TileTooltip uses zIndex: 200 while ClaimOverlay uses zIndex: 40. On mobile, tooltip renders above claim buttons blocking time-sensitive interaction.

Fix: Normalize z-index stack. Tooltip should be below claim overlay. Also dismiss tooltip when ClaimOverlay appears. Current hierarchy: 10 (draw btn) < 20 (tile anim) < 30 (center action) < 40 (claim) < 50 (confirm modal) < 200 (tooltip) < 10000 (connection). Tooltip at 200 is the outlier.

Files: TileTooltip.tsx, ClaimOverlay.tsx, possibly index.css

Closes #434