### PR TITLE
Show tile combination preview on peng gang chi claim buttons

### DIFF
--- a/apps/web/src/components/ClaimOverlay.tsx
+++ b/apps/web/src/components/ClaimOverlay.tsx
@@ -120,7 +120,7 @@ export function ClaimOverlay({ actions, gameState, onAction }: ClaimOverlayProps
           )}
 
           {actions.canMingGang && gameState.lastDiscard && (() => {
-            const gangTiles = findMatchingHandTiles(gameState.players[myIndex].hand, gameState.lastDiscard!.tile, 3);
+            const gangTiles = findMatchingHandTiles(gameState.myHand, gameState.lastDiscard!.tile, 3);
             return (
               <button
                 style={{ ...BTN.base, ...BTN.gang, display: "flex", flexDirection: "column", alignItems: "center", gap: 2, padding: isCompact ? "6px 10px" : "10px 16px" }}
@@ -149,7 +149,7 @@ export function ClaimOverlay({ actions, gameState, onAction }: ClaimOverlayProps
           })()}
 
           {actions.canPeng && gameState.lastDiscard && (() => {
-            const pengTiles = findMatchingHandTiles(gameState.players[myIndex].hand, gameState.lastDiscard!.tile, 2);
+            const pengTiles = findMatchingHandTiles(gameState.myHand, gameState.lastDiscard!.tile, 2);
             return (
               <button
                 style={{ ...BTN.base, ...BTN.peng, display: "flex", flexDirection: "column", alignItems: "center", gap: 2, padding: isCompact ? "6px 10px" : "10px 16px" }}


### PR DESCRIPTION
Currently the claim buttons (碰/杠/吃) only show text. Show the actual tile combination preview directly on each button so players can see what meld they would form before tapping.

For 碰: find 2 matching tiles from gameState hand + show lastDiscard tile highlighted (orange border like chi picker does)
For 明杠: find 3 matching tiles from hand + lastDiscard highlighted
For 吃 (single option): show the 2 hand tiles + lastDiscard highlighted (skip chi picker since only 1 option - this already works)
For 吃 (multiple): keep current behavior - show chi picker on tap

Reference the chi picker button style (ClaimOverlay.tsx lines 197-235) which already shows tile previews with TileView small + highlighted discard tile.

Use small TileView components on the buttons. Keep the action text (碰/杠/吃) as a small label. The button should be wider to accommodate the tile previews.

Client-only: apps/web/src/components/ClaimOverlay.tsx

Closes #624