### PR TITLE
Consolidate remaining hardcoded z-index to CSS variables

### DIFF
--- a/apps/web/src/components/GameTable.tsx
+++ b/apps/web/src/components/GameTable.tsx
@@ -82,7 +82,7 @@ export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTile
       perspectiveOrigin: "50% 60%",
     }}>
       {/* Top player (index 2 in otherPlayers = across from me) */}
-      <div style={{ gridArea: "top", position: "relative", zIndex: 1 }}>
+      <div style={{ gridArea: "top", position: "relative", zIndex: "var(--z-game-table-cell)" }}>
         <PlayerArea
           isMe={false}
           hand={revealedHands?.[(myIndex + 2) % 4]?.hand}
@@ -104,7 +104,7 @@ export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTile
       </div>
 
       {/* Left player — rotated 90° clockwise to face left */}
-      <div style={{ gridArea: "left", position: "relative", zIndex: 1, transform: "rotate(90deg)", transformOrigin: "center center", display: "flex", alignItems: "center", justifyContent: "center" }}>
+      <div style={{ gridArea: "left", position: "relative", zIndex: "var(--z-game-table-cell)", transform: "rotate(90deg)", transformOrigin: "center center", display: "flex", alignItems: "center", justifyContent: "center" }}>
         <PlayerArea
           isMe={false}
           hand={revealedHands?.[(myIndex + 3) % 4]?.hand}
@@ -126,7 +126,7 @@ export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTile
       </div>
 
       {/* Center - game info */}
-      <div className="table-center-area" style={{ gridArea: "center", display: "flex", flexDirection: isCompact ? "column" : "row", alignItems: "center", justifyContent: "center", position: "relative", zIndex: 1, overflow: "hidden", padding: isCompact ? 0 : "12px" }}>
+      <div className="table-center-area" style={{ gridArea: "center", display: "flex", flexDirection: isCompact ? "column" : "row", alignItems: "center", justifyContent: "center", position: "relative", zIndex: "var(--z-game-table-cell)", overflow: "hidden", padding: isCompact ? 0 : "12px" }}>
         {isCompact && (
           <TileWall wallRemaining={wallRemaining} wallDrawCount={state.wallDrawCount} wallSupplementCount={state.wallSupplementCount} gold={gold} canDraw={canDraw} onDraw={onDraw} compact />
         )}
@@ -145,17 +145,17 @@ export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTile
       {/* Wall segments along table edges (non-compact only) */}
       {!isCompact && (
         <>
-          <div style={{ gridArea: "center", alignSelf: "start", justifySelf: "center", zIndex: 2, marginTop: "clamp(8%, 10dvh, 18%)" }}>
+          <div style={{ gridArea: "center", alignSelf: "start", justifySelf: "center", zIndex: "var(--z-wall-segment)", marginTop: "clamp(8%, 10dvh, 18%)" }}>
             <TileWall segment="top" wallRemaining={wallRemaining} wallDrawCount={state.wallDrawCount} wallSupplementCount={state.wallSupplementCount} gold={gold} canDraw={canDraw} onDraw={onDraw} />
           </div>
-          <div style={{ gridArea: "center", alignSelf: "center", justifySelf: "start", zIndex: 2, marginLeft: "clamp(8%, 10dvw, 18%)" }}>
+          <div style={{ gridArea: "center", alignSelf: "center", justifySelf: "start", zIndex: "var(--z-wall-segment)", marginLeft: "clamp(8%, 10dvw, 18%)" }}>
             <TileWall segment="left" wallRemaining={wallRemaining} wallDrawCount={state.wallDrawCount} wallSupplementCount={state.wallSupplementCount} gold={gold} canDraw={canDraw} onDraw={onDraw} />
           </div>
-          <div style={{ gridArea: "center", alignSelf: "center", justifySelf: "end", zIndex: 2, marginRight: "clamp(8%, 10dvw, 18%)" }}>
+          <div style={{ gridArea: "center", alignSelf: "center", justifySelf: "end", zIndex: "var(--z-wall-segment)", marginRight: "clamp(8%, 10dvw, 18%)" }}>
             <TileWall segment="right" wallRemaining={wallRemaining} wallDrawCount={state.wallDrawCount} wallSupplementCount={state.wallSupplementCount} gold={gold} canDraw={canDraw} onDraw={onDraw} />
           </div>
           {!isFirstPersonMobile && (
-            <div style={{ gridArea: "center", alignSelf: "end", justifySelf: "center", zIndex: 2, marginBottom: "clamp(8%, 10dvh, 18%)" }}>
+            <div style={{ gridArea: "center", alignSelf: "end", justifySelf: "center", zIndex: "var(--z-wall-segment)", marginBottom: "clamp(8%, 10dvh, 18%)" }}>
               <TileWall segment="bottom" wallRemaining={wallRemaining} wallDrawCount={state.wallDrawCount} wallSupplementCount={state.wallSupplementCount} gold={gold} canDraw={canDraw} onDraw={onDraw} />
             </div>
           )}
@@ -163,7 +163,7 @@ export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTile
       )}
 
       {/* Right player — rotated 90° counter-clockwise to face right */}
