### PR TITLE
Fix ActionWindow cancel not setting resolved causing bot freeze

### DIFF
--- a/apps/server/src/gameEngine.ts
+++ b/apps/server/src/gameEngine.ts
@@ -126,6 +126,7 @@ class ActionWindow {
 
   cancel(): void {
     if (this.timer) { clearTimeout(this.timer); this.timer = null; }
+    this.resolved = true;
   }
 }
 
@@ -1376,7 +1377,6 @@ export function emitOrBotAction(
         console.log(`${tag} Safety timer skipped — not this bot's turn (currentTurn=${game.state.currentTurn}) ts=${Date.now()}`);
         return;
       }
-      acted = true;
       const safetyWindow = activeWindows.get(game.roomId);
       if (safetyWindow) {
         if (!safetyWindow.isPending(playerIndex)) {
@@ -1384,7 +1384,7 @@ export function emitOrBotAction(
         } else {
           console.warn(`[Bot:SAFETY] ${tag} Safety timeout during action window — passing (roomId=${game.roomId}, playerIndex=${playerIndex}, turn=${turnNumber}, phase=${game.state.phase}, version=${version}, hasActionWindow=true) ts=${Date.now()}`);
           try {
-            handlePlayerAction(io, game.roomId, { type: ActionType.Pass, playerIndex }, playerIndex);
+            if (handlePlayerAction(io, game.roomId, { type: ActionType.Pass, playerIndex }, playerIndex)) acted = true;
           } catch (e) {
             console.error(`${tag} Safety timeout Pass fallback failed:`, e);
           }
@@ -1393,7 +1393,7 @@ export function emitOrBotAction(
         console.warn(`[Bot:SAFETY] ${tag} Safety timeout — forcing emergency discard (roomId=${game.roomId}, playerIndex=${playerIndex}, turn=${turnNumber}, phase=${game.state.phase}, version=${version}, hasActionWindow=false) ts=${Date.now()}`);
         try {
           const player = game.state.players[playerIndex];
-          handlePlayerAction(io, game.roomId, emergencyDiscard(player.hand, playerIndex, game.state.gold), playerIndex);
+          if (handlePlayerAction(io, game.roomId, emergencyDiscard(player.hand, playerIndex, game.state.gold), playerIndex)) acted = true;
         } catch (e) {
           console.error(`${tag} Safety timeout fallback failed:`, e);
         }
@@ -1432,6 +1432,7 @@ export function emitOrBotAction(
             console.log(tag + " Stale bail — bot turn is over, no action needed");
           }
         }
+        clearTimeout(safetyTimer);
         return;
       }
         // Restore the snapshotted drawn tile ID so downstream handlers


### PR DESCRIPTION
ActionWindow.cancel() at gameEngine.ts:127-129 only clears the timer but never sets this.resolved = true. When a new discard/BuGang overwrites the active window, the old cancelled window can still accept late bot responses via addResponse(). The old window onResolve then calls activeWindows.delete(game.roomId) which deletes the NEW live window (same roomId key), causing bots to silently hang.

Also fix: (1) Safety timer at line 1376 sets acted=true BEFORE the action succeeds, preventing watchdog recovery on failure. Move it after success like the main timer pattern. (2) Stale-version early-return path ~line 1404-1432 does not clear safetyTimer, leaving ghost timers.

All changes in gameEngine.ts only.

Closes #609