### PR TITLE
Move activeWindows delete before resolveActionWindow to fix bot freeze

### DIFF
--- a/apps/server/src/gameEngine.ts
+++ b/apps/server/src/gameEngine.ts
@@ -441,8 +441,8 @@ function handleDiscard(
       existingWindow.cancel();
     }
     const window = new ActionWindow(pendingPlayers, playerIndex, (winner) => {
-      resolveActionWindow(io, game, winner, playerIndex, tile);
       activeWindows.delete(game.roomId);
+      resolveActionWindow(io, game, winner, playerIndex, tile);
     });
     activeWindows.set(game.roomId, window);
   }
@@ -633,13 +633,13 @@ function handleBuGang(
       existingWindow.cancel();
     }
     const window = new ActionWindow(canRob, playerIndex, (winner) => {
+      activeWindows.delete(game.roomId);
       if (winner && winner.action.type === ActionType.Hu) {
         endGameWin(io, game, winner.playerIndex, tile, false, true);
       } else {
         // No one robbed, proceed with bu gang
         executeBuGang(io, game, playerIndex, tile, meldIdx);
       }
-      activeWindows.delete(game.roomId);
     });
     activeWindows.set(game.roomId, window);
   } else {


### PR DESCRIPTION
Bot freeze after Peng/Chi: resolveActionWindow calls emitOrBotAction while window is still in activeWindows map. Bot callback sees resolved window, isPending returns false, early returns with no action.

Fix: Move activeWindows.delete BEFORE resolveActionWindow at lines 444-445 and 641-642. The window is fully resolved by the onResolve callback - delete it before scheduling next actions.

Server-only: gameEngine.ts

Closes #583