### PR TITLE
Add landscape width breakpoint for narrow phones 320-390px

### DIFF
--- a/apps/web/src/components/ClaimOverlay.tsx
+++ b/apps/web/src/components/ClaimOverlay.tsx
@@ -21,7 +21,7 @@ interface ClaimOverlayProps {
 const BTN = {
   base: {
     padding: "var(--btn-padding)", fontSize: "var(--btn-font)", fontWeight: "bold" as const,
-    borderRadius: 8, border: "none", minHeight: "var(--btn-min-size)", minWidth: "var(--btn-min-size)",
+    borderRadius: 8, border: "none", minHeight: "clamp(40px, 8dvh, 56px)", minWidth: "var(--btn-min-size)",
     cursor: "pointer",
   },
   hu: { background: "var(--color-action-hu)", color: "#fff" },
@@ -95,7 +95,7 @@ export function ClaimOverlay({ actions, gameState, onAction }: ClaimOverlayProps
           {isCompact ? "选择" : "可以操作！请选择"}
         </div>
 
-        <div style={{ display: "flex", flexWrap: "wrap", justifyContent: "center", gap: isUltraCompact ? 8 : 10 }}>
+        <div style={{ display: "flex", flexWrap: "wrap", justifyContent: "center", gap: isUltraCompact ? 6 : 10 }}>
           {actions.canHu && (
             <button
               style={{ ...BTN.base, ...BTN.hu }}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1127,3 +1127,10 @@ button.lobby-create-btn:active:not(:disabled) {
     padding: clamp(6px, 1.8dvh, 10px);
   }
 }
+
+/* Narrow landscape phones (≤390px width, e.g. iPhone SE landscape height as width) */
+@media (orientation: landscape) and (max-width: 390px) {
+  .confirm-modal {
+    padding: clamp(12px, 2dvh, 16px);
+  }
+}


### PR DESCRIPTION
No max-width 390px landscape breakpoint. iPhone SE landscape (568x320) has cramped modals.

Add @media (orientation: landscape) and (max-width: 390px) breakpoint:
- confirm-modal padding to clamp(12px, 2dvh, 16px)
- game-over max-width to 95vw
- ClaimOverlay button minHeight to clamp(40px, 8dvh, 56px)
- ClaimOverlay button gaps to 6px

Client-only: index.css, ClaimOverlay.tsx

Closes #596