### PR TITLE
Add resize debounce to useIsMobile hooks

### DIFF
--- a/apps/web/src/hooks/useIsMobile.ts
+++ b/apps/web/src/hooks/useIsMobile.ts
@@ -12,9 +12,18 @@ export function useIsCompactLandscape(): boolean {
   const [isCompact, setIsCompact] = useState(() => window.innerHeight <= BREAKPOINTS.COMPACT_HEIGHT);
 
   useEffect(() => {
-    const onResize = () => setIsCompact(window.innerHeight <= BREAKPOINTS.COMPACT_HEIGHT);
+    let timeout: ReturnType<typeof setTimeout>;
+    const onResize = () => {
+      clearTimeout(timeout);
+      timeout = setTimeout(() => {
+        setIsCompact(window.innerHeight <= BREAKPOINTS.COMPACT_HEIGHT);
+      }, 100);
+    };
     window.addEventListener("resize", onResize);
-    return () => window.removeEventListener("resize", onResize);
+    return () => {
+      clearTimeout(timeout);
+      window.removeEventListener("resize", onResize);
+    };
   }, []);
 
   return isCompact;
@@ -25,10 +34,18 @@ export function useIsFirstPersonMobile(): boolean {
     () => window.innerHeight <= BREAKPOINTS.COMPACT_HEIGHT && window.innerWidth <= 1024
   );
   useEffect(() => {
-    const onResize = () =>
-      setIsFP(window.innerHeight <= BREAKPOINTS.COMPACT_HEIGHT && window.innerWidth <= 1024);
+    let timeout: ReturnType<typeof setTimeout>;
+    const onResize = () => {
+      clearTimeout(timeout);
+      timeout = setTimeout(() => {
+        setIsFP(window.innerHeight <= BREAKPOINTS.COMPACT_HEIGHT && window.innerWidth <= 1024);
+      }, 100);
+    };
     window.addEventListener("resize", onResize);
-    return () => window.removeEventListener("resize", onResize);
+    return () => {
+      clearTimeout(timeout);
+      window.removeEventListener("resize", onResize);
+    };
   }, []);
   return isFP;
 }


### PR DESCRIPTION
useIsMobile.ts lines 14,27: useIsCompactLandscape and useIsFirstPersonMobile attach raw resize listeners with no debounce. During iOS Safari toolbar transitions, layout flips rapidly causing flicker. Apply same 100ms debounce as useWindowSize.ts.

Client-only: useIsMobile.ts

Closes #475