### PR TITLE
Harden playerAction validation and reconnect race condition

### DIFF
--- a/apps/server/src/gameEngine.ts
+++ b/apps/server/src/gameEngine.ts
@@ -309,6 +309,12 @@ export function handlePlayerAction(
     }
     playerIndex = game.getPlayerIndex(socketIdOrRoomId);
     if (playerIndex === -1) return false;
+
+    // Validate client-supplied playerIndex matches server-computed index
+    if (action.playerIndex !== playerIndex) {
+      console.warn(`[GameEngine] playerIndex mismatch: client sent ${action.playerIndex}, server computed ${playerIndex} for socket=${socketIdOrRoomId}. Using server value.`);
+      action.playerIndex = playerIndex;
+    }
   }
 
   // Clear watchdog on any successful action processing for this player

--- a/apps/server/src/handlers/roomHandlers.ts
+++ b/apps/server/src/handlers/roomHandlers.ts
@@ -18,6 +18,7 @@ type GameSocket = Socket<ClientEvents, ServerEvents>;
 type GameServer = Server<ClientEvents, ServerEvents>;
 
 const RECONNECT_TIMEOUT_MS = 60_000;
+const reconnectingPlayers = new Set<string>();
 
 function broadcastRoomList(io: GameServer): void {
   io.emit("roomList", getAvailableRooms());
@@ -63,25 +64,35 @@ export function registerRoomHandlers(io: GameServer, socket: GameSocket): void {
   });
 
   socket.on("rejoinGame", (playerId: string) => {
+    if (reconnectingPlayers.has(playerId)) {
+      socket.emit("error", "Reconnection already in progress");
+      return;
+    }
+
     const room = findRoomByPlayerId(playerId);
     if (!room) { socket.emit("error", "No active game found"); return; }
     if (room.isStartingRound) { socket.emit("error", "Round initializing, retry shortly"); return; }
 
-    const player = room.reconnectPlayer(playerId, socket.id);
-    if (!player) { socket.emit("error", "Player not found in room"); return; }
+    reconnectingPlayers.add(playerId);
+    try {
+      const player = room.reconnectPlayer(playerId, socket.id);
+      if (!player) { socket.emit("error", "Player not found in room"); return; }
 
-    socket.join(room.id);
+      socket.join(room.id);
 
-    const game = getGame(room.id);
-    if (game) {
-      const playerIndex = room.getPlayerIndexByPlayerId(playerId);
-      game.updateSocketId(playerIndex, socket.id);
-      socket.emit("playerIdAssigned", playerId);
-      socket.emit("gameStarted", game.getClientGameState(playerIndex));
-      io.to(room.id).emit("playerReconnected", { playerIndex, playerName: player.name });
-      console.log(`Player ${player.name} reconnected to room ${room.id}`);
-    } else {
-      socket.emit("roomJoined", room.getState());
+      const game = getGame(room.id);
+      if (game) {
+        const playerIndex = room.getPlayerIndexByPlayerId(playerId);
+        game.updateSocketId(playerIndex, socket.id);
+        socket.emit("playerIdAssigned", playerId);
+        socket.emit("gameStarted", game.getClientGameState(playerIndex));
+        io.to(room.id).emit("playerReconnected", { playerIndex, playerName: player.name });
+        console.log(`Player ${player.name} reconnected to room ${room.id}`);
+      } else {
+        socket.emit("roomJoined", room.getState());
+      }
+    } finally {
+      reconnectingPlayers.delete(playerId);
     }
   });
 
@@ -263,6 +274,9 @@ export function registerRoomHandlers(io: GameServer, socket: GameSocket): void {
     }
 
     triggerDealerAction(io, game, room);
+    } catch (err) {
+      console.error(`[RoomHandlers] nextRound failed in room ${room.id}:`, err);
+      socket.emit("error", "Failed to start next round");
     } finally {
       room.isStartingRound = false;
     }


### PR DESCRIPTION
3 server hardening fixes:

1. gameHandlers.ts ~line 11: playerAction event has no validation that action.playerIndex matches computed index. Add validation + warning log.
2. roomHandlers.ts ~lines 65-86: rejoinGame race - two sockets can rejoin same playerId concurrently. Add mutex guard.
3. roomHandlers.ts ~lines 212-268: startNextRound has no error handling if game.startNextRound throws. Add try-catch + error emit.

Server-only: gameHandlers.ts, roomHandlers.ts

Closes #569