### PR TITLE
Normalize z-index system and fix remaining vh to dvh

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -91,7 +91,7 @@ export function App() {
 
   if (!connected && !reconnecting) {
     return (
-      <div className="loading-state" style={{ minHeight: "80vh" }}>
+      <div className="loading-state" style={{ minHeight: "80dvh" }}>
         <div className="spinner" />
         连接服务器中... / Connecting...
       </div>

--- a/apps/web/src/components/CenterAction.tsx
+++ b/apps/web/src/components/CenterAction.tsx
@@ -57,7 +57,7 @@ export function CenterAction({ display, gold }: { display: ActionDisplay | null;
         top: "50%",
         left: "50%",
         transform: "translate(-50%, -50%)",
-        zIndex: 29,
+        zIndex: "var(--z-center-action)" as any,
         textAlign: "center",
         animation: "centerActionIn 0.3s ease-out, centerActionOut 0.4s ease-in 0.8s forwards",
         pointerEvents: "none",

--- a/apps/web/src/components/ClaimOverlay.tsx
+++ b/apps/web/src/components/ClaimOverlay.tsx
@@ -67,7 +67,7 @@ export function ClaimOverlay({ actions, gameState, onAction }: ClaimOverlayProps
         display: "flex",
         alignItems: "center",
         justifyContent: "center",
-        zIndex: 40,
+        zIndex: "var(--z-claim-overlay)" as any,
         animation: exiting ? "overlayFadeOut 0.18s ease-in forwards" : "overlayFadeIn 0.2s ease-out",
       }}
       onClick={(e) => {

--- a/apps/web/src/components/ConnectionStatus.tsx
+++ b/apps/web/src/components/ConnectionStatus.tsx
@@ -28,7 +28,7 @@ export function ConnectionStatus({ connectionState, reconnectAttempt, timeoutMs,
     <div style={{
       position: "fixed",
       inset: 0,
-      zIndex: 10000,
+      zIndex: "var(--z-connection-status)" as any,
       background: "var(--overlay-bg)",
       display: "flex",
       flexDirection: "column",

--- a/apps/web/src/components/GameTable.tsx
+++ b/apps/web/src/components/GameTable.tsx
@@ -228,7 +228,7 @@ export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTile
             left: "50%",
             marginLeft: "calc(var(--wall-tw) / -2)",
             pointerEvents: "none",
-            zIndex: 20,
+            zIndex: "var(--z-tile-anim)" as any,
             animation: "discardFlyToPool 0.3s ease-in forwards",
           }}
         >
@@ -247,7 +247,7 @@ export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTile
             marginTop: "calc(var(--wall-th) / -2)",
             marginLeft: "calc(var(--wall-tw) / -2)",
             pointerEvents: "none",
-            zIndex: 20,
+            zIndex: "var(--z-tile-anim)" as any,
             animation: `${drawAnimation.isSupplement ? "supplementFly" : "drawFly"}${drawAnimation.seat.charAt(0).toUpperCase() + drawAnimation.seat.slice(1)} ${drawAnimation.seat === "bottom" ? "0.3s" : "0.2s"} ease-out forwards`,
           }}
         >
@@ -279,7 +279,7 @@ export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTile
             marginTop: "calc(var(--wall-th) / -2)",
             marginLeft: "calc(var(--wall-tw) / -2)",
             pointerEvents: "none",
-            zIndex: 20,
+            zIndex: "var(--z-tile-anim)" as any,
             animation: `claimFly${claimAnimation.seat.charAt(0).toUpperCase() + claimAnimation.seat.slice(1)} 0.3s ease-out forwards`,
           }}
         >

--- a/apps/web/src/components/PlayerArea.tsx
+++ b/apps/web/src/components/PlayerArea.tsx
@@ -372,7 +372,7 @@ export function PlayerArea({
                   flexDirection: ultraCompact ? "row" : "column",
                   flexWrap: ultraCompact ? "wrap" : "nowrap",
                   gap: 4,
-                  zIndex: 20,
+                  zIndex: "var(--z-tile-anim)" as any,
                   maxHeight: ultraCompact ? undefined : "40dvh",
                   overflowY: ultraCompact ? undefined : "auto",
                   animation: "bubbleFadeIn 0.15s ease-out",

--- a/apps/web/src/components/SessionSummary.tsx
+++ b/apps/web/src/components/SessionSummary.tsx
@@ -126,7 +126,7 @@ export function SessionSummary({ data, onClose }: SessionSummaryProps) {
 
   return (
     <div style={{
-      position: "fixed", inset: 0, zIndex: 9999,
+      position: "fixed", inset: 0, zIndex: "var(--z-portrait-overlay)" as any,
       background: "rgba(0,0,0,0.85)",
       display: "flex", alignItems: "center", justifyContent: "center",
       animation: "pageFadeIn 0.3s ease-out",

--- a/apps/web/src/components/TileTooltip.tsx
+++ b/apps/web/src/components/TileTooltip.tsx
@@ -71,7 +71,7 @@ export function useLongPress(gold: GoldState | null) {
         border: isGold ? "2px solid var(--color-gold-bright)" : "1px solid var(--color-text-secondary)",
         borderRadius: 8,
         padding: 12,
-        zIndex: 34,
+        zIndex: "var(--z-tooltip)" as any,
         textAlign: "center",
         boxShadow: "0 4px 20px rgba(0,0,0,0.5)",
         pointerEvents: "none",

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -37,7 +37,7 @@ body {
   display: flex;
   position: fixed;
   inset: 0;
-  z-index: 9999;
+  z-index: var(--z-portrait-overlay);
   background: radial-gradient(ellipse at center, var(--color-bg-medium) 0%, var(--color-bg-dark) 70%);
   flex-direction: column;
   align-items: center;
@@ -127,6 +127,19 @@ body {
   --color-draw-action: #6a5acd;
   --color-tile-back-border: #1a3c2a;
   --color-tile-back-border-right: #1e4530;
+
+  /* Z-index scale */
+  --z-tile-anim: 20;
+  --z-center-action: 29;
+  --z-settings-btn: 30;
+  --z-tooltip: 34;
+  --z-settings-dropdown: 35;
+  --z-claim-overlay: 40;
+  --z-confirm-modal: 50;
+  --z-game-over: 100;
+  --z-toast: 9000;
+  --z-portrait-overlay: 9999;
+  --z-connection-status: 10000;
 
   /* Spacing */
   --spacing-xs: 4px;
@@ -582,7 +595,7 @@ hr {
 
 /* Lobby content column */
 .lobby-content {
-  max-width: 560px;
+  max-width: min(560px, 95vw);
   width: 100%;
   display: flex;
   flex-direction: column;
@@ -599,7 +612,7 @@ hr {
 
 /* Room content column */
 .room-content {
-  max-width: 480px;
+  max-width: min(480px, 95vw);
   width: 100%;
 }
 
@@ -967,14 +980,14 @@ button.lobby-create-btn:hover:not(:disabled) {
 }
 
 /* Shared confirmation modal */
-.confirm-modal-backdrop { position: fixed; inset: 0; background: rgba(0,0,0,0.6); display: flex; align-items: center; justify-content: center; z-index: 50; }
+.confirm-modal-backdrop { position: fixed; inset: 0; background: rgba(0,0,0,0.6); display: flex; align-items: center; justify-content: center; z-index: var(--z-confirm-modal); }
 .confirm-modal { background: var(--overlay-bg); border: 2px solid var(--color-gold-border-hover); border-radius: var(--radius-lg); padding: 24px; max-width: min(360px, 90vw); text-align: center; max-height: calc(100dvh - 40px); overflow-y: auto; }
 .confirm-modal-title { font-size: 18px; margin-bottom: 8px; }
 .confirm-modal-subtitle { font-size: 13px; color: var(--color-text-secondary); margin-bottom: 0; }
 .confirm-modal-actions { display: flex; gap: 12px; justify-content: center; margin-top: 16px; }
 
 /* Toast notifications */
-.game-toast-container { position: fixed; top: 16px; left: 50%; transform: translateX(-50%); z-index: 9000; display: flex; flex-direction: column; gap: 8px; align-items: center; pointer-events: none; }
+.game-toast-container { position: fixed; top: 16px; left: 50%; transform: translateX(-50%); z-index: var(--z-toast); display: flex; flex-direction: column; gap: 8px; align-items: center; pointer-events: none; }
 .game-toast-container.compact { top: auto; bottom: calc(clamp(40px, 18vh, 70px) + env(safe-area-inset-bottom, 0px)); }
 .game-toast { background: var(--toast-bg); color: var(--color-text-warm); padding: 8px 20px; border-radius: 8px; font-size: var(--label-font); font-weight: bold; border: 1px solid var(--color-gold-border); animation: pageFadeIn 0.3s ease-out; white-space: nowrap; }
 

--- a/apps/web/src/pages/Game.tsx
+++ b/apps/web/src/pages/Game.tsx
@@ -387,7 +387,7 @@ export function Game({ initialGameState, onLeave }: GameProps) {
 
 
   if (!gameState) {
-    return <div className="loading-state" style={{ minHeight: "80vh" }}><div className="spinner" />等待游戏数据...</div>;
+    return <div className="loading-state" style={{ minHeight: "80dvh" }}><div className="spinner" />等待游戏数据...</div>;
   }
 
   return (
@@ -472,7 +472,7 @@ export function Game({ initialGameState, onLeave }: GameProps) {
         position: 'fixed',
         top: 'calc(8px + env(safe-area-inset-top, 0px))',
         right: 'calc(8px + env(safe-area-inset-right, 0px))',
-        zIndex: 30,
+        zIndex: "var(--z-settings-btn)" as any,
       }}>
         <button
           onClick={() => setSettingsOpen((v) => !v)}
@@ -487,7 +487,7 @@ export function Game({ initialGameState, onLeave }: GameProps) {
         >⚙</button>
         {settingsOpen && (
           <div style={{
-            position: 'absolute', top: 'calc(100% + 4px)', right: 0, zIndex: 35,
+            position: 'absolute', top: 'calc(100% + 4px)', right: 0, zIndex: "var(--z-settings-dropdown)" as any,
             background: 'var(--overlay-bg)', border: '1px solid var(--color-gold-border-hover)',
             borderRadius: 'var(--radius-md)', padding: 4, minWidth: "clamp(120px, 35vw, 160px)",
             display: 'flex', flexDirection: 'column', gap: 2,
@@ -538,7 +538,7 @@ export function Game({ initialGameState, onLeave }: GameProps) {
         const go = gameOver!;
         return (
         <div style={{
-          position: "fixed", inset: 0, zIndex: 100,
+          position: "fixed", inset: 0, zIndex: "var(--z-game-over)" as any,
           background: "rgba(0,0,0,0.35)",
           display: "flex", alignItems: "center", justifyContent: "center",
           animation: "overlayFadeIn 0.3s ease-out",


### PR DESCRIPTION
CSS cleanup:

1. App.tsx:94 and Game.tsx:390: minHeight 80vh to 80dvh
2. Create z-index CSS variables in index.css root and replace all hardcoded z-index values across ClaimOverlay, Game, SessionSummary, ConnectionStatus, index.css
3. index.css:585 lobby max-width 560px to min(560px, 95vw)
4. index.css:602 room max-width 480px to min(480px, 95vw)

Client-only: index.css, App.tsx, Game.tsx, ClaimOverlay.tsx, SessionSummary.tsx, ConnectionStatus.tsx

Closes #505