### PR TITLE
Prevent pinch-zoom and fix TileCounter overflow on small screens

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
     <meta name="description" content="福州麻将在线游戏 - Fuzhou Mahjong Online">
     <meta property="og:title" content="福州麻将 - Fuzhou Mahjong">
     <meta property="og:description" content="福州麻将在线游戏 - Fuzhou Mahjong Online">

--- a/apps/web/src/components/TileCounter.tsx
+++ b/apps/web/src/components/TileCounter.tsx
@@ -98,7 +98,7 @@ export function TileCounter({ gameState }: TileCounterProps) {
         <div style={{
           marginBottom: 4,
           padding: 8,
-          maxWidth: 200,
+          maxWidth: 'clamp(160px, 50vw, 240px)',
           background: "rgba(0,0,0,0.75)",
           backdropFilter: "blur(8px)",
           WebkitBackdropFilter: "blur(8px)",


### PR DESCRIPTION
Two mobile fixes:

1. index.html line 5: Add user-scalable=no, maximum-scale=1.0 to viewport meta tag. Game layout breaks on pinch-zoom.
2. TileCounter.tsx line 98: maxWidth 200 hardcoded. 9-tile grid overflows causing mid-suit wrapping. Use clamp-based maxWidth.

Client-only: index.html, TileCounter.tsx

Closes #542