### PR TITLE
Fix discard bubble clipping by parent overflow hidden

### DIFF
--- a/apps/web/src/components/PlayerArea.tsx
+++ b/apps/web/src/components/PlayerArea.tsx
@@ -304,7 +304,7 @@ export function PlayerArea({
       <div style={{
         display: "flex", flexWrap: "nowrap", gap: firstPerson ? "var(--fp-hand-gap)" : 1, marginBottom: 4, alignItems: "flex-end",
         justifyContent: isMe ? "center" : undefined,
-        paddingTop: isMe ? "var(--hand-padding-top)" : 0, overflow: "hidden", position: "relative",
+        paddingTop: isMe ? "var(--hand-padding-top)" : 0, overflow: "visible", clipPath: "inset(-9999px 0px -9999px 0px)", position: "relative",
         touchAction: "manipulation",
         ...(firstPerson ? { "--tile-w": "var(--fp-tile-w)", "--tile-h": "var(--fp-tile-h)" } as React.CSSProperties : {}),
       }}>


### PR DESCRIPTION
PlayerArea.tsx lines 307 and 354-368: hand container has overflow: hidden but discard bubble is absolutely positioned within it. On compact landscape, bubble gets clipped making buttons inaccessible.

Fix: Use React portal to render discard bubble outside hand container, mounted to GameTable container. Keeps bubble visible regardless of hand container bounds.

Client-only: PlayerArea.tsx, possibly GameTable.tsx

Closes #442