### PR TITLE
Fix mainTimer uninitialized race with safetyTimer in emitOrBotAction

### DIFF
--- a/apps/server/src/gameEngine.ts
+++ b/apps/server/src/gameEngine.ts
@@ -1264,7 +1264,7 @@ export function emitOrBotAction(
 
     console.log(`${tag} Scheduling action (version=${version}, delay=${Math.round(delay)}ms, phase=${game.state.phase}) ts=${Date.now()}`);
 
-    let mainTimer: NodeJS.Timeout;
+    let mainTimer: NodeJS.Timeout | null = null;
     const safetyTimer = setTimeout(() => {
       if (acted) {
         // Verify the turn actually advanced — if still on this bot, something went wrong
@@ -1283,7 +1283,7 @@ export function emitOrBotAction(
       }
       const currentV = getBotVersion(game.roomId, playerIndex);
       if (currentV !== version) {
-        clearTimeout(mainTimer);
+        if (mainTimer) clearTimeout(mainTimer);
         console.log(`${tag} Safety timer STALE — bailing (had=${version}, now=${currentV}), cleared mainTimer ts=${Date.now()}`);
         // Re-trigger if game is stuck
         if (game.state.phase === GamePhase.Playing) {


### PR DESCRIPTION
gameEngine.ts ~line 1267: mainTimer declared uninitialized. safetyTimer (~line 1286) can fire before mainTimer assigned at line 1348. clearTimeout(undefined) is no-op = double-action or stall.

Fix: Initialize let mainTimer: NodeJS.Timeout | null = null. Guard clear with if (mainTimer). Verify acted flag covers all paths.

Server-only: gameEngine.ts

Closes #551