### PR TITLE
Add onTouchCancel handlers and fix settings touch dismissal

### DIFF
--- a/apps/web/src/components/PlayerArea.tsx
+++ b/apps/web/src/components/PlayerArea.tsx
@@ -55,7 +55,7 @@ export function PlayerArea({
   canDiscard, onDiscard, canHu, onHu, kongTileIds, onAnGang, onBuGang, departingTileId, hasDiscardedGold,
   isDisconnected, compact, ultraCompact, firstPerson, cumulativeScore, claimActive,
 }: PlayerAreaProps) {
-  const { onTouchStart: lpTouchStart, onTouchEnd: lpTouchEnd, onMouseEnter, onMouseLeave, Tooltip, dismiss } = useLongPress(gold);
+  const { onTouchStart: lpTouchStart, onTouchEnd: lpTouchEnd, onTouchCancel: lpTouchCancel, onMouseEnter, onMouseLeave, Tooltip, dismiss } = useLongPress(gold);
 
   // Auto-dismiss tooltip when claim overlay appears
   useEffect(() => {
@@ -333,7 +333,8 @@ export function PlayerArea({
               key={t.id}
               onTouchStart={(e) => swipe.onTouchStart(t.id, e)}
               onTouchMove={swipe.onTouchMove}
-              onTouchEnd={(e) => { swipe.onTouchEnd(); }}
+              onTouchEnd={() => { swipe.onTouchEnd(); }}
+              onTouchCancel={() => { swipe.onTouchCancel(); }}
               style={{
                 display: "inline-flex",
                 marginLeft: lastDrawnTileId === t.id ? "var(--hand-new-tile-margin)" : 0,
@@ -423,6 +424,7 @@ export function PlayerArea({
                 className={departingTileId === t.id ? "tile-departing" : lastDrawnTileId === t.id ? "tile-new" : undefined}
                 onTouchStart={(e) => lpTouchStart(t, e)}
                 onTouchEnd={lpTouchEnd}
+                onTouchCancel={lpTouchCancel}
                 onMouseEnter={(e) => onMouseEnter(t, e)}
                 onMouseLeave={onMouseLeave}
                 onClick={() => handleTap(t)}

--- a/apps/web/src/components/Tile.tsx
+++ b/apps/web/src/components/Tile.tsx
@@ -16,6 +16,7 @@ interface TileProps {
   className?: string;
   onTouchStart?: (e: React.TouchEvent) => void;
   onTouchEnd?: () => void;
+  onTouchCancel?: () => void;
   onMouseEnter?: (e: React.MouseEvent) => void;
   onMouseLeave?: () => void;
   style?: React.CSSProperties;
@@ -47,7 +48,7 @@ function getTileDisplay(tile: Tile): { value: string; suit: string; color: strin
   }
 }
 
-export function TileView({ tile, faceUp = true, selected, claimable, onClick, onDoubleClick, gold, small, className, onTouchStart, onTouchEnd, onMouseEnter, onMouseLeave, style: styleProp }: TileProps) {
+export function TileView({ tile, faceUp = true, selected, claimable, onClick, onDoubleClick, gold, small, className, onTouchStart, onTouchEnd, onTouchCancel, onMouseEnter, onMouseLeave, style: styleProp }: TileProps) {
   const w = styleProp?.width as string ?? (small ? "var(--tile-w-sm)" : "var(--tile-w)");
   const h = styleProp?.height as string ?? (small ? "var(--tile-h-sm)" : "var(--tile-h)");
   const fontSize = styleProp?.fontSize as string ?? (small ? "var(--tile-font-sm)" : "var(--tile-font)");
@@ -91,6 +92,7 @@ export function TileView({ tile, faceUp = true, selected, claimable, onClick, on
       onKeyDown={onClick ? (e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onClick(); } } : undefined}
       onTouchStart={onTouchStart}
       onTouchEnd={onTouchEnd}
+      onTouchCancel={onTouchCancel}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
       style={{

--- a/apps/web/src/components/TileTooltip.tsx
+++ b/apps/web/src/components/TileTooltip.tsx
@@ -83,10 +83,15 @@ export function useLongPress(gold: GoldState | null) {
     );
   };
 
+  const onTouchCancel = useCallback(() => {
+    if (timerRef.current) { clearTimeout(timerRef.current); timerRef.current = null; }
+    setTooltip((t) => t.visible ? { ...t, visible: false } : t);
+  }, []);
+
   const dismiss = useCallback(() => {
     if (timerRef.current) { clearTimeout(timerRef.current); timerRef.current = null; }
     setTooltip((t) => t.visible ? { ...t, visible: false } : t);
   }, []);
 
-  return { onTouchStart, onTouchEnd, onMouseEnter, onMouseLeave, Tooltip, dismiss };
+  return { onTouchStart, onTouchEnd, onTouchCancel, onMouseEnter, onMouseLeave, Tooltip, dismiss };
 }

--- a/apps/web/src/hooks/useSwipeGesture.ts
+++ b/apps/web/src/hooks/useSwipeGesture.ts
@@ -75,5 +75,11 @@ export function useSwipeGesture({
     setSwipeOffset(0);
   }, [swipeOffset, thresholdProp, onSwipeUp]);
 
-  return { onTouchStart, onTouchMove, onTouchEnd, swipingTileId, swipeOffset };
+  const onTouchCancel = useCallback(() => {
+    touchRef.current = null;
+    setSwipingTileId(null);
+    setSwipeOffset(0);
+  }, []);
+
+  return { onTouchStart, onTouchMove, onTouchEnd, onTouchCancel, swipingTileId, swipeOffset };
 }

--- a/apps/web/src/pages/Game.tsx
+++ b/apps/web/src/pages/Game.tsx
@@ -88,16 +88,20 @@ export function Game({ initialGameState, onLeave }: GameProps) {
   }, []);
   const settingsRef = useRef<HTMLDivElement>(null);
 
-  // Close settings dropdown on click outside
+  // Close settings dropdown on click/touch outside
   useEffect(() => {
     if (!settingsOpen) return;
-    const handler = (e: MouseEvent) => {
+    const handler = (e: MouseEvent | TouchEvent) => {
       if (settingsRef.current && !settingsRef.current.contains(e.target as Node)) {
         setSettingsOpen(false);
       }
     };
     document.addEventListener('mousedown', handler);
-    return () => document.removeEventListener('mousedown', handler);
+    document.addEventListener('touchstart', handler);
+    return () => {
+      document.removeEventListener('mousedown', handler);
+      document.removeEventListener('touchstart', handler);
+    };
   }, [settingsOpen]);
 
   // First-game auto-show tutorial


### PR DESCRIPTION
Mobile touch reliability:

1. PlayerArea.tsx and useSwipeGesture.ts: No onTouchCancel handler. OS touch interrupts leave tile stuck mid-swipe.
2. Game.tsx ~line 99: Settings dropdown dismiss uses mousedown only, not touchstart. Tapping outside doesnt close on mobile.

Client-only: PlayerArea.tsx, useSwipeGesture.ts, Game.tsx

Closes #474