### PR TITLE
Fix TileCounter zIndex 15 magic number and add CSS variable

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -151,6 +151,7 @@ body {
   --z-wall-segment: 2;
   --z-draw-button: 10;
   --z-swipe-hint: 11;
+  --z-tile-counter: 15;
   --z-tile-anim: 20;
   --z-center-action: 29;
   --z-settings-btn: 30;

--- a/apps/web/src/pages/Game.tsx
+++ b/apps/web/src/pages/Game.tsx
@@ -464,7 +464,7 @@ export function Game({ initialGameState, onLeave }: GameProps) {
         <ClaimOverlay actions={actions} gameState={gameState} onAction={handleAction} />
       )}
       {/* Floating tile counter overlay */}
-      <div style={{ position: "fixed", bottom: "calc(12px + env(safe-area-inset-bottom, 0px))", left: "calc(12px + env(safe-area-inset-left, 0px))", zIndex: 15 }}>
+      <div style={{ position: "fixed", bottom: "calc(12px + env(safe-area-inset-bottom, 0px))", left: "calc(12px + env(safe-area-inset-left, 0px))", zIndex: "var(--z-tile-counter)" }}>
         <TileCounter gameState={gameState} />
       </div>
       {/* Settings gear button + dropdown */}


### PR DESCRIPTION
In Game.tsx line 467, the floating TileCounter overlay uses a hardcoded zIndex: 15. This magic number sits above --z-draw-button: 10 and could overlap the draw button on compact layouts. It should use a named CSS variable.

Fix: Add --z-tile-counter: 15 to the z-index variable system in index.css and use var(--z-tile-counter) in Game.tsx.

Client-only: apps/web/src/pages/Game.tsx and apps/web/src/index.css

Closes #621