### PR TITLE
Fix TileWall hardcoded 3px offset and verify onTouchCancel wiring

### DIFF
--- a/apps/web/src/components/TileWall.tsx
+++ b/apps/web/src/components/TileWall.tsx
@@ -143,7 +143,7 @@ function WallSegment({ side, stacks, drawStack, canDraw, onDraw, standalone }: {
               </div>
               {/* Upper tile, offset slightly */}
               <div style={{
-                position: "absolute", bottom: 3, left: 0,
+                position: "absolute", bottom: "min(3px, calc(var(--wall-tw) * 0.4))", left: 0,
                 opacity: s.hasUpper ? 1 : 0,
                 transform: s.hasUpper ? "scale(1)" : "scale(0.5)",
                 transition: "opacity 0.15s ease-out, transform 0.15s ease-out",


### PR DESCRIPTION
Two small fixes:

1. TileWall.tsx line 146: bottom: 3 hardcoded pixel. Replace with min(3px, 0.4dvh) or tie to wall tile size CSS var.
2. PlayerArea.tsx: verify onTouchCancel wired correctly to swipe.onTouchCancel(). May be dead code causing phantom swipe states.

Client-only: TileWall.tsx, PlayerArea.tsx

Closes #531