### PR TITLE
Mobile touch-action CSS and responsive swipe thresholds

### DIFF
--- a/apps/web/src/hooks/useSwipeGesture.ts
+++ b/apps/web/src/hooks/useSwipeGesture.ts
@@ -44,7 +44,8 @@ export function useSwipeGesture({
     // If not yet locked into a direction, check which axis dominates
     if (!ref.locked) {
       // Need minimum movement before deciding direction
-      if (Math.abs(deltaX) < 10 && Math.abs(deltaY) < 10) return;
+      const deadzone = Math.max(6, window.innerHeight * 0.02);
+      if (Math.abs(deltaX) < deadzone && Math.abs(deltaY) < deadzone) return;
       // Horizontal scroll — abort swipe tracking
       if (Math.abs(deltaX) > Math.abs(deltaY)) {
         touchRef.current = null;
@@ -69,7 +70,7 @@ export function useSwipeGesture({
 
   const onTouchEnd = useCallback(() => {
     const ref = touchRef.current;
-    const threshold = thresholdProp ?? Math.min(40, window.innerHeight * 0.08);
+    const threshold = thresholdProp ?? Math.max(25, window.innerHeight * 0.08);
     if (ref && ref.locked && swipeOffset < -threshold) {
       onSwipeUp(ref.tileId);
     }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -532,6 +532,7 @@ body {
   border-radius: var(--radius-md);
   box-shadow: 0 2px 8px rgba(0,0,0,0.3), inset 0 1px 0 rgba(255,255,255,0.03);
   padding: 6px;
+  touch-action: manipulation;
 }
 
 /* ─── Center area composition ─── */
@@ -588,6 +589,12 @@ input:focus {
 
 input::placeholder {
   color: var(--color-text-secondary);
+}
+
+/* Disable double-tap zoom on tile buttons for snappier touch response */
+[role="button"],
+.player-area-card button {
+  touch-action: manipulation;
 }
 
 /* Keyboard focus outline for tiles and buttons */


### PR DESCRIPTION
Mobile touch polish:

1. Add touch-action: manipulation to tile buttons and player-area cards in CSS. Eliminates iOS double-tap delay.
2. useSwipeGesture.ts:72 — swipe threshold Math.min(40,...) to Math.max(25, window.innerHeight * 0.08).
3. useSwipeGesture.ts:47 — direction-lock 10px to Math.max(6, window.innerHeight * 0.02).

Client-only: useSwipeGesture.ts, index.css

Closes #579