### PR TITLE
fix: align JS compact detection with CSS media queries

### DIFF
--- a/apps/web/src/hooks/useIsMobile.ts
+++ b/apps/web/src/hooks/useIsMobile.ts
@@ -8,22 +8,16 @@ export const BREAKPOINTS = {
   TINY_WIDTH: 360,
 } as const;
 
+const COMPACT_LANDSCAPE_MQ = `(orientation: landscape) and (max-height: ${BREAKPOINTS.COMPACT_HEIGHT}px)`;
+
 export function useIsCompactLandscape(): boolean {
-  const [isCompact, setIsCompact] = useState(() => window.innerHeight <= BREAKPOINTS.COMPACT_HEIGHT);
+  const [isCompact, setIsCompact] = useState(() => window.matchMedia(COMPACT_LANDSCAPE_MQ).matches);
 
   useEffect(() => {
-    let timeout: ReturnType<typeof setTimeout>;
-    const onResize = () => {
-      clearTimeout(timeout);
-      timeout = setTimeout(() => {
-        setIsCompact(window.innerHeight <= BREAKPOINTS.COMPACT_HEIGHT);
-      }, 100);
-    };
-    window.addEventListener("resize", onResize);
-    return () => {
-      clearTimeout(timeout);
-      window.removeEventListener("resize", onResize);
-    };
+    const mq = window.matchMedia(COMPACT_LANDSCAPE_MQ);
+    const handler = (e: MediaQueryListEvent) => setIsCompact(e.matches);
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
   }, []);
 
   return isCompact;

--- a/apps/web/src/pages/Game.tsx
+++ b/apps/web/src/pages/Game.tsx
@@ -6,8 +6,7 @@ import { CenterAction, useCenterAction } from "../components/CenterAction";
 import { sounds, setMuted, isMuted } from "../sounds";
 import { TileCounter } from "../components/TileCounter";
 import { TutorialModal } from "../components/TutorialModal";
-import { BREAKPOINTS } from "../hooks/useIsMobile";
-import { useWindowSize } from "../hooks/useWindowSize";
+import { useIsCompactLandscape } from "../hooks/useIsMobile";
 import { TileView } from "../components/Tile";
 import { SessionSummary, type SessionData } from "../components/SessionSummary";
 import { Button } from "../components/Button";
@@ -78,7 +77,7 @@ export function Game({ initialGameState, onLeave }: GameProps) {
   const [departingTile, setDepartingTile] = useState<TileInstance | null>(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [muted, setMutedState] = useState(isMuted);
-  const [isPortrait, setIsPortrait] = useState(() => window.matchMedia("(orientation: portrait)").matches && window.innerWidth <= 768);
+  const [isPortrait, setIsPortrait] = useState(() => window.matchMedia("(orientation: portrait) and (max-width: 768px)").matches);
 
   useEffect(() => {
     const mq = window.matchMedia("(orientation: portrait) and (max-width: 768px)");
@@ -360,8 +359,7 @@ export function Game({ initialGameState, onLeave }: GameProps) {
     if (isClaimWindow) setSettingsOpen(false);
   }, [isClaimWindow]);
 
-  const { height: windowHeight } = useWindowSize();
-  const isCompactMain = windowHeight <= BREAKPOINTS.COMPACT_HEIGHT;
+  const isCompactMain = useIsCompactLandscape();
 
   const handleAction = (action: GameAction) => {
     socket.emit("playerAction", action);


### PR DESCRIPTION
## Summary
- `useIsCompactLandscape` now uses `matchMedia("(orientation: landscape) and (max-height: 550px)")` instead of a bare `height <= 550` check, matching the CSS breakpoint exactly
- `Game.tsx` uses the hook instead of a manual height comparison, and the `isPortrait` init uses a single `matchMedia` call
- Removed unused `useWindowSize` import from Game.tsx

Fixes iPad landscape (1024×600) where JS and CSS disagreed on compact detection.

## Test plan
- [x] `npm run build` passes
- [ ] Verify on iPad landscape (1024×600): no compact layout applied (matches CSS)
- [ ] Verify on small phone landscape (e.g. 667×375): compact layout applied in both JS and CSS

🤖 Generated with [Claude Code](https://claude.com/claude-code)