### PR TITLE
Add landscape width breakpoint for mid-size phones 390-480px

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1134,3 +1134,17 @@ button.lobby-create-btn:active:not(:disabled) {
     padding: clamp(12px, 2dvh, 16px);
   }
 }
+
+/* Mid-size landscape phones (≤480px width) */
+@media (orientation: landscape) and (max-width: 480px) {
+  :root {
+    --game-gap: 4px;
+    --game-padding: 4px;
+  }
+  .confirm-modal {
+    padding: 16px;
+  }
+  .table-center-area {
+    padding: 8px;
+  }
+}


### PR DESCRIPTION
No width-based coverage between 390-480px landscape. Affects Samsung Galaxy A, Pixel 3a/4a, Moto G.

Add @media (orientation: landscape) and (max-width: 480px) with tighter game-gap, game-padding, confirm-modal padding, toast padding, table-center-area padding.

Client-only: index.css

Closes #604