### PR TITLE
Fix bot stale actions in activeWindow branch of emitOrBotAction

### DIFF
--- a/apps/server/src/gameEngine.ts
+++ b/apps/server/src/gameEngine.ts
@@ -120,6 +120,10 @@ class ActionWindow {
     return this.pendingPlayers.has(playerIndex);
   }
 
+  getDiscarderIndex(): number {
+    return this.discarderIndex;
+  }
+
   cancel(): void {
     if (this.timer) { clearTimeout(this.timer); this.timer = null; }
   }
@@ -1458,7 +1462,11 @@ export function emitOrBotAction(
           console.log(`${tag} Bot already responded to action window, skipping ts=${Date.now()}`);
           return;
         }
-        const freshActions = activeWindow ? actions : getPostDrawActions(game, playerIndex, inFinal);
+        const freshActions = activeWindow && lastDiscardTile
+          ? getResponseActions(game, playerIndex, lastDiscardTile, activeWindow.getDiscarderIndex())
+          : activeWindow
+            ? actions  // activeWindow but no lastDiscardTile — use captured actions as fallback
+            : getPostDrawActions(game, playerIndex, inFinal);
         const botAction = decideBotAction(player.hand, player.melds, freshActions, playerIndex, game.state.gold, lastDiscardTile, botContext);
         console.log(`${tag} Decided action=${botAction.type} (version=${version}) ts=${Date.now()}`);
         const success = handlePlayerAction(io, game.roomId, botAction, playerIndex);


### PR DESCRIPTION
emitOrBotAction ~line 1456-1465: when activeWindow exists, bot uses stale captured actions from 300-800ms ago. Non-window branch re-queries but window branch does not. If actions are now invalid, handlePlayerAction rejects and bot gets stuck.

Fix: In the activeWindow branch, derive available actions from current window state instead of using captured actions parameter.

Server-only: gameEngine.ts

Closes #599