### PR TITLE
Clear disconnectTimers when game ends to prevent memory leak

### DIFF
--- a/apps/server/src/gameEngine.ts
+++ b/apps/server/src/gameEngine.ts
@@ -258,6 +258,12 @@ setOnGameDeleted((roomId) => {
     for (const t of gangTimers) clearTimeout(t);
     gangSafetyTimeouts.delete(roomId);
   }
+  // Clear disconnect timers to prevent stale callbacks after game ends
+  const room = findRoom(roomId);
+  if (room) {
+    for (const t of room.disconnectTimers.values()) clearTimeout(t);
+    room.disconnectTimers.clear();
+  }
 });
 
 /** Pick first non-gold tile to discard as emergency fallback. Returns Pass if hand is empty. */

--- a/apps/server/src/handlers/roomHandlers.ts
+++ b/apps/server/src/handlers/roomHandlers.ts
@@ -307,6 +307,9 @@ export function registerRoomHandlers(io: GameServer, socket: GameSocket): void {
         room.disconnectTimers.delete(player.playerId);
         console.log(`Reconnect timeout for ${player.name} in room ${room.id}`);
 
+        // Clean up this player's room mapping regardless of whether others remain
+        unregisterPlayerRoom(player.playerId);
+
         // If no humans left connected, clean up room and game
         if (!room.hasConnectedPlayers()) {
           deleteGame(room.id);


### PR DESCRIPTION
In roomHandlers.ts, room.disconnectTimers entries are not cleared when a game ends (endGameWin/endGameDraw). The setOnGameDeleted callback cleans up botWatchdogs, activeWindows, and gangSafetyTimeouts but not disconnectTimers. If a player disconnects and the game ends before the 60s timeout fires, the timer reference leaks and may fire against a cleaned-up room.

Fix: In the setOnGameDeleted callback (or endGame flow), iterate room.disconnectTimers, clearTimeout each entry, and clear the map. Also clean up playerRoomMap entries for timed-out players when other players are still connected.

Server-only: apps/server/src/handlers/roomHandlers.ts

Closes #613