### PR TITLE
Fix TileWall bottom 3px and GameTable horizontal vw to dvw

### DIFF
--- a/apps/web/src/components/GameTable.tsx
+++ b/apps/web/src/components/GameTable.tsx
@@ -148,10 +148,10 @@ export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTile
           <div style={{ gridArea: "center", alignSelf: "start", justifySelf: "center", zIndex: 2, marginTop: "clamp(8%, 10dvh, 18%)" }}>
             <TileWall segment="top" wallRemaining={wallRemaining} wallDrawCount={state.wallDrawCount} wallSupplementCount={state.wallSupplementCount} gold={gold} canDraw={canDraw} onDraw={onDraw} />
           </div>
-          <div style={{ gridArea: "center", alignSelf: "center", justifySelf: "start", zIndex: 2, marginLeft: "clamp(8%, 10vw, 18%)" }}>
+          <div style={{ gridArea: "center", alignSelf: "center", justifySelf: "start", zIndex: 2, marginLeft: "clamp(8%, 10dvw, 18%)" }}>
             <TileWall segment="left" wallRemaining={wallRemaining} wallDrawCount={state.wallDrawCount} wallSupplementCount={state.wallSupplementCount} gold={gold} canDraw={canDraw} onDraw={onDraw} />
           </div>
-          <div style={{ gridArea: "center", alignSelf: "center", justifySelf: "end", zIndex: 2, marginRight: "clamp(8%, 10vw, 18%)" }}>
+          <div style={{ gridArea: "center", alignSelf: "center", justifySelf: "end", zIndex: 2, marginRight: "clamp(8%, 10dvw, 18%)" }}>
             <TileWall segment="right" wallRemaining={wallRemaining} wallDrawCount={state.wallDrawCount} wallSupplementCount={state.wallSupplementCount} gold={gold} canDraw={canDraw} onDraw={onDraw} />
           </div>
           {!isFirstPersonMobile && (


### PR DESCRIPTION
Two quick fixes:

1. TileWall.tsx line 146: bottom: 3 hardcoded. Change to min(3px, 0.4dvh).
2. GameTable.tsx lines 151, 154: horizontal clamp uses 10vw, should be 10dvw per convention. Change to clamp(8%, 10dvw, 18%).

Client-only: TileWall.tsx, GameTable.tsx

Closes #533