### PR TITLE
Mobile touch and tap target fixes across components

### DIFF
--- a/apps/web/src/components/PlayerArea.tsx
+++ b/apps/web/src/components/PlayerArea.tsx
@@ -366,8 +366,8 @@ export function PlayerArea({
                 <div className="discard-bubble" style={{
                   position: "absolute",
                   bottom: "100%", marginBottom: "clamp(2px, 1dvh, 4px)",
-                  left: "50%",
-                  transform: "translateX(-50%)",
+                  left: "max(8px, 50%)",
+                  transform: "translateX(max(-50%, calc(-100% + 8px)))",
                   display: "flex",
                   flexDirection: ultraCompact ? "row" : "column",
                   flexWrap: ultraCompact ? "wrap" : "nowrap",

--- a/apps/web/src/components/SessionSummary.tsx
+++ b/apps/web/src/components/SessionSummary.tsx
@@ -39,20 +39,29 @@ function RoundHistorySection({ roundHistory, playerNames, isCompact }: {
 
   return (
     <div style={{ marginBottom: "clamp(8px, 2.5dvh, 16px)" }}>
-      <div
-        style={{
-          fontSize: "clamp(11px, 3dvh, 13px)", color: "var(--color-text-secondary)", marginBottom: "clamp(3px, 1dvh, 6px)",
-          ...(showToggle ? { cursor: "pointer", userSelect: "none" as const } : {}),
-        }}
-        onClick={showToggle ? () => setExpanded(e => !e) : undefined}
-      >
-        每局记录 / Round History
-        {showToggle && (
+      {showToggle ? (
+        <button
+          type="button"
+          onClick={() => setExpanded(e => !e)}
+          style={{
+            fontSize: "clamp(11px, 3dvh, 13px)", color: "var(--color-text-secondary)", marginBottom: "clamp(3px, 1dvh, 6px)",
+            cursor: "pointer", userSelect: "none" as const,
+            background: "transparent", border: "none", padding: 0, minHeight: 44,
+            display: "block", width: "100%", textAlign: "left",
+          }}
+        >
+          每局记录 / Round History
           <span style={{ marginLeft: 6, fontSize: "clamp(9px, 2.5dvh, 11px)" }}>
             {expanded ? "▲ 收起" : "▼ 展开"}
           </span>
-        )}
-      </div>
+        </button>
+      ) : (
+        <div style={{
+          fontSize: "clamp(11px, 3dvh, 13px)", color: "var(--color-text-secondary)", marginBottom: "clamp(3px, 1dvh, 6px)",
+        }}>
+          每局记录 / Round History
+        </div>
+      )}
       {(!showToggle || expanded) && (
         <div style={{ maxHeight: contentMaxHeight, overflowY: "auto" }}>
           {/* Player name header */}

--- a/apps/web/src/components/TutorialModal.tsx
+++ b/apps/web/src/components/TutorialModal.tsx
@@ -277,6 +277,7 @@ export function TutorialModal({ open, onClose, condensed }: TutorialModalProps) 
             cursor: "pointer",
             padding: "4px 8px",
             minHeight: 44,
+            minWidth: 44,
             lineHeight: 1,
           }}
         >
@@ -307,6 +308,7 @@ export function TutorialModal({ open, onClose, condensed }: TutorialModalProps) 
               background: isFirst ? "transparent" : "var(--color-bg-button)",
               border: isFirst ? "1px solid transparent" : "1px solid var(--color-bg-button-hover)",
               minHeight: 44,
+              minWidth: 44,
             }}
           >
             上一页
@@ -356,6 +358,7 @@ export function TutorialModal({ open, onClose, condensed }: TutorialModalProps) 
                 border: "1px solid var(--color-text-gold)",
                 color: "var(--color-gold-bright)",
                 minHeight: 44,
+                minWidth: 44,
               }}
             >
               知道了
@@ -367,6 +370,7 @@ export function TutorialModal({ open, onClose, condensed }: TutorialModalProps) 
                 padding: isCompact ? "6px 12px" : "8px 18px",
                 fontSize: isCompact ? 13 : 14,
                 minHeight: 44,
+                minWidth: 44,
               }}
             >
               下一页

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -533,17 +533,16 @@ button {
   min-height: 44px;
 }
 
-button:hover:not(:disabled) {
-  background: var(--color-bg-button-hover);
+@media (hover: hover) {
+  button:hover:not(:disabled) {
+    background: var(--color-bg-button-hover);
+    filter: brightness(1.2);
+  }
 }
 
 button:disabled {
   opacity: 0.5;
   cursor: not-allowed;
-}
-
-button:hover:not(:disabled) {
-  filter: brightness(1.2);
 }
 
 button:active:not(:disabled) {
@@ -796,10 +795,12 @@ hr {
   transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
-.room-card:hover {
-  transform: translateY(-2px);
-  border-color: var(--color-gold-border-hover);
-  box-shadow: 0 4px 12px rgba(255,215,0,0.15), 0 4px 16px rgba(0,0,0,0.4), inset 0 1px 0 rgba(255,255,255,0.05);
+@media (hover: hover) {
+  .room-card:hover {
+    transform: translateY(-2px);
+    border-color: var(--color-gold-border-hover);
+    box-shadow: 0 4px 12px rgba(255,215,0,0.15), 0 4px 16px rgba(0,0,0,0.4), inset 0 1px 0 rgba(255,255,255,0.05);
+  }
 }
 
 /* Quick Start gradient button */


### PR DESCRIPTION
5 mobile UX fixes:

1. SessionSummary.tsx ~line 42: RoundHistorySection expand div has no min-height. Make it a button with min-height 44px.
2. TutorialModal.tsx: close X and nav buttons have minHeight but no minWidth 44. Add it.
3. PlayerArea.tsx ~line 369: discard bubble left 50% translateX no viewport clamping. Add max(8px,...) so bubble stays on screen.
4. index.css ~lines 535-546: duplicate button:hover rule. Deduplicate and wrap in @media (hover: hover).
5. index.css ~line 798: room-card:hover stuck on mobile. Wrap in @media (hover: hover).

Client-only: SessionSummary.tsx, TutorialModal.tsx, PlayerArea.tsx, index.css

Closes #567