### PR TITLE
Fix SessionSummary touch target and lobby-right vh to dvh

### DIFF
--- a/apps/web/src/components/SessionSummary.tsx
+++ b/apps/web/src/components/SessionSummary.tsx
@@ -210,7 +210,7 @@ export function SessionSummary({ data, onClose }: SessionSummaryProps) {
             background: "var(--color-bg-button)", color: "var(--color-text-primary)",
             border: "1px solid rgba(255,215,0,0.3)",
             borderRadius: 6, cursor: "pointer",
-            minHeight: "max(36px, 9vh)",
+            minHeight: "max(44px, 9vh)",
           }}
         >
           返回大厅 / Back to Lobby

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -436,7 +436,7 @@ body {
     grid-column: 1 / -1;
   }
   .lobby-left { gap: 12px; }
-  .lobby-right { gap: 12px; overflow-y: auto; max-height: 70vh; }
+  .lobby-right { gap: 12px; overflow-y: auto; max-height: 70dvh; }
 
   /* Room page compact: reduce spacing to fit above fold */
   .room-page h2 { margin-bottom: 6px !important; }


### PR DESCRIPTION
Two small fixes:

1. SessionSummary.tsx:213 — button minHeight max(36px,9vh). 36px violates 44px minimum. Change to max(44px,9vh).
2. index.css:439 — .lobby-right max-height: 70vh. Should be 70dvh. Missed in vh-to-dvh sweep.

Client-only: SessionSummary.tsx, index.css

Closes #517