### PR TITLE
Add nextRound mutex to prevent concurrent round initialization

### DIFF
--- a/apps/server/src/handlers/roomHandlers.ts
+++ b/apps/server/src/handlers/roomHandlers.ts
@@ -65,6 +65,7 @@ export function registerRoomHandlers(io: GameServer, socket: GameSocket): void {
   socket.on("rejoinGame", (playerId: string) => {
     const room = findRoomByPlayerId(playerId);
     if (!room) { socket.emit("error", "No active game found"); return; }
+    if (room.isStartingRound) { socket.emit("error", "Round initializing, retry shortly"); return; }
 
     const player = room.reconnectPlayer(playerId, socket.id);
     if (!player) { socket.emit("error", "Player not found in room"); return; }
@@ -205,7 +206,10 @@ export function registerRoomHandlers(io: GameServer, socket: GameSocket): void {
       socket.emit("error", "Game is still in progress");
       return;
     }
+    if (room.isStartingRound) { socket.emit("error", "Round already starting"); return; }
+    room.isStartingRound = true;
 
+    try {
     game.startNextRound();
     console.log(`Next round in room ${room.id}, dealer: ${game.state.dealerIndex}`);
 
@@ -259,6 +263,9 @@ export function registerRoomHandlers(io: GameServer, socket: GameSocket): void {
     }
 
     triggerDealerAction(io, game, room);
+    } finally {
+      room.isStartingRound = false;
+    }
   });
 
   socket.on("disconnect", () => {

--- a/apps/server/src/room.ts
+++ b/apps/server/src/room.ts
@@ -19,6 +19,7 @@ export class Room {
   disconnectTimers = new Map<string, ReturnType<typeof setTimeout>>();
   cumulativeScores: number[] = [0, 0, 0, 0];  // per seat index
   roundsPlayed = 0;
+  isStartingRound = false;
 
   constructor(id: string) {
     this.id = id;


### PR DESCRIPTION
Simplified scope — just the mutex, no flower guard.

1. Add isStartingRound boolean field to Room class in room.ts
2. In roomHandlers.ts nextRound handler: check flag at entry, set before startNextRound, clear in finally block
3. In rejoinGame handler: if isStartingRound, emit error asking to retry

Server-only: room.ts, roomHandlers.ts

Closes #436