### PR TITLE
Fix emergency discard in claim window and safety timer double-fire gap

### DIFF
--- a/apps/server/src/gameEngine.ts
+++ b/apps/server/src/gameEngine.ts
@@ -1189,9 +1189,14 @@ export function emitOrBotAction(
     // Guard against infinite recursion from stale re-triggers
     if (depth > 3) {
       const tag = `[Bot:${game.roomId}:p${playerIndex}:t${game.state.currentTurn}]`;
-      console.error(`${tag} Recursion depth limit exceeded (depth=${depth}) — forcing emergency discard`);
-      const player = game.state.players[playerIndex];
-      handlePlayerAction(io, game.roomId, emergencyDiscard(player.hand, playerIndex, game.state.gold), playerIndex);
+      console.error(`${tag} Recursion depth limit exceeded (depth=${depth})`);
+      const window = activeWindows.get(game.roomId);
+      if (window) {
+        handlePlayerAction(io, game.roomId, { type: ActionType.Pass, playerIndex }, playerIndex);
+      } else {
+        const player = game.state.players[playerIndex];
+        handlePlayerAction(io, game.roomId, emergencyDiscard(player.hand, playerIndex, game.state.gold), playerIndex);
+      }
       return;
     }
     const version = nextBotVersion(game.roomId, playerIndex);
@@ -1328,6 +1333,7 @@ export function emitOrBotAction(
           throw new Error(`Bot action ${botAction.type} was rejected by handlePlayerAction`);
         }
       } catch (err) {
+        clearTimeout(safetyTimer);
         console.error(`${tag} Bot callback unhandled error:`, err);
         // Fallback: try pass first, then discard if pass not allowed
         console.warn(`${tag} Entering fallback chain (canPass=${actions.canPass}) ts=${Date.now()}`);


### PR DESCRIPTION
Two remaining bot race conditions in gameEngine.ts:

1. Emergency discard at recursion depth >3 (~line 1194) blindly discards without checking if bot is in claim window. Should Pass instead if activeWindow exists.
2. Gap between catch block spawning fallback and finally clearing safetyTimer allows double-fire. Move clearTimeout(safetyTimer) to top of catch block.

Server-only: gameEngine.ts. ~10 lines.

Closes #496