### PR TITLE
Fix action window addResponse return check in handlePlayerAction

### DIFF
--- a/apps/server/src/gameEngine.ts
+++ b/apps/server/src/gameEngine.ts
@@ -310,7 +310,11 @@ export function handlePlayerAction(
   // Check if there's an active action window
   const window = activeWindows.get(room.id);
   if (window) {
-    window.addResponse(playerIndex, action);
+    const accepted = window.addResponse(playerIndex, action);
+    if (!accepted) {
+      console.warn(`[GameEngine] addResponse rejected for player ${playerIndex} — window may be stale`);
+      return false;
+    }
     return true;
   }
 


### PR DESCRIPTION
gameEngine.ts ~line 312-315: handlePlayerAction returns true even when addResponse fails because window was deleted between check and call. Return value of addResponse not checked.

Fix: Check addResponse return value. Dont return true on lost response. Ensure watchdog can detect response-lost state.

Server-only: gameEngine.ts

Closes #523