### PR TITLE
Bound swipe offset and use responsive units in remaining hardcoded spots

### DIFF
--- a/apps/web/src/animations.css
+++ b/apps/web/src/animations.css
@@ -123,8 +123,8 @@
 
 .confetti {
   position: absolute;
-  width: 10px;
-  height: 10px;
+  width: clamp(8px, 2vmin, 12px);
+  height: clamp(8px, 2vmin, 12px);
   animation: confettiFall 3s ease-in forwards;
 }
 

--- a/apps/web/src/components/PlayerArea.tsx
+++ b/apps/web/src/components/PlayerArea.tsx
@@ -339,7 +339,7 @@ export function PlayerArea({
                 display: "inline-flex",
                 marginLeft: lastDrawnTileId === t.id ? "var(--hand-new-tile-margin)" : 0,
                 position: "relative",
-                transform: tileSwipeOffset < 0 ? `translateY(${tileSwipeOffset}px)` : undefined,
+                transform: tileSwipeOffset < 0 ? `translateY(${Math.max(-80, Math.min(0, tileSwipeOffset))}px)` : undefined,
                 opacity: isSwiping ? 1 - Math.min(0.5, Math.abs(tileSwipeOffset) / 100) : 1,
                 touchAction: "manipulation",
                 transition: isSwiping ? "none" : "transform 0.2s ease, opacity 0.2s ease, margin 0.15s ease",

--- a/apps/web/src/components/TutorialModal.tsx
+++ b/apps/web/src/components/TutorialModal.tsx
@@ -268,8 +268,8 @@ export function TutorialModal({ open, onClose, condensed }: TutorialModalProps) 
           aria-label="Close tutorial"
           style={{
             position: "absolute",
-            top: 8,
-            right: 8,
+            top: "clamp(8px, 2dvh, 16px)",
+            right: "clamp(8px, 2dvh, 16px)",
             background: "transparent",
             border: "none",
             color: "var(--color-text-secondary)",


### PR DESCRIPTION
Polish fixes:
1. PlayerArea.tsx:342 — translateY unbounded. Clamp tileSwipeOffset.
2. TutorialModal.tsx:271-272 — close button top/right 8 to clamp(8px,2dvh,16px).
3. animations.css:126-127 — confetti 10px to clamp(8px,2vmin,12px).

Client-only: PlayerArea.tsx, TutorialModal.tsx, animations.css

Closes #553