### PR TITLE
Audit discard area touch targets on mobile landscape

### DIFF
--- a/apps/web/src/components/ClaimOverlay.tsx
+++ b/apps/web/src/components/ClaimOverlay.tsx
@@ -95,7 +95,7 @@ export function ClaimOverlay({ actions, gameState, onAction }: ClaimOverlayProps
           {isCompact ? "选择" : "可以操作！请选择"}
         </div>
 
-        <div style={{ display: "flex", flexWrap: "wrap", justifyContent: "center", gap: isUltraCompact ? 4 : 10 }}>
+        <div style={{ display: "flex", flexWrap: "wrap", justifyContent: "center", gap: isUltraCompact ? 8 : 10 }}>
           {actions.canHu && (
             <button
               style={{ ...BTN.base, ...BTN.hu }}

--- a/apps/web/src/components/PlayerArea.tsx
+++ b/apps/web/src/components/PlayerArea.tsx
@@ -371,7 +371,7 @@ export function PlayerArea({
                   display: "flex",
                   flexDirection: ultraCompact ? "row" : "column",
                   flexWrap: ultraCompact ? "wrap" : "nowrap",
-                  gap: 4,
+                  gap: 8,
                   zIndex: "var(--z-tile-anim)" as any,
                   maxHeight: ultraCompact ? undefined : "40dvh",
                   overflowY: ultraCompact ? undefined : "auto",


### PR DESCRIPTION
Audit mobile landscape touch targets:

1. PlayerArea.tsx action buttons - are touch targets 44px min per Apple HIG?
2. Hu/Gang/Pong/Chi/Pass button spacing - can thumb accidentally hit wrong one?
3. Discard tile selection + confirm flow on 375px landscape
4. Fix any issues found.

Client-only: PlayerArea.tsx, ClaimOverlay.tsx

Closes #535