### PR TITLE
Fix playerRoomMap memory leak on disconnect timeout

### DIFF
--- a/apps/server/src/handlers/roomHandlers.ts
+++ b/apps/server/src/handlers/roomHandlers.ts
@@ -296,6 +296,8 @@ export function registerRoomHandlers(io: GameServer, socket: GameSocket): void {
         // If no humans left connected, clean up room and game
         if (!room.hasConnectedPlayers()) {
           deleteGame(room.id);
+          const playerIds = room.players.map((p) => p.playerId);
+          for (const id of playerIds) unregisterPlayerRoom(id);
           room.players = [];
           deleteRoomIfEmpty(room.id);
           console.log(`Room ${room.id} cleaned up (all humans disconnected)`);


### PR DESCRIPTION
roomHandlers.ts ~lines 298-300: disconnect timer sets room.players=[] before deleteRoomIfEmpty. Cleanup iterates empty array, playerRoomMap.delete never runs. Permanent memory leak + stale routing.

Fix: collect player IDs before clearing, call unregisterPlayerRoom for each.

Server-only: roomHandlers.ts

Closes #546