### PR TITLE
Chi picker landscape overflow audit on 340px viewport

### DIFF
--- a/apps/web/src/components/ClaimOverlay.tsx
+++ b/apps/web/src/components/ClaimOverlay.tsx
@@ -88,6 +88,7 @@ export function ClaimOverlay({ actions, gameState, onAction }: ClaimOverlayProps
         maxWidth: "90vw",
         maxHeight: isUltraCompact ? "70dvh" : isCompact ? "80dvh" : "90dvh",
         overflowY: "auto",
+        WebkitOverflowScrolling: "touch",
         animation: exiting ? "overlayScaleOut 0.18s ease-in forwards" : "overlayScaleIn 0.2s ease-out",
       }}>
         <div style={{ color: "var(--color-accent-orange)", fontWeight: "bold", fontSize: "var(--btn-font)", marginBottom: 4 }}>


### PR DESCRIPTION
ClaimOverlay.tsx:192 chi picker min(45dvh, calc(100dvh-160px)) = 153px at 340px. With 3+ chi options at 44px each + padding, overflows.

Audit on 340x640 viewport. Ensure overflowY auto works with scroll snap. Initial action buttons must not get pushed off-screen when chi picker expands.

Client-only: ClaimOverlay.tsx

Closes #518