### PR TITLE
Add gangDraw flower loop safety limit and fix TutorialModal vh

### DIFF
--- a/apps/server/src/gameEngine.ts
+++ b/apps/server/src/gameEngine.ts
@@ -730,11 +730,14 @@ function gangDraw(
   const player = state.players[playerIndex];
 
   // Iterative loop to handle consecutive flowers from wallTail
+  const maxFlowers = 8; // max flower tiles in the game
+  let iterations = 0;
   while (true) {
-    if (state.wallTail.length === 0) {
+    if (state.wallTail.length === 0 || iterations >= maxFlowers) {
       endGameDraw(io, game);
       return;
     }
+    iterations++;
 
     const tile = state.wallTail.pop()!;
 

--- a/apps/web/src/components/TutorialModal.tsx
+++ b/apps/web/src/components/TutorialModal.tsx
@@ -256,7 +256,7 @@ export function TutorialModal({ open, onClose, condensed }: TutorialModalProps) 
           padding: isCompact ? "12px 16px" : "20px 24px",
           maxWidth: 480,
           width: "100%",
-          maxHeight: isCompact ? "95dvh" : "85vh",
+          maxHeight: isCompact ? "95dvh" : "85dvh",
           overflowY: "auto",
           position: "relative",
           animation: "overlayScaleIn 0.25s ease-out",


### PR DESCRIPTION
Two fixes:

1. gameEngine.ts gangDraw ~line 724-756: while(true) loop for consecutive flowers has no iteration limit. Add max 8 iterations (total flower count), call endGameDraw if exceeded.

2. TutorialModal.tsx:259: maxHeight 85vh should be 85dvh.

Server + Client: gameEngine.ts, TutorialModal.tsx

Closes #539