### PR TITLE
Loosen double-tap discard timing window from 300ms to 450ms

### DIFF
--- a/apps/web/src/components/PlayerArea.tsx
+++ b/apps/web/src/components/PlayerArea.tsx
@@ -74,7 +74,7 @@ export function PlayerArea({
   const lastTapRef = useRef<{ id: number; time: number } | null>(null);
   const handleTap = (t: TileInstance) => {
     const now = Date.now();
-    if (lastTapRef.current?.id === t.id && now - lastTapRef.current.time < 300) {
+    if (lastTapRef.current?.id === t.id && now - lastTapRef.current.time < 450) {
       // Double-tap detected
       lastTapRef.current = null;
       onTileDoubleClick?.(t);


### PR DESCRIPTION
The double-tap-to-discard window in Game.tsx is 300ms which is too tight on slower devices. Users can miss the window and get select-then-bubble instead of instant discard. Bump to 450ms.

One-line change in Game.tsx double-tap handler around line 426.

Client-only: apps/web/src/pages/Game.tsx

Closes #627