### PR TITLE
Fix dealer initial AnGang detection in getInitialDealerActions

### DIFF
--- a/apps/server/src/gameState.ts
+++ b/apps/server/src/gameState.ts
@@ -8,6 +8,8 @@ import {
   sortHand,
   findTenpaiTiles,
   checkWin,
+  findAnGang,
+  findBuGang,
 } from "@fuzhou-mahjong/shared";
 import { findRoom } from "./room.js";
 import type {
@@ -179,16 +181,20 @@ export class ServerGameState {
       canHu = winResult.isWin;
     }
 
+    const anGangOptions = findAnGang(dealer.hand, this.state.gold);
+    const buGangOptions = findBuGang(dealer.hand, dealer.melds, this.state.gold);
+    const hasGangOptions = anGangOptions.length > 0 || buGangOptions.length > 0;
+
     return {
       canDraw: false,
       canDiscard: true,
       chiOptions: [],
       canPeng: false,
       canMingGang: false,
-      anGangOptions: [],
-      buGangOptions: [],
+      anGangOptions,
+      buGangOptions,
       canHu,
-      canPass: canHu,
+      canPass: canHu || hasGangOptions,
     };
   }
 


### PR DESCRIPTION
Rules bug: gameState.ts getInitialDealerActions hardcodes anGangOptions: [] and buGangOptions: []. Dealer with four-of-a-kind on initial 14 tiles cannot declare AnGang.

Fix: Compute real anGangOptions by scanning dealer hand for 4-of-a-kind. Update canPass if gang available. BuGang unlikely on initial deal but add for correctness.

Server-only: gameState.ts

Closes #572