### PR TITLE
Fix SessionSummary modal layout overflow on mobile landscape

### DIFF
--- a/apps/web/src/components/SessionSummary.tsx
+++ b/apps/web/src/components/SessionSummary.tsx
@@ -35,7 +35,7 @@ function RoundHistorySection({ roundHistory, playerNames, isCompact }: {
 }) {
   const [expanded, setExpanded] = useState(false);
   const showToggle = isCompact;
-  const contentMaxHeight = isCompact ? (expanded ? 240 : 0) : 160;
+  const contentMaxHeight = isCompact ? (expanded ? 120 : 0) : 160;
 
   return (
     <div style={{ marginBottom: "clamp(8px, 2.5vh, 16px)" }}>
@@ -138,7 +138,7 @@ export function SessionSummary({ data, onClose }: SessionSummaryProps) {
         padding: isCompact ? "clamp(8px, 2.5vh, 16px) clamp(12px, 3vh, 20px)" : "24px 28px",
         maxWidth: "min(440px, 90vw)",
         width: "90vw",
-        maxHeight: "90dvh",
+        maxHeight: "clamp(200px, 80dvh, 90vh)",
         overflowY: "auto",
         color: "var(--color-text-primary)",
       }}>


### PR DESCRIPTION
SessionSummary modal has two layout bugs at 375px viewport:

1. maxHeight: 90dvh with no minimum clamp (line ~141). Should use clamp(200px, 80dvh, 90vh) like game-over modal.
2. RoundHistorySection expanded height = 240px when compact (line ~38). 240px is 64% of 375px viewport. Should be min(160, 30dvh) or similar.

Client-only: SessionSummary.tsx

Closes #481