### PR TITLE
Fix bot decideBotAction fallback returns invalid Pass when canPass false

### DIFF
--- a/packages/shared/src/game/bot.ts
+++ b/packages/shared/src/game/bot.ts
@@ -576,7 +576,16 @@ export function decideBotAction(
     return { type: ActionType.Discard, playerIndex, tile };
   }
 
-  // Default: pass
+  // Default: pass (but verify pass is actually allowed)
+  if (!actions.canPass && actions.canDiscard) {
+    // Pass is not valid — must discard instead. Pick first non-gold tile.
+    const fallbackTile = hand.find((t) => !(gold && isGoldTile(t, gold))) ?? hand[0];
+    console.warn(
+      `[Bot:decision] Player ${playerIndex} cannot Pass, falling back to Discard`,
+    );
+    return { type: ActionType.Discard, playerIndex, tile: fallbackTile };
+  }
+
   console.warn(
     `[Bot:decision] Player ${playerIndex} defaulting to Pass — available: canHu=${actions.canHu}, canPeng=${actions.canPeng}, canMingGang=${actions.canMingGang}, chiOptions=${actions.chiOptions.length}, canDiscard=${actions.canDiscard}, canDraw=${actions.canDraw}`,
   );


### PR DESCRIPTION
bot.ts decideBotAction ~line 583: default fallback returns Pass without checking canPass. Post-draw has canPass:false, so bot returns invalid action, server rejects silently, game hangs.

Fix: Before returning Pass, check canPass. If false, return emergency discard (first non-gold tile). Bot should never return an action the server rejects.

Shared package: bot.ts

Closes #601