### PR TITLE
Fix robbing-kong scoring and final-draws human stall

### DIFF
--- a/apps/server/src/gameEngine.ts
+++ b/apps/server/src/gameEngine.ts
@@ -482,6 +482,13 @@ function handleDraw(
   const inFinalDraws = isInFinalDraws(state.wall.length, state.wallTail.length, state.retainCount);
 
   const actions = getPostDrawActions(game, playerIndex, inFinalDraws);
+
+  // During final draws, if human can't hu, auto-pass immediately instead of waiting for input
+  if (inFinalDraws && !actions.canHu && !game.isBot(playerIndex)) {
+    handlePlayerAction(io, game.roomId, { type: ActionType.Pass, playerIndex }, playerIndex);
+    return;
+  }
+
   emitOrBotAction(io, game, playerIndex, actions);
 }
 
@@ -617,7 +624,7 @@ function handleBuGang(
     }
     const window = new ActionWindow(canRob, playerIndex, (winner) => {
       if (winner && winner.action.type === ActionType.Hu) {
-        endGameWin(io, game, winner.playerIndex, tile, false);
+        endGameWin(io, game, winner.playerIndex, tile, false, true);
       } else {
         // No one robbed, proceed with bu gang
         executeBuGang(io, game, playerIndex, tile, meldIdx);
@@ -1075,6 +1082,7 @@ function endGameWin(
   winnerIndex: number,
   winningTile: TileInstance,
   isSelfDraw: boolean,
+  isRobbingKong = false,
 ): void {
   const state = game.state;
   state.phase = GamePhase.Finished;
@@ -1091,7 +1099,7 @@ function endGameWin(
     isSelfDraw,
     isFirstAction: !game.firstActionTaken,
     isDealer: winner.isDealer,
-    isRobbingKong: false,
+    isRobbingKong,
     totalFlowers: winner.flowers.length,
     totalGangs: winner.melds.filter(
       (m) => m.type === MeldType.MingGang || m.type === MeldType.AnGang || m.type === MeldType.BuGang,


### PR DESCRIPTION
Two high-severity game logic bugs:

1. gameEngine.ts ~line 620: robbing-kong win calls endGameWin with isRobbingKong: false. Score multiplier wrong. Pass true from handleBuGang action window.

2. gameEngine.ts ~lines 1025-1037: In inFinalDraws, human with canHu:false gets canDiscard:false canPass:true with no timeout. Turn hangs forever. Add auto-pass timeout or auto-pass immediately.

Server-only: gameEngine.ts

Closes #545