### PR TITLE
Replace hardcoded 15 percent wall margins with responsive units

### DIFF
--- a/apps/web/src/components/GameTable.tsx
+++ b/apps/web/src/components/GameTable.tsx
@@ -145,17 +145,17 @@ export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTile
       {/* Wall segments along table edges (non-compact only) */}
       {!isCompact && (
         <>
-          <div style={{ gridArea: "center", alignSelf: "start", justifySelf: "center", zIndex: 2, marginTop: "15%" }}>
+          <div style={{ gridArea: "center", alignSelf: "start", justifySelf: "center", zIndex: 2, marginTop: "clamp(8%, 10dvh, 18%)" }}>
             <TileWall segment="top" wallRemaining={wallRemaining} wallDrawCount={state.wallDrawCount} wallSupplementCount={state.wallSupplementCount} gold={gold} canDraw={canDraw} onDraw={onDraw} />
           </div>
-          <div style={{ gridArea: "center", alignSelf: "center", justifySelf: "start", zIndex: 2, marginLeft: "15%" }}>
+          <div style={{ gridArea: "center", alignSelf: "center", justifySelf: "start", zIndex: 2, marginLeft: "clamp(8%, 10vw, 18%)" }}>
             <TileWall segment="left" wallRemaining={wallRemaining} wallDrawCount={state.wallDrawCount} wallSupplementCount={state.wallSupplementCount} gold={gold} canDraw={canDraw} onDraw={onDraw} />
           </div>
-          <div style={{ gridArea: "center", alignSelf: "center", justifySelf: "end", zIndex: 2, marginRight: "15%" }}>
+          <div style={{ gridArea: "center", alignSelf: "center", justifySelf: "end", zIndex: 2, marginRight: "clamp(8%, 10vw, 18%)" }}>
             <TileWall segment="right" wallRemaining={wallRemaining} wallDrawCount={state.wallDrawCount} wallSupplementCount={state.wallSupplementCount} gold={gold} canDraw={canDraw} onDraw={onDraw} />
           </div>
           {!isFirstPersonMobile && (
-            <div style={{ gridArea: "center", alignSelf: "end", justifySelf: "center", zIndex: 2, marginBottom: "15%" }}>
+            <div style={{ gridArea: "center", alignSelf: "end", justifySelf: "center", zIndex: 2, marginBottom: "clamp(8%, 10dvh, 18%)" }}>
               <TileWall segment="bottom" wallRemaining={wallRemaining} wallDrawCount={state.wallDrawCount} wallSupplementCount={state.wallSupplementCount} gold={gold} canDraw={canDraw} onDraw={onDraw} />
             </div>
           )}
@@ -224,7 +224,7 @@ export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTile
           key={discardFlyKey}
           style={{
             position: "absolute",
-            bottom: "15%",
+            bottom: "clamp(8%, 10dvh, 18%)",
             left: "50%",
             marginLeft: "calc(var(--wall-tw) / -2)",
             pointerEvents: "none",


### PR DESCRIPTION
GameTable.tsx lines 148,151,154,158: wall segments use marginTop/Left/Right/Bottom 15% which doesnt account for viewport aspect ratio. On ultra-wide mobile, pushes walls into weird positions.

Fix: Replace with clamp - vertical: clamp(8%, 10dvh, 18%), horizontal: clamp(8%, 10vw, 18%). Also fix bottom: 15% on discard-fly overlay at line 227.

Client-only: GameTable.tsx

Closes #529