### PR TITLE
Fix discard bubble overflow and fp-tile-w wrap at ultra-compact

### DIFF
--- a/apps/web/src/components/PlayerArea.tsx
+++ b/apps/web/src/components/PlayerArea.tsx
@@ -373,8 +373,8 @@ export function PlayerArea({
                   flexWrap: ultraCompact ? "wrap" : "nowrap",
                   gap: 8,
                   zIndex: "var(--z-tile-anim)" as any,
-                  maxHeight: ultraCompact ? undefined : "40dvh",
-                  overflowY: ultraCompact ? undefined : "auto",
+                  maxHeight: ultraCompact ? "clamp(60px, 40dvh, 160px)" : "40dvh",
+                  overflowY: "auto",
                   animation: "bubbleFadeIn 0.15s ease-out",
                 }}>
                   {canHu && (

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -396,7 +396,7 @@ body {
     --compact-padding: max(2px, 0.5dvh) max(4px, 1dvh);
     --compact-label-font: max(10px, 2.6dvh);
     --compact-info-font: max(9px, 2.3dvh);
-    --fp-tile-w: clamp(40px, 8.5dvh, 44px);
+    --fp-tile-w: clamp(26px, 8.5dvh, 40px);
     --fp-tile-h: clamp(40px, 12dvh, 56px);
     --fp-opponent-tile-w: clamp(16px, 5.3dvh, 24px);
     --fp-opponent-tile-h: clamp(22px, 7.2dvh, 32px);


### PR DESCRIPTION
Two ultra-compact issues:

1. PlayerArea.tsx lines 372-376: discard bubble has no maxHeight/overflowY at ultraCompact. 4 buttons overflow viewport. Add maxHeight clamp(60px,40dvh,160px) and overflowY auto.
2. index.css: fp-tile-w clamp(40px,...) too wide for 360px phones. 13x40=520px > 360px viewport. Lower to clamp(26px, 8.5dvh, 40px).

Client-only: PlayerArea.tsx, index.css

Closes #590