### PR TITLE
Fix ClaimOverlay chi picker overflow on ultra-compact screens

### DIFF
--- a/apps/web/src/components/ClaimOverlay.tsx
+++ b/apps/web/src/components/ClaimOverlay.tsx
@@ -189,7 +189,7 @@ export function ClaimOverlay({ actions, gameState, onAction }: ClaimOverlayProps
               scrollSnapType: "x mandatory",
               WebkitOverflowScrolling: "touch",
               justifyContent: actions.chiOptions.length <= 2 ? "center" : undefined,
-              maxHeight: "60dvh",
+              maxHeight: isUltraCompact ? "45dvh" : "60dvh",
               overflowY: "auto",
             }}>
               {actions.chiOptions.map((combo, i) => (


### PR DESCRIPTION
ClaimOverlay.tsx ~line 184-194: chi picker maxHeight 60dvh is too tall on ultra-compact (340-390px). Causes nested scrolling.

Fix: Cap chi picker height more aggressively on ultra-compact. Audit action button layout — 4 buttons at 375px width must wrap cleanly with 44px min touch targets.

Client-only: ClaimOverlay.tsx

Closes #486