-      <div style={{ gridArea: "right", position: "relative", zIndex: 1, transform: "rotate(-90deg)", transformOrigin: "center center", display: "flex", alignItems: "center", justifyContent: "center" }}>
+      <div style={{ gridArea: "right", position: "relative", zIndex: "var(--z-game-table-cell)", transform: "rotate(-90deg)", transformOrigin: "center center", display: "flex", alignItems: "center", justifyContent: "center" }}>
         <PlayerArea
           isMe={false}
           hand={revealedHands?.[(myIndex + 1) % 4]?.hand}
@@ -185,7 +185,7 @@ export function GameTable({ state, onTileSelect, onTileDoubleClick, selectedTile
       </div>
 
       {/* Bottom - my area */}
-      <div style={{ gridArea: "bottom", position: "relative", zIndex: 1 }}>
+      <div style={{ gridArea: "bottom", position: "relative", zIndex: "var(--z-game-table-cell)" }}>
         <PlayerArea
           isMe
           hand={myHand}

--- a/apps/web/src/components/PlayerArea.tsx
+++ b/apps/web/src/components/PlayerArea.tsx
@@ -357,7 +357,7 @@ export function PlayerArea({
                   position: "absolute", bottom: "100%", left: "50%",
                   transform: "translateX(-50%)", marginBottom: "clamp(2px, 1.5vh, 6px)",
                   fontSize: "var(--font-xs)", color: "var(--color-gold-bright)",
-                  whiteSpace: "nowrap", zIndex: 10,
+                  whiteSpace: "nowrap", zIndex: "var(--z-swipe-hint)",
                   textShadow: "0 1px 4px rgba(0,0,0,0.8)",
                 }}>↑ 上滑出牌</div>
               )}

--- a/apps/web/src/components/TileWall.tsx
+++ b/apps/web/src/components/TileWall.tsx
@@ -172,7 +172,7 @@ function WallSegment({ side, stacks, drawStack, canDraw, onDraw, standalone }: {
                   whiteSpace: "nowrap",
                   minHeight: 44,
                   minWidth: 44,
-                  zIndex: 10,
+                  zIndex: "var(--z-draw-button)",
                 }}
               >
                 摸牌

--- a/apps/web/src/components/TutorialModal.tsx
+++ b/apps/web/src/components/TutorialModal.tsx
@@ -241,7 +241,7 @@ export function TutorialModal({ open, onClose, condensed }: TutorialModalProps) 
         display: "flex",
         alignItems: "center",
         justifyContent: "center",
-        zIndex: 60,
+        zIndex: "var(--z-tutorial)",
         animation: "overlayFadeIn 0.2s ease-out",
         padding: 16,
       }}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -129,6 +129,10 @@ body {
   --color-tile-back-border-right: #1e4530;
 
   /* Z-index scale */
+  --z-game-table-cell: 1;
+  --z-wall-segment: 2;
+  --z-draw-button: 10;
+  --z-swipe-hint: 11;
   --z-tile-anim: 20;
   --z-center-action: 29;
   --z-settings-btn: 30;
@@ -136,6 +140,7 @@ body {
   --z-settings-dropdown: 35;
   --z-claim-overlay: 40;
   --z-confirm-modal: 50;
+  --z-tutorial: 60;
   --z-game-over: 100;
   --z-toast: 9000;
   --z-portrait-overlay: 9999;


### PR DESCRIPTION
Several components still use inline zIndex instead of CSS vars:
- TileWall.tsx:175 zIndex:10, PlayerArea.tsx:360 zIndex:10 (conflict!), TutorialModal.tsx:244 zIndex:60, GameTable.tsx various zIndex:1/2.

Add --z-draw-button, --z-swipe-hint, --z-tutorial tokens. Resolve 10/10 conflict.

Client-only: index.css, TileWall.tsx, PlayerArea.tsx, TutorialModal.tsx, GameTable.tsx

Closes #552