### PR TITLE
Ultra-compact layout fixes for 340px viewport height

### DIFF
--- a/apps/web/src/components/GameTable.tsx
+++ b/apps/web/src/components/GameTable.tsx
@@ -73,7 +73,7 @@ export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTile
         ? `". top ." "left center right" ". bottom ."`
         : `". top ." "left center right" "bottom bottom bottom"`,
       gridTemplateColumns: isFirstPersonMobile ? "var(--fp-side-col) 1fr var(--fp-side-col)" : isCompact ? "var(--grid-side-col) 1fr var(--grid-side-col)" : "1fr 2fr 1fr",
-      gridTemplateRows: isFirstPersonMobile ? "var(--fp-top-row) 1fr minmax(min(55%, 200px), 65%)" : isCompact ? "var(--grid-top-row) var(--grid-center-row) 1fr" : "auto 1fr auto",
+      gridTemplateRows: isFirstPersonMobile ? "var(--fp-top-row) 1fr minmax(min(55%, 45dvh), 65%)" : isCompact ? "var(--grid-top-row) var(--grid-center-row) 1fr" : "auto 1fr auto",
       flex: 1,
       minHeight: 0,
       gap: "var(--game-gap)",

--- a/apps/web/src/components/TileWall.tsx
+++ b/apps/web/src/components/TileWall.tsx
@@ -119,8 +119,8 @@ function WallSegment({ side, stacks, drawStack, canDraw, onDraw, standalone }: {
         return (
           <div key={i} style={{
             position: "relative",
-            width: isH ? "var(--wall-tw)" : "calc(var(--wall-th) + 3px)",
-            height: isH ? "calc(var(--wall-th) + 3px)" : "var(--wall-tw)",
+            width: isH ? "var(--wall-tw)" : "calc(var(--wall-th) + var(--wall-tw) * 0.4)",
+            height: isH ? "calc(var(--wall-th) + var(--wall-tw) * 0.4)" : "var(--wall-tw)",
             flexShrink: 0,
           }}>
             <div style={{

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -975,7 +975,7 @@ button.lobby-create-btn:hover:not(:disabled) {
 
 /* Toast notifications */
 .game-toast-container { position: fixed; top: 16px; left: 50%; transform: translateX(-50%); z-index: 9000; display: flex; flex-direction: column; gap: 8px; align-items: center; pointer-events: none; }
-.game-toast-container.compact { top: auto; bottom: calc(70px + env(safe-area-inset-bottom, 0px)); }
+.game-toast-container.compact { top: auto; bottom: calc(clamp(40px, 18vh, 70px) + env(safe-area-inset-bottom, 0px)); }
 .game-toast { background: var(--toast-bg); color: var(--color-text-warm); padding: 8px 20px; border-radius: 8px; font-size: var(--label-font); font-weight: bold; border: 1px solid var(--color-gold-border); animation: pageFadeIn 0.3s ease-out; white-space: nowrap; }
 
 /* ── Game-over overlay ── */


### PR DESCRIPTION
3 hardcoded values break on iPhone SE landscape (340px viewport):

1. Toast container (index.css:978): bottom: 70px hardcoded. Use CSS variable or calc.
2. TileWall.tsx:122-123: 3px spacing is 50% of wall-tw at 7px. Use proportional value.
3. GameTable.tsx grid bottom row: minmax(min(55%, 200px), 65%) — 200px too aggressive for <350px. Change to minmax(min(55%, 45dvh), 65%).

Client-only: index.css, TileWall.tsx, GameTable.tsx

Closes #453