### PR TITLE
Fix bot stall in final draws - pass rejection loop

### DIFF
--- a/apps/server/src/gameEngine.ts
+++ b/apps/server/src/gameEngine.ts
@@ -483,8 +483,8 @@ function handleDraw(
 
   const actions = getPostDrawActions(game, playerIndex, inFinalDraws);
 
-  // During final draws, if human can't hu, auto-pass immediately instead of waiting for input
-  if (inFinalDraws && !actions.canHu && !game.isBot(playerIndex)) {
+  // During final draws, if player can't hu, auto-pass immediately instead of waiting for input
+  if (inFinalDraws && !actions.canHu) {
     handlePlayerAction(io, game.roomId, { type: ActionType.Pass, playerIndex }, playerIndex);
     return;
   }


### PR DESCRIPTION
gameEngine.ts ~line 487-492: bot in final draws with no hu calls emitOrBotAction which returns Pass. handlePlayerAction rejects Pass due to currentTurn mismatch. Watchdog fires emergencyDiscard, hand empty returns Pass again. Infinite 10s loop.

Fix: In final-draws path, call handlePlayerAction directly with Pass for bots instead of routing through emitOrBotAction. Or skip turn check for Pass during final draws.

Server-only: gameEngine.ts

Closes #557