### PR TITLE
Fix silent-return paths in emitOrBotAction staleness and fallback chain

### DIFF
--- a/apps/server/src/gameEngine.ts
+++ b/apps/server/src/gameEngine.ts
@@ -1154,6 +1154,8 @@ export function emitOrBotAction(
             const currentActions = getPostDrawActions(game, playerIndex, false);
             console.warn(`[Bot:FALLBACK] ${tag} Stale safety re-trigger on own turn (roomId=${game.roomId}, playerIndex=${playerIndex}, turn=${turnNumber}, phase=${game.state.phase}, hasActionWindow=false) ts=${Date.now()}`);
             emitOrBotAction(io, game, playerIndex, currentActions);
+          } else {
+            console.warn(`${tag} Stale safety bail — not this bot's turn (currentTurn=${game.state.currentTurn}), no window. Watchdog will handle.`);
           }
         }
         return;
@@ -1162,12 +1164,12 @@ export function emitOrBotAction(
         console.log(`${tag} Safety timer skipped — game phase=${game.state.phase} ts=${Date.now()}`);
         return;
       }
-      acted = true;
-      const safetyWindow = activeWindows.get(game.roomId);
       if (game.state.phase !== GamePhase.Playing) {
         console.warn(`[Bot:SAFETY] ${tag} Safety timeout skipped — game ended (phase=${game.state.phase})`);
         return;
       }
+      acted = true;
+      const safetyWindow = activeWindows.get(game.roomId);
       if (safetyWindow) {
         console.warn(`[Bot:SAFETY] ${tag} Safety timeout during action window — passing (roomId=${game.roomId}, playerIndex=${playerIndex}, turn=${turnNumber}, phase=${game.state.phase}, version=${version}, hasActionWindow=true) ts=${Date.now()}`);
         try {
@@ -1204,6 +1206,8 @@ export function emitOrBotAction(
             const currentActions = getPostDrawActions(game, playerIndex, false);
             console.warn(`[Bot:FALLBACK] ${tag} Stale callback re-trigger on own turn (roomId=${game.roomId}, playerIndex=${playerIndex}, turn=${turnNumber}, phase=${game.state.phase}, hasActionWindow=false) ts=${Date.now()}`);
             emitOrBotAction(io, game, playerIndex, currentActions);
+          } else {
+            console.warn(`${tag} Stale callback bail — not this bot's turn (currentTurn=${game.state.currentTurn}), no window. Watchdog will handle.`);
           }
         }
         return;


### PR DESCRIPTION
Confirmed dead-end in emitOrBotAction stale version check (~line 1207): if currentTurn != playerIndex AND no window, silent return. Bot vanishes.

Also: fallback chain (lines 1236-1268) has multiple early return paths where bot marks acted=true but does nothing.

Fix: Add else clause to stale re-trigger, audit every return in fallback chain, fix acted=true before phase check race.

Server-only: gameEngine.ts

Closes #464