### PR TITLE
Fix swipe passive listener and tooltip timer leak and gold flip reset

### DIFF
--- a/apps/web/src/components/GameInfo.tsx
+++ b/apps/web/src/components/GameInfo.tsx
@@ -24,6 +24,8 @@ export function GameInfo({ gold, wallRemaining, dealerIndex, lianZhuangCount, my
       if (prevGoldRef.current !== key) {
         prevGoldRef.current = key;
         setGoldFlip(true);
+        const timer = setTimeout(() => setGoldFlip(false), 600);
+        return () => clearTimeout(timer);
       }
     } else {
       prevGoldRef.current = null;

--- a/apps/web/src/components/PlayerArea.tsx
+++ b/apps/web/src/components/PlayerArea.tsx
@@ -310,7 +310,7 @@ export function PlayerArea({
       </div>
 
       {/* Hand */}
-      <div style={{
+      <div ref={(el) => { swipe.containerRef.current = el; }} style={{
         display: "flex", flexWrap: "nowrap", gap: firstPerson ? "var(--fp-hand-gap)" : 1, marginBottom: 4, alignItems: "flex-end",
         justifyContent: isMe ? "center" : undefined,
         paddingTop: isMe ? "var(--hand-padding-top)" : 0, overflow: "visible", clipPath: "inset(-9999px 0px -9999px 0px)", position: "relative",
@@ -332,7 +332,6 @@ export function PlayerArea({
             <div
               key={t.id}
               onTouchStart={(e) => swipe.onTouchStart(t.id, e)}
-              onTouchMove={swipe.onTouchMove}
               onTouchEnd={() => { swipe.onTouchEnd(); }}
               onTouchCancel={() => { swipe.onTouchCancel(); }}
               style={{

--- a/apps/web/src/components/TileTooltip.tsx
+++ b/apps/web/src/components/TileTooltip.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { TileInstance, GoldState, Tile } from "@fuzhou-mahjong/shared";
 import { isSuitedTile, isGoldTile } from "@fuzhou-mahjong/shared";
 
@@ -31,6 +31,13 @@ interface TooltipState {
 export function useLongPress(gold: GoldState | null) {
   const [tooltip, setTooltip] = useState<TooltipState>({ visible: false, tile: null, x: 0, y: 0 });
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Clear any pending timer on unmount to prevent setState on unmounted component
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) { clearTimeout(timerRef.current); timerRef.current = null; }
+    };
+  }, []);
 
   const onTouchStart = useCallback((tile: TileInstance, e: React.TouchEvent) => {
     const touch = e.touches[0];

--- a/apps/web/src/components/TileWall.tsx
+++ b/apps/web/src/components/TileWall.tsx
@@ -198,6 +198,8 @@ export function TileWall({ wallRemaining, wallDrawCount, wallSupplementCount, go
       if (prevGoldRef.current !== key) {
         prevGoldRef.current = key;
         setGoldFlip(true);
+        const timer = setTimeout(() => setGoldFlip(false), 600);
+        return () => clearTimeout(timer);
       }
     } else {
       prevGoldRef.current = null;

--- a/apps/web/src/hooks/useSwipeGesture.ts
+++ b/apps/web/src/hooks/useSwipeGesture.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 interface SwipeConfig {
   onSwipeUp: (tileId: number) => void;
@@ -34,7 +34,11 @@ export function useSwipeGesture({
     [enabled],
   );
 
-  const onTouchMove = useCallback((e: React.TouchEvent) => {
+  // Ref to the container element so we can attach a non-passive touchmove listener
+  const containerRef = useRef<HTMLElement | null>(null);
+
+  // Native touchmove handler — must be non-passive so preventDefault() works on iOS
+  const handleTouchMove = useCallback((e: TouchEvent) => {
     const ref = touchRef.current;
     if (!ref) return;
     const touch = e.touches[0];
@@ -68,6 +72,14 @@ export function useSwipeGesture({
     }
   }, []);
 
+  // Attach touchmove via addEventListener with { passive: false }
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    el.addEventListener("touchmove", handleTouchMove, { passive: false });
+    return () => el.removeEventListener("touchmove", handleTouchMove);
+  }, [handleTouchMove]);
+
   const onTouchEnd = useCallback(() => {
     const ref = touchRef.current;
     const threshold = thresholdProp ?? Math.max(25, window.innerHeight * 0.08);
@@ -85,5 +97,5 @@ export function useSwipeGesture({
     setSwipeOffset(0);
   }, []);
 
-  return { onTouchStart, onTouchMove, onTouchEnd, onTouchCancel, swipingTileId, swipeOffset };
+  return { onTouchStart, containerRef, onTouchEnd, onTouchCancel, swipingTileId, swipeOffset };
 }


### PR DESCRIPTION
Three frontend fixes:

1. useSwipeGesture.ts: preventDefault on passive listener broken. Use ref.addEventListener with passive:false.
2. TileTooltip.tsx: timerRef no cleanup on unmount. Add useEffect cleanup.
3. TileWall.tsx/GameInfo.tsx: goldFlip never resets to false. Add timeout to reset after animation.

Client-only: useSwipeGesture.ts, TileTooltip.tsx, TileWall.tsx, GameInfo.tsx

Closes #605