### PR TITLE
Fix animations css hardcoded z-index values bypassing variable system

### DIFF
--- a/apps/web/src/animations.css
+++ b/apps/web/src/animations.css
@@ -118,7 +118,7 @@
   height: 100%;
   pointer-events: none;
   overflow: hidden;
-  z-index: 100;
+  z-index: var(--z-game-over);
 }
 
 .confetti {
@@ -194,7 +194,7 @@
   bottom: 0;
   background: radial-gradient(ellipse at center, rgba(255,165,0,0.3) 0%, transparent 70%);
   pointer-events: none;
-  z-index: 50;
+  z-index: var(--z-confirm-modal);
   animation: screenFlash 1.2s ease-out forwards;
 }
 
@@ -211,7 +211,7 @@
   right: 0;
   bottom: 0;
   pointer-events: none;
-  z-index: 49;
+  z-index: var(--z-border-flash);
   box-shadow: inset 0 0 60px rgba(255,165,0,0.6);
   animation: borderFlash 1.5s ease-out forwards;
 }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -157,6 +157,7 @@ body {
   --z-tooltip: 34;
   --z-settings-dropdown: 35;
   --z-claim-overlay: 40;
+  --z-border-flash: 49;
   --z-confirm-modal: 50;
   --z-tutorial: 60;
   --z-game-over: 100;


### PR DESCRIPTION
In animations.css, lines 121, 197, 214 use raw z-index values (100, 50, 49) instead of the CSS variable system used everywhere else. These could conflict with --z-game-over: 100 and other variable-based z-index values.

Fix: Replace these hardcoded z-index values with the appropriate CSS variables from the z-index system defined in index.css.

Client-only: apps/web/src/animations.css

Closes #616