### PR TITLE
Fix discard bubble and swipe hint overlap on ultra-compact screens

### DIFF
--- a/apps/web/src/components/PlayerArea.tsx
+++ b/apps/web/src/components/PlayerArea.tsx
@@ -355,7 +355,7 @@ export function PlayerArea({
               {idx === 0 && showSwipeHint && (
                 <div className="swipe-hint" style={{
                   position: "absolute", bottom: "100%", left: "50%",
-                  transform: "translateX(-50%)", marginBottom: 6,
+                  transform: "translateX(-50%)", marginBottom: "clamp(2px, 1.5vh, 6px)",
                   fontSize: "var(--font-xs)", color: "var(--color-gold-bright)",
                   whiteSpace: "nowrap", zIndex: 10,
                   textShadow: "0 1px 4px rgba(0,0,0,0.8)",
@@ -365,7 +365,7 @@ export function PlayerArea({
               {showBubble && (
                 <div className="discard-bubble" style={{
                   position: "absolute",
-                  bottom: "100%", marginBottom: 4,
+                  bottom: "100%", marginBottom: "clamp(2px, 1vh, 4px)",
                   left: "50%",
                   transform: "translateX(-50%)",
                   display: "flex",


### PR DESCRIPTION
On iPhone SE landscape (340px viewport height), discard bubble 4px marginBottom and swipe hint 6px margin can overlap with top player area.

Audit PlayerArea.tsx bubble and hint positioning at 340px. Replace fixed px margins with relative units or clamp. Test against --fp-top-row: 24px. Verify no regression at 550px+.

Client-only: PlayerArea.tsx

Closes #511