### PR TITLE
Fix CenterAction tile overflow on 320px narrow screens

### DIFF
--- a/apps/web/src/components/CenterAction.tsx
+++ b/apps/web/src/components/CenterAction.tsx
@@ -55,9 +55,11 @@ export function CenterAction({ display, gold }: { display: ActionDisplay | null;
   const baseTileW = width <= 360 ? 30 : width <= 480 ? 34 : 44;
   const gap = 4;
   const maxMeldWidth = width * 0.9;
-  const totalBaseWidth = tileCount * baseTileW + (tileCount - 1) * gap;
-  const desiredScale = isCompact ? 1.2 : 1.8;
-  const scale = isCompact ? 1.2 : Math.min(desiredScale, maxMeldWidth / totalBaseWidth);
+  // scale applies per-tile via transform (doesn't affect layout), so visual width =
+  // tileCount * baseTileW * scale + (tileCount - 1) * gap
+  // Solve for max scale: scale <= (maxMeldWidth - (tileCount - 1) * gap) / (tileCount * baseTileW)
+  const maxScale = (maxMeldWidth - (tileCount - 1) * gap) / (tileCount * baseTileW);
+  const scale = isCompact ? 1.2 : Math.min(1.8, maxScale);
 
   return (
     <div


### PR DESCRIPTION
In CenterAction.tsx line 74, tiles are scaled 1.8x in non-compact mode. A 4-tile meld scaled 1.8x can overflow the 320px viewport horizontally. The component is position absolute centered with pointerEvents none so no interaction issue, but visual overflow is visible.

Fix: Clamp the scale factor based on viewport width so that the total meld width never exceeds ~90vw. Use something like scale(min(1.8, 90vw / (tileCount * baseTileWidth))) or a simpler clamp approach.

Client-only: apps/web/src/components/CenterAction.tsx

Closes #620