### PR TITLE
Replace hardcoded top -14px offset for new tile label

### DIFF
--- a/apps/web/src/components/PlayerArea.tsx
+++ b/apps/web/src/components/PlayerArea.tsx
@@ -348,7 +348,7 @@ export function PlayerArea({
             >
               {lastDrawnTileId === t.id && !isCompactLandscape && (
                 <div style={{
-                  position: "absolute", top: -14, left: "50%", transform: "translateX(-50%)",
+                  position: "absolute", top: "clamp(-8px, -3.5dvh, -14px)", left: "50%", transform: "translateX(-50%)",
                   fontSize: "var(--font-xs)", color: "#4fc3f7", whiteSpace: "nowrap",
                 }}>新牌</div>
               )}


### PR DESCRIPTION
PlayerArea.tsx line 351: top: -14 hardcoded for new tile label. Can overlap content on ultra-compact screens.

Replace with clamp(-8px, -3.5vh, -14px) or similar responsive unit.

Client-only: PlayerArea.tsx

Closes #524