### PR TITLE
Fix chi picker and discard bubble overflow on sub-390px viewports

### DIFF
--- a/apps/web/src/components/ClaimOverlay.tsx
+++ b/apps/web/src/components/ClaimOverlay.tsx
@@ -189,7 +189,7 @@ export function ClaimOverlay({ actions, gameState, onAction }: ClaimOverlayProps
               scrollSnapType: "x mandatory",
               WebkitOverflowScrolling: "touch",
               justifyContent: actions.chiOptions.length <= 2 ? "center" : undefined,
-              maxHeight: isUltraCompact ? "45dvh" : "60dvh",
+              maxHeight: isUltraCompact ? "min(45dvh, calc(100dvh - 160px))" : "60dvh",
               overflowY: "auto",
             }}>
               {actions.chiOptions.map((combo, i) => (

--- a/apps/web/src/components/PlayerArea.tsx
+++ b/apps/web/src/components/PlayerArea.tsx
@@ -369,11 +369,12 @@ export function PlayerArea({
                   left: "50%",
                   transform: "translateX(-50%)",
                   display: "flex",
-                  flexDirection: "column",
+                  flexDirection: ultraCompact ? "row" : "column",
+                  flexWrap: ultraCompact ? "wrap" : "nowrap",
                   gap: 4,
                   zIndex: 20,
-                  maxHeight: "40dvh",
-                  overflowY: "auto",
+                  maxHeight: ultraCompact ? undefined : "40dvh",
+                  overflowY: ultraCompact ? undefined : "auto",
                   animation: "bubbleFadeIn 0.15s ease-out",
                 }}>
                   {canHu && (


### PR DESCRIPTION
At 340px viewport height (iPhone SE landscape minus chrome):

1. ClaimOverlay.tsx:192 — 45dvh = 153px. Chi picker title + 4 combos at 44px = 176px+ = clips. Replace with min(45dvh, calc(100dvh - var(--hand-area-height, 55%) - 16px)) or make scrollable.
2. PlayerArea.tsx:375 — 40dvh = 136px. With 4 action buttons (hu/discard/angang/bugang) at 44px each = 176px = clips. Use horizontal layout in ultra-compact or make scrollable.

Client-only: ClaimOverlay.tsx, PlayerArea.tsx

Closes #500