### PR TITLE
Add touchAction manipulation to TileWall draw button and chi picker

### DIFF
--- a/apps/web/src/components/ClaimOverlay.tsx
+++ b/apps/web/src/components/ClaimOverlay.tsx
@@ -189,6 +189,7 @@ export function ClaimOverlay({ actions, gameState, onAction }: ClaimOverlayProps
               padding: "4px 4px",
               scrollSnapType: "x mandatory",
               WebkitOverflowScrolling: "touch",
+              touchAction: "pan-x",
               justifyContent: actions.chiOptions.length <= 2 ? "center" : undefined,
               maxHeight: isUltraCompact ? "min(45dvh, calc(100dvh - 160px))" : "60dvh",
               overflowY: "auto",

--- a/apps/web/src/components/TileWall.tsx
+++ b/apps/web/src/components/TileWall.tsx
@@ -173,6 +173,7 @@ function WallSegment({ side, stacks, drawStack, canDraw, onDraw, standalone }: {
                   minHeight: "var(--btn-min-size)",
                   minWidth: "var(--btn-min-size)",
                   zIndex: "var(--z-draw-button)",
+                  touchAction: "manipulation",
                 }}
               >
                 摸牌


### PR DESCRIPTION
TileWall draw button (lines 157-179) has no touchAction property - double-tap can trigger browser zoom before click fires on mobile. ClaimOverlay chi picker scroll container (line 185) uses overflowX auto with scrollSnapType but no touchAction - vertical scroll gestures interfere with horizontal chi-picker scrolling.

Fix: Add touchAction manipulation to the TileWall draw button. Add touchAction pan-x to the ClaimOverlay chi picker scroll container.

Client-only: apps/web/src/components/TileWall.tsx and ClaimOverlay.tsx

Closes #617