### PR TITLE
Restrict claims during final draws - only Hu allowed

### DIFF
--- a/apps/server/src/gameEngine.ts
+++ b/apps/server/src/gameEngine.ts
@@ -1012,6 +1012,22 @@ function getResponseActions(
     canHuFlag = winResult.isWin;
   }
 
+  // During final draws, only Hu is allowed — skip Peng/Chi/Gang
+  const inFinal = isInFinalDraws(state.wall.length, state.wallTail.length, state.retainCount);
+  if (inFinal) {
+    return {
+      canDraw: false,
+      canDiscard: false,
+      chiOptions: [],
+      canPeng: false,
+      canMingGang: false,
+      anGangOptions: [],
+      buGangOptions: [],
+      canHu: canHuFlag,
+      canPass: true,
+    };
+  }
+
   // Chi: only the next counterclockwise player can chi
   const isNextPlayer = ((discarderIndex + 1) % 4) === playerIndex;
   const chiOpts = isNextPlayer ? findChiCombinations(player.hand, discardTile, gold) : [];


### PR DESCRIPTION
gameEngine.ts getResponseActions ~line 1015-1032: does not check isInFinalDraws. Players can still Peng/Chi/Gang during final draws. Per mahjong rules, only Hu should be allowed.

Fix: Check isInFinalDraws at top of getResponseActions. If true, only return Hu options.

Server-only: gameEngine.ts

Closes #589