### PR TITLE
Consolidate hardcoded values in TileWall to CSS variables

### DIFF
--- a/apps/web/src/components/TileWall.tsx
+++ b/apps/web/src/components/TileWall.tsx
@@ -161,8 +161,8 @@ function WallSegment({ side, stacks, drawStack, canDraw, onDraw, standalone }: {
                   position: "absolute",
                   top: "50%", left: "50%",
                   transform: "translate(-50%, -50%)",
-                  padding: "6px 16px",
-                  fontSize: 14,
+                  padding: "var(--btn-padding)",
+                  fontSize: "var(--btn-font)",
                   fontWeight: "bold",
                   background: "var(--color-draw-action)",
                   color: "#fff",
@@ -229,7 +229,7 @@ export function TileWall({ wallRemaining, wallDrawCount, wallSupplementCount, go
       }}>
         {gold && (
           <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
-            <span style={{ fontSize: 10, color: "var(--color-gold-bright)" }}>金</span>
+            <span style={{ fontSize: "var(--font-xs)", color: "var(--color-gold-bright)" }}>金</span>
             <TileView tile={gold.indicatorTile} faceUp gold={null} small className={goldFlip ? "gold-flip-reveal" : undefined} />
           </div>
         )}
@@ -241,14 +241,14 @@ export function TileWall({ wallRemaining, wallDrawCount, wallSupplementCount, go
               borderRadius: 3, transition: "width 0.3s ease",
             }} />
           </div>
-          <span style={{ fontSize: 11, color: "var(--color-text-secondary)" }}>{wallRemaining}</span>
+          <span style={{ fontSize: "var(--font-sm)", color: "var(--color-text-secondary)" }}>{wallRemaining}</span>
         </div>
         {canDraw && (
           <button
             className="draw-button-pulse"
             onClick={onDraw}
             style={{
-              padding: "4px 12px", fontSize: 12, fontWeight: "bold",
+              padding: "var(--btn-padding)", fontSize: "var(--btn-font)", fontWeight: "bold",
               background: "var(--color-draw-action)", color: "#fff", border: "none",
               borderRadius: 4, minHeight: 44, minWidth: 44,
               boxShadow: "0 0 12px rgba(106,90,205,0.6)",
@@ -293,7 +293,7 @@ export function TileWall({ wallRemaining, wallDrawCount, wallSupplementCount, go
       }}>
         {gold && (
           <div style={{ display: "flex", flexDirection: "column", alignItems: "center" }}>
-            <div style={{ fontSize: 10, color: "var(--color-gold-bright)", marginBottom: 2 }}>金</div>
+            <div style={{ fontSize: "var(--font-xs)", color: "var(--color-gold-bright)", marginBottom: 2 }}>金</div>
             <TileView tile={gold.indicatorTile} faceUp gold={null} small className={goldFlip ? "gold-flip-reveal" : undefined} />
           </div>
         )}
@@ -301,7 +301,7 @@ export function TileWall({ wallRemaining, wallDrawCount, wallSupplementCount, go
           <div
             className="wall-low-pulse"
             style={{
-              fontSize: 11,
+              fontSize: "var(--font-sm)",
               color: "var(--color-error)",
               padding: "2px 6px",
               borderRadius: 4,


### PR DESCRIPTION
TileWall.tsx has 4+ hardcoded fontSize and padding values (lines ~165, 232, 244, 251) bypassing dvh-based CSS variable system. Replace with existing CSS variables (--btn-font, --font-sm etc).

Client-only: TileWall.tsx

Closes #547