### PR TITLE
Remove dead candidates array in winning ts

### DIFF
--- a/packages/shared/src/game/winning.ts
+++ b/packages/shared/src/game/winning.ts
@@ -141,19 +141,6 @@ export function isValidHand(
   goldCount: number,
   setsNeeded: number = 5,
 ): boolean {
-  // Find unique tile types for pair candidates
-  const seen = new Set<string>();
-  const candidates: { suit: string; value: number; count: number }[] = [];
-  for (const t of handTiles) {
-    const key = `${t.suit}-${t.value}`;
-    if (!seen.has(key)) {
-      seen.add(key);
-      candidates.push({ suit: t.suit, value: t.value, count: 0 });
-    }
-    candidates[candidates.length - 1].count++;
-  }
-
-  // Fix count tracking
   const countMap = new Map<string, number>();
   for (const t of handTiles) {
     const key = `${t.suit}-${t.value}`;


### PR DESCRIPTION
winning.ts lines 144-154: candidates array built with broken count increment bug. Array never used - countMap replaces it immediately. Delete dead code.

Shared package: winning.ts

Closes #559