### PR TITLE
Unify hardcoded breakpoints and fix tooltip safe-area

### DIFF
--- a/apps/web/src/components/TileTooltip.tsx
+++ b/apps/web/src/components/TileTooltip.tsx
@@ -65,8 +65,8 @@ export function useLongPress(gold: GoldState | null) {
     return (
       <div style={{
         position: "fixed",
-        left: `clamp(max(8px, env(safe-area-inset-left, 0px)), ${tooltip.x - 40}px, calc(100vw - 128px - env(safe-area-inset-right, 0px)))`,
-        top: `max(${Math.max(tooltip.y - 100, 0)}px, env(safe-area-inset-top, 10px))`,
+        left: `clamp(env(safe-area-inset-left, 8px), ${tooltip.x - 40}px, calc(100vw - 128px - env(safe-area-inset-right, 8px)))`,
+        top: `max(${tooltip.y - 100}px, env(safe-area-inset-top, 10px))`,
         background: "var(--color-bg-dark)",
         border: isGold ? "2px solid var(--color-gold-bright)" : "1px solid var(--color-text-secondary)",
         borderRadius: 8,

--- a/apps/web/src/hooks/useIsMobile.ts
+++ b/apps/web/src/hooks/useIsMobile.ts
@@ -6,6 +6,7 @@ export const BREAKPOINTS = {
   TABLET_WIDTH: 768,
   PHONE_WIDTH: 480,
   TINY_WIDTH: 360,
+  FIRST_PERSON_WIDTH_THRESHOLD: 1024,
 } as const;
 
 export function useIsCompactLandscape(): boolean {
@@ -31,14 +32,14 @@ export function useIsCompactLandscape(): boolean {
 
 export function useIsFirstPersonMobile(): boolean {
   const [isFP, setIsFP] = useState(
-    () => window.innerHeight <= BREAKPOINTS.COMPACT_HEIGHT && window.innerWidth <= 1024
+    () => window.innerHeight <= BREAKPOINTS.COMPACT_HEIGHT && window.innerWidth <= BREAKPOINTS.FIRST_PERSON_WIDTH_THRESHOLD
   );
   useEffect(() => {
     let timeout: ReturnType<typeof setTimeout>;
     const onResize = () => {
       clearTimeout(timeout);
       timeout = setTimeout(() => {
-        setIsFP(window.innerHeight <= BREAKPOINTS.COMPACT_HEIGHT && window.innerWidth <= 1024);
+        setIsFP(window.innerHeight <= BREAKPOINTS.COMPACT_HEIGHT && window.innerWidth <= BREAKPOINTS.FIRST_PERSON_WIDTH_THRESHOLD);
       }, 100);
     };
     window.addEventListener("resize", onResize);

--- a/apps/web/src/pages/Game.tsx
+++ b/apps/web/src/pages/Game.tsx
@@ -78,10 +78,10 @@ export function Game({ initialGameState, onLeave }: GameProps) {
   const [departingTile, setDepartingTile] = useState<TileInstance | null>(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [muted, setMutedState] = useState(isMuted);
-  const [isPortrait, setIsPortrait] = useState(() => window.matchMedia("(orientation: portrait)").matches && window.innerWidth <= 768);
+  const [isPortrait, setIsPortrait] = useState(() => window.matchMedia("(orientation: portrait)").matches && window.innerWidth <= BREAKPOINTS.TABLET_WIDTH);
 
   useEffect(() => {
-    const mq = window.matchMedia("(orientation: portrait) and (max-width: 768px)");
+    const mq = window.matchMedia(`(orientation: portrait) and (max-width: ${BREAKPOINTS.TABLET_WIDTH}px)`);
     const handler = (e: MediaQueryListEvent) => setIsPortrait(e.matches);
     mq.addEventListener("change", handler);
     return () => mq.removeEventListener("change", handler);


### PR DESCRIPTION
Breakpoint cleanup:

1. Game.tsx:81,84 — replace hardcoded 768 with BREAKPOINTS.TABLET_WIDTH.
2. useIsMobile.ts:34,41 — extract 1024 to FIRST_PERSON_WIDTH_THRESHOLD constant.
3. TileTooltip.tsx:68-69 — simplify safe-area handling for notch devices.

Client-only: Game.tsx, useIsMobile.ts, TileTooltip.tsx

Closes #580