### PR TITLE
Add missing color-action-discard CSS variable

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -121,6 +121,7 @@ body {
   --color-action-peng: #1e6ec4;
   --color-action-gang: #d4760a;
   --color-action-chi: #2e8b57;
+  --color-action-discard: #1a9e8f;
   --color-action-pass-bg: #444;
   --color-action-pass-text: #ccc;
   --color-draw-action: #6a5acd;


### PR DESCRIPTION
PlayerArea.tsx:383 references var(--color-action-discard) but it is never defined in index.css. Discard button falls back to transparent.

Fix: Add --color-action-discard: #1a9e8f (teal to differentiate from chi green) to :root in index.css around line 123 with other action colors.

Client-only: index.css

Closes #440