### PR TITLE
Fix swipe gesture scroll conflict with preventDefault on touchmove

### DIFF
--- a/apps/web/src/hooks/useSwipeGesture.ts
+++ b/apps/web/src/hooks/useSwipeGesture.ts
@@ -55,6 +55,9 @@ export function useSwipeGesture({
       ref.locked = true;
     }
 
+    // Prevent iOS scroll while actively swiping
+    e.preventDefault();
+
     // Only track upward movement (negative deltaY)
     if (deltaY < 0) {
       setSwipingTileId(ref.tileId);


### PR DESCRIPTION
useSwipeGesture missing preventDefault on touchmove. iOS Safari native scroll competes with swipe-to-discard gesture.

1. Add preventDefault to touchmove in swipe hook when swipe is active.
2. Verify touch-action CSS on hand tile area.
3. Ensure pinch-zoom still works outside hand area.

Client-only: useSwipeGesture.ts, possibly PlayerArea.tsx

Closes #574