### PR TITLE
Lobby visual polish with themed background and animations

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -600,6 +600,7 @@ hr {
   display: flex;
   flex-direction: column;
   gap: 20px;
+  animation: pageFadeIn 0.3s ease-out;
 }
 
 /* Lobby left/right wrappers — stack by default */
@@ -786,12 +787,13 @@ hr {
   border-radius: var(--radius-md);
   padding: 14px 16px;
   box-shadow: 0 2px 8px rgba(0,0,0,0.3), inset 0 1px 0 rgba(255,255,255,0.03);
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .room-card:hover {
+  transform: translateY(-2px);
   border-color: var(--color-gold-border-hover);
-  box-shadow: 0 4px 16px rgba(0,0,0,0.4), inset 0 1px 0 rgba(255,255,255,0.05);
+  box-shadow: 0 4px 12px rgba(255,215,0,0.15), 0 4px 16px rgba(0,0,0,0.4), inset 0 1px 0 rgba(255,255,255,0.05);
 }
 
 /* Quick Start gradient button */
@@ -804,6 +806,10 @@ hr {
 button.lobby-create-btn:hover:not(:disabled) {
   border-color: rgba(184, 134, 11, 0.7);
   box-shadow: 0 0 12px rgba(184, 134, 11, 0.2);
+}
+
+button.lobby-create-btn:active:not(:disabled) {
+  transform: scale(0.97);
 }
 
 /* ─── Room: seat layout (mahjong table view) ─── */


### PR DESCRIPTION
Lobby page visual overhaul — first impression polish.

1. Add themed background (gradient or subtle tile pattern using existing SVG assets)
2. Room cards: hover lift/glow, better spacing
3. Entrance animation using existing pageFadeIn keyframe
4. Button hover/press visual feedback
5. Mobile-first: must work at 667x375 landscape

Not in scope: no features, no layout restructure. Just visual polish.

Client-only: Lobby.tsx, index.css

Closes #513