### PR TITLE
Fix JS CSS breakpoint mismatch for compact detection

### DIFF
--- a/apps/web/src/components/PlayerArea.tsx
+++ b/apps/web/src/components/PlayerArea.tsx
@@ -363,9 +363,7 @@ export function PlayerArea({
               {showBubble && (
                 <div className="discard-bubble" style={{
                   position: "absolute",
-                  ...(isCompactLandscape
-                    ? { top: "100%", marginTop: 4 }
-                    : { bottom: "100%", marginBottom: 4 }),
+                  bottom: "100%", marginBottom: 4,
                   left: "50%",
                   transform: "translateX(-50%)",
                   display: "flex",

--- a/apps/web/src/hooks/useIsMobile.ts
+++ b/apps/web/src/hooks/useIsMobile.ts
@@ -8,13 +8,16 @@ export const BREAKPOINTS = {
   TINY_WIDTH: 360,
 } as const;
 
+const COMPACT_LANDSCAPE_MQ = `(orientation: landscape) and (max-height: ${BREAKPOINTS.COMPACT_HEIGHT}px)`;
+
 export function useIsCompactLandscape(): boolean {
-  const [isCompact, setIsCompact] = useState(() => window.innerHeight <= BREAKPOINTS.COMPACT_HEIGHT);
+  const [isCompact, setIsCompact] = useState(() => window.matchMedia(COMPACT_LANDSCAPE_MQ).matches);
 
   useEffect(() => {
-    const onResize = () => setIsCompact(window.innerHeight <= BREAKPOINTS.COMPACT_HEIGHT);
-    window.addEventListener("resize", onResize);
-    return () => window.removeEventListener("resize", onResize);
+    const mq = window.matchMedia(COMPACT_LANDSCAPE_MQ);
+    const handler = (e: MediaQueryListEvent) => setIsCompact(e.matches);
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
   }, []);
 
   return isCompact;

--- a/apps/web/src/pages/Game.tsx
+++ b/apps/web/src/pages/Game.tsx
@@ -6,8 +6,7 @@ import { CenterAction, useCenterAction } from "../components/CenterAction";
 import { sounds, setMuted, isMuted } from "../sounds";
 import { TileCounter } from "../components/TileCounter";
 import { TutorialModal } from "../components/TutorialModal";
-import { BREAKPOINTS } from "../hooks/useIsMobile";
-import { useWindowSize } from "../hooks/useWindowSize";
+import { useIsCompactLandscape } from "../hooks/useIsMobile";
 import { TileView } from "../components/Tile";
 import { SessionSummary, type SessionData } from "../components/SessionSummary";
 import { Button } from "../components/Button";
@@ -78,7 +77,7 @@ export function Game({ initialGameState, onLeave }: GameProps) {
   const [departingTile, setDepartingTile] = useState<TileInstance | null>(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [muted, setMutedState] = useState(isMuted);
-  const [isPortrait, setIsPortrait] = useState(() => window.matchMedia("(orientation: portrait)").matches && window.innerWidth <= 768);
+  const [isPortrait, setIsPortrait] = useState(() => window.matchMedia("(orientation: portrait) and (max-width: 768px)").matches);
 
   useEffect(() => {
     const mq = window.matchMedia("(orientation: portrait) and (max-width: 768px)");
@@ -351,8 +350,12 @@ export function Game({ initialGameState, onLeave }: GameProps) {
     ? (actions.canHu || actions.canPeng || actions.canMingGang || actions.chiOptions.length > 0) && !actions.canDiscard
     : false;
 
-  const { height: windowHeight } = useWindowSize();
-  const isCompactMain = windowHeight <= BREAKPOINTS.COMPACT_HEIGHT;
+  // Auto-close settings dropdown when claim overlay appears
+  useEffect(() => {
+    if (isClaimWindow) setSettingsOpen(false);
+  }, [isClaimWindow]);
+
+  const isCompactMain = useIsCompactLandscape();
 
   const handleAction = (action: GameAction) => {
     socket.emit("playerAction", action);
@@ -478,7 +481,7 @@ export function Game({ initialGameState, onLeave }: GameProps) {
         >⚙</button>
         {settingsOpen && (
           <div style={{
-            position: 'absolute', top: 'calc(48px + env(safe-area-inset-top, 0px))', right: 0, zIndex: 45,
+            position: 'absolute', top: 'calc(100% + 4px)', right: 0, zIndex: 35,
             background: 'var(--overlay-bg)', border: '1px solid var(--color-gold-border-hover)',
             borderRadius: 'var(--radius-md)', padding: 4, minWidth: 160,
             display: 'flex', flexDirection: 'column', gap: 2,


### PR DESCRIPTION
JS portrait detection uses width (768px) but CSS compact mode uses height (550px). On iPad landscape (1024x600), JS and CSS disagree creating layout mismatches.

Fix: Change JS compact detection in Game.tsx (~lines 81,84) to use window.matchMedia matching the CSS breakpoint: orientation:landscape and max-height:550px.

Client-only: Game.tsx, possibly useIsMobile.ts

Closes #